### PR TITLE
added ability to record transposition to the ODD and schema

### DIFF
--- a/documentation/tei_beeing_human.html
+++ b/documentation/tei_beeing_human.html
@@ -55,7 +55,7 @@
                            <li class="toc"><span class="headingNumber">3.4.2. </span><a class="toc toc_2" href="#encVarCha" title="Likeforlike change">Like-for-like change</a></li>
                            <li class="toc"><span class="headingNumber">3.4.3. </span><a class="toc toc_2" href="#encVarDel" title="Text that has been cut from 1609">Text that has been cut from 1609</a></li>
                            <li class="toc"><span class="headingNumber">3.4.4. </span><a class="toc toc_2" href="#encVarAdd" title="Text that has been newly added to 1623">Text that has been newly added to 1623</a></li>
-                           <li class="toc"><span class="headingNumber">3.4.5. </span><a class="toc toc_2" href="#encVarMov" title="Text that has been moved from its original position in 1609">Text that has been moved from its original position in 1609</a></li>
+                           <li class="toc"><span class="headingNumber">3.4.5. </span><a class="toc toc_2" href="#encVarMov" title="Text that has been moved from its original position in 1609 (transposition)">Text that has been moved from its original position in 1609 (transposition)</a></li>
                         </ul>
                      </li>
                   </ul>
@@ -702,9 +702,9 @@
                       while go unregarded, without friends or acquaintance:...<span class="element">&lt;/p&gt;</span></div><span class="">1623</span><div id="index.xml-egXML-d31e1509" class="pre egXML_valid"><span class="element">&lt;p&gt;</span>...or otherwise the sense doth plainely shew that it is spoken of the whole Moneth. <span class="element">&lt;/p&gt;</span>
                      <span class="element">&lt;app <span class="attribute">type</span>="<span class="attributevalue">major</span>" <span class="attribute">subtype</span>="<span class="attributevalue">add</span>"&gt;</span>
                       <span class="element">&lt;lem <span class="attribute">wit</span>="<span class="attributevalue">#b1623</span>"&gt;</span>
-                       <span class="element">&lt;p <span class="attribute">xml:id</span>="<span class="attributevalue">frontpar7</span>"&gt;</span>When you
-                          have once, for your satisfaction, perused this Booke, you need not afterward
-                          seeke farre for anything therein, whereof you doubt: the <span class="element">&lt;ref <span class="attribute">target</span>="<span class="attributevalue">#contents</span>" <span class="attribute">rend</span>="<span class="attributevalue">italic</span>"&gt;</span>Index<span class="element">&lt;/ref&gt;</span> of the Chapters or Contents of the Booke; and of the
+                       <span class="element">&lt;p <span class="attribute">xml:id</span>="<span class="attributevalue">frontpar7</span>"&gt;</span>When you have
+                          once, for your satisfaction, perused this Booke, you need not afterward seeke
+                          farre for anything therein, whereof you doubt: the <span class="element">&lt;ref <span class="attribute">target</span>="<span class="attributevalue">#contents</span>" <span class="attribute">rend</span>="<span class="attributevalue">italic</span>"&gt;</span>Index<span class="element">&lt;/ref&gt;</span> of the Chapters or Contents of the Booke; and of the
                           Marginall notes, or Contents of the Chapters will readily direct you. For
                           example, if you would know the Spleeting of Hives, or the manner of Hiving Bees;
                           looking into the <span class="element">&lt;ref <span class="attribute">target</span>="<span class="attributevalue">#contents</span>" <span class="attribute">rend</span>="<span class="attributevalue">italic</span>"&gt;</span>Index<span class="element">&lt;/ref&gt;</span> of the
@@ -732,12 +732,56 @@
                       friends or acquaintance:...<span class="element">&lt;/p&gt;</span></div>
                </div>
                <div class="teidiv2" id="encVarMov">
-                  <h3><span class="headingNumber">3.4.5. </span><span class="head">Text that has been moved from its original position in 1609</span></h3>
+                  <h3><span class="headingNumber">3.4.5. </span><span class="head">Text that has been moved from its original position in 1609 (transposition)</span></h3>
                   <p>Text that has been moved from one location in 1609 to another in 1623 (akin to cut
-                     and paste) is currently not marked up in any special way, the variation already beeing
-                     covered by <a class="link_ref" href="#encVarAdd" title="Text that has been newly added to 1623"><span class="val">add</span></a> and <a class="link_ref" href="#encVarDel" title="Text that has been cut from 1609"><span class="val">del</span></a>. If you do find any significant variation that falls in this category, make a note
-                     of its locations in both 1609 and 1623 but, for now, mark it up as additions and deletions
-                     to the normal flow of text. See <a class="link_ref" href="https://github.com/NewcastleRSE/beeing-human-tei-data/issues/32">this github issue</a> for more.</p>
+                     and paste) can be indicated by the use of a <span class="tag">&lt;transpose&gt;</span> element. <span class="tag">&lt;transpose&gt;</span> will include (at least) two <span class="tag">&lt;ptr&gt;</span> elements pointing to segments of text (paragraph or smaller), the order of which
+                     will indicate the original order of those segments of text. Consider the following
+                     example:</p><span class="">Text A</span><div id="index.xml-egXML-d31e1576" class="pre egXML_valid"><span class="element">&lt;p <span class="attribute">xml:id</span>="<span class="attributevalue">Ap1</span>"&gt;</span>This is the first paragraph.<span class="element">&lt;/p&gt;</span>
+                     <span class="element">&lt;p <span class="attribute">xml:id</span>="<span class="attributevalue">Ap2</span>"&gt;</span>This is the second paragraph.<span class="element">&lt;/p&gt;</span>
+                     <span class="element">&lt;p <span class="attribute">xml:id</span>="<span class="attributevalue">Ap3</span>"&gt;</span>This is an additional paragraph.<span class="element">&lt;/p&gt;</span></div><span class="">Text B</span><div id="index.xml-egXML-d31e1584" class="pre egXML_valid"><span class="element">&lt;p <span class="attribute">xml:id</span>="<span class="attributevalue">Bp1</span>"&gt;</span>This is the first paragraph.<span class="element">&lt;/p&gt;</span>
+                     <span class="element">&lt;p <span class="attribute">xml:id</span>="<span class="attributevalue">Bp2</span>"&gt;</span>This is an additional paragraph.<span class="element">&lt;/p&gt;</span>
+                     <span class="element">&lt;p <span class="attribute">xml:id</span>="<span class="attributevalue">Bp3</span>"&gt;</span>This is the second paragraph.<span class="element">&lt;/p&gt;</span></div>
+                  <div class="p">To indicate that text B has been reordered, you would use a <span class="tag">&lt;transpose&gt;</span> element like so: 
+                     <div id="index.xml-egXML-d31e1596" class="pre egXML_valid"><span class="element">&lt;transpose&gt;</span>
+                         <span class="element">&lt;ptr <span class="attribute">target</span>="<span class="attributevalue">#Bp1</span>"/&gt;</span>
+                         <span class="element">&lt;ptr <span class="attribute">target</span>="<span class="attributevalue">#Bp3</span>"/&gt;</span>
+                         <span class="element">&lt;ptr <span class="attribute">target</span>="<span class="attributevalue">#Bp2</span>"/&gt;</span>
+                        <span class="element">&lt;/transpose&gt;</span></div> which corresponds to the order of text A.</div>
+                  <div class="p">The <span class="tag">&lt;transpose&gt;</span> element will appear inside a <span class="tag">&lt;listTranspose&gt;</span> element, which will itself appear <em>outside</em> the body of the text in a <span class="tag">&lt;standOff&gt;</span> element, which will be the sibling of <span class="tag">&lt;teiHeader&gt;</span> and <span class="tag">&lt;text&gt;</span>. The <span class="tag">&lt;listTranspose&gt;</span> element <em>must</em> have a <span class="att">wit</span> attribute pointing to the witness where the different order of text is found. In the
+                     example above, it would be something like this: 
+                     <div id="index.xml-egXML-d31e1630" class="pre egXML_valid"><span class="element">&lt;teiHeader&gt;</span>
+                        <span class="comment">&lt;!-- TEI Header goes here --&gt;</span>
+                        <span class="element">&lt;/teiHeader&gt;</span>
+                        <span class="element">&lt;standOff&gt;</span>
+                         <span class="element">&lt;listTranspose <span class="attribute">wit</span>="<span class="attributevalue">#TextA</span>"&gt;</span>
+                          <span class="element">&lt;transpose&gt;</span>
+                           <span class="element">&lt;ptr <span class="attribute">target</span>="<span class="attributevalue">#Bp1</span>"/&gt;</span>
+                           <span class="element">&lt;ptr <span class="attribute">target</span>="<span class="attributevalue">#Bp3</span>"/&gt;</span>
+                           <span class="element">&lt;ptr <span class="attribute">target</span>="<span class="attributevalue">#Bp2</span>"/&gt;</span>
+                          <span class="element">&lt;/transpose&gt;</span>
+                         <span class="element">&lt;/listTranspose&gt;</span>
+                        <span class="element">&lt;/standOff&gt;</span>
+                        <span class="element">&lt;text&gt;</span>
+                        <span class="comment">&lt;!-- Body of the text goes here --&gt;</span>
+                        <span class="element">&lt;/text&gt;</span></div>
+                  </div>
+                  <p>Variation within transposed text should be recorded in the usual way (with <span class="tag">&lt;app&gt;</span>, <span class="tag">&lt;lem&gt;</span>, and <span class="tag">&lt;rdg&gt;</span>as described <a class="link_ref" href="#encVar" title="Variation">above</a>, as if the text was in the same order.</p>
+                  <p>If the sections of text that have been transposed are smaller than paragraphs, encapsulate
+                     them in <span class="tag">&lt;seg&gt;</span> elements, with a significant <span class="att">xml:id</span> following the format chXsegY, i.e., </p>
+                  <pre id="index.xml-eg-d31e1663" class="pre_eg cdata">ch1seg1<a href="#index.xml-eg-d31e1663" class="anchorlink">⚓</a></pre>
+                  <p>, </p>
+                  <pre id="index.xml-eg-d31e1665" class="pre_eg cdata">ch1seg2<a href="#index.xml-eg-d31e1665" class="anchorlink">⚓</a></pre>
+                  <p>, etc.</p>
+                  <div class="p">If the sections of text that have been transposed are larger than paragraphs, use
+                     more <span class="tag">&lt;ptr&gt;</span> elements in the <span class="tag">&lt;transpose&gt;</span> element to indicate a larger span of text, for example: 
+                     <div id="index.xml-egXML-d31e1675" class="pre egXML_valid"><span class="element">&lt;transpose&gt;</span>
+                         <span class="element">&lt;ptr <span class="attribute">target</span>="<span class="attributevalue">p5</span>"/&gt;</span>
+                         <span class="element">&lt;ptr <span class="attribute">target</span>="<span class="attributevalue">p1</span>"/&gt;</span>
+                         <span class="element">&lt;ptr <span class="attribute">target</span>="<span class="attributevalue">p2</span>"/&gt;</span>
+                         <span class="element">&lt;ptr <span class="attribute">target</span>="<span class="attributevalue">p3</span>"/&gt;</span>
+                         <span class="element">&lt;ptr <span class="attribute">target</span>="<span class="attributevalue">p4</span>"/&gt;</span>
+                        <span class="element">&lt;/transpose&gt;</span></div>
+                  </div>
                </div>
             </div>
          </section>
@@ -817,6 +861,7 @@
                            <td class="wovenodd-col2">
                               <div class="specChildren">
                                  <div class="specChild"><span class="specChildModule">header: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.teiHeader" title="&lt;teiHeader&gt;">teiHeader</a></span></div>
+                                 <div class="specChild"><span class="specChildModule">linking: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.standOff" title="&lt;standOff&gt;">standOff</a></span></div>
                                  <div class="specChild"><span class="specChildModule">textstructure: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.TEI" title="&lt;TEI&gt;">TEI</a> <a class="link_odd_elementSpec" href="#TEI.text" title="&lt;text&gt;">text</a></span></div>
                               </div>
                            </td>
@@ -830,7 +875,7 @@
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Example</span></td>
                            <td class="wovenodd-col2">
-                              <div id="index.xml-egXML-d31e1834" class="pre egXML_valid"><span class="element">&lt;TEI <span class="attribute">version</span>="<span class="attributevalue">3.3.0</span>" xmlns="http://www.tei-c.org/ns/1.0"&gt;</span>
+                              <div id="index.xml-egXML-d31e1945" class="pre egXML_valid"><span class="element">&lt;TEI <span class="attribute">version</span>="<span class="attributevalue">3.3.0</span>" xmlns="http://www.tei-c.org/ns/1.0"&gt;</span>
                                   <span class="element">&lt;teiHeader&gt;</span>
                                    <span class="element">&lt;fileDesc&gt;</span>
                                     <span class="element">&lt;titleStmt&gt;</span>
@@ -856,7 +901,7 @@
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Example</span></td>
                            <td class="wovenodd-col2">
-                              <div id="index.xml-egXML-d31e1852" class="pre egXML_valid"><span class="element">&lt;TEI <span class="attribute">version</span>="<span class="attributevalue">2.9.1</span>" xmlns="http://www.tei-c.org/ns/1.0"&gt;</span>
+                              <div id="index.xml-egXML-d31e1963" class="pre egXML_valid"><span class="element">&lt;TEI <span class="attribute">version</span>="<span class="attributevalue">2.9.1</span>" xmlns="http://www.tei-c.org/ns/1.0"&gt;</span>
                                   <span class="element">&lt;teiHeader&gt;</span>
                                    <span class="element">&lt;fileDesc&gt;</span>
                                     <span class="element">&lt;titleStmt&gt;</span>
@@ -900,7 +945,7 @@
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Content model</span></td>
                            <td class="wovenodd-col2">
-                              <pre id="index.xml-eg-d31e1886" class="pre_eg cdata">
+                              <pre id="index.xml-eg-d31e1997" class="pre_eg cdata">
 &lt;content&gt;
  &lt;sequence&gt;
   &lt;elementRef key="teiHeader"/&gt;
@@ -916,20 +961,20 @@
   &lt;/alternate&gt;
  &lt;/sequence&gt;
 &lt;/content&gt;
-    <a href="#index.xml-eg-d31e1886" class="anchorlink">⚓</a></pre>
+    <a href="#index.xml-eg-d31e1997" class="anchorlink">⚓</a></pre>
                            </td>
                         </tr>
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Schema Declaration</span></td>
                            <td class="wovenodd-col2">
-                              <pre id="index.xml-eg-d31e1894" class="pre_eg">
+                              <pre id="index.xml-eg-d31e2005" class="pre_eg">
 element TEI
 {
    tei_att.global.attributes,
    tei_att.typed.attributes,
    attribute version { text }?,
    ( tei_teiHeader, ( ( tei_model.resource+, tei_TEI* ) | tei_TEI+ ) )
-}<a href="#index.xml-eg-d31e1894" class="anchorlink">⚓</a></pre>
+}<a href="#index.xml-eg-d31e2005" class="anchorlink">⚓</a></pre>
                            </td>
                         </tr>
                      </table>
@@ -1045,7 +1090,7 @@ element TEI
                                  <div class="specChild"><span class="specChildModule">linking: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.seg" title="&lt;seg&gt;">seg</a></span></div>
                                  <div class="specChild"><span class="specChildModule">namesdates: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.orgName" title="&lt;orgName&gt;">orgName</a> <a class="link_odd_elementSpec" href="#TEI.persName" title="&lt;persName&gt;">persName</a> <a class="link_odd_elementSpec" href="#TEI.placeName" title="&lt;placeName&gt;">placeName</a></span></div>
                                  <div class="specChild"><span class="specChildModule">textcrit: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.app" title="&lt;app&gt;">app</a></span></div>
-                                 <div class="specChild"><span class="specChildModule">transcr: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.fw" title="&lt;fw&gt;">fw</a></span></div>
+                                 <div class="specChild"><span class="specChildModule">transcr: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.fw" title="&lt;fw&gt;">fw</a> <a class="link_odd_elementSpec" href="#TEI.listTranspose" title="&lt;listTranspose&gt;">listTranspose</a></span></div>
                                  <div class="specChild">character data</div>
                               </div>
                            </td>
@@ -1060,7 +1105,7 @@ element TEI
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Example</span></td>
                            <td class="wovenodd-col2">
-                              <div id="index.xml-egXML-d31e2549" class="pre egXML_valid"><span class="element">&lt;choice&gt;</span>
+                              <div id="index.xml-egXML-d31e2664" class="pre egXML_valid"><span class="element">&lt;choice&gt;</span>
                                   <span class="element">&lt;expan&gt;</span>North Atlantic Treaty Organization<span class="element">&lt;/expan&gt;</span>
                                   <span class="element">&lt;abbr <span class="attribute">cert</span>="<span class="attributevalue">low</span>"&gt;</span>NorATO<span class="element">&lt;/abbr&gt;</span>
                                   <span class="element">&lt;abbr <span class="attribute">cert</span>="<span class="attributevalue">high</span>"&gt;</span>NATO<span class="element">&lt;/abbr&gt;</span>
@@ -1071,7 +1116,7 @@ element TEI
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Example</span></td>
                            <td class="wovenodd-col2">
-                              <div id="index.xml-egXML-d31e2563" class="pre egXML_valid"><span class="element">&lt;choice&gt;</span>
+                              <div id="index.xml-egXML-d31e2678" class="pre egXML_valid"><span class="element">&lt;choice&gt;</span>
                                   <span class="element">&lt;abbr&gt;</span>SPQR<span class="element">&lt;/abbr&gt;</span>
                                   <span class="element">&lt;expan&gt;</span>senatus populusque romanorum<span class="element">&lt;/expan&gt;</span>
                                  <span class="element">&lt;/choice&gt;</span></div>
@@ -1080,24 +1125,24 @@ element TEI
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Content model</span></td>
                            <td class="wovenodd-col2">
-                              <pre id="index.xml-eg-d31e2572" class="pre_eg cdata">
+                              <pre id="index.xml-eg-d31e2687" class="pre_eg cdata">
 &lt;content&gt;
  &lt;macroRef key="macro.phraseSeq"/&gt;
 &lt;/content&gt;
-    <a href="#index.xml-eg-d31e2572" class="anchorlink">⚓</a></pre>
+    <a href="#index.xml-eg-d31e2687" class="anchorlink">⚓</a></pre>
                            </td>
                         </tr>
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Schema Declaration</span></td>
                            <td class="wovenodd-col2">
-                              <pre id="index.xml-eg-d31e2579" class="pre_eg">
+                              <pre id="index.xml-eg-d31e2694" class="pre_eg">
 element abbr
 {
    tei_att.global.attributes,
    tei_att.typed.attribute.subtype,
    attribute type { text }?,
    tei_macro.phraseSeq
-}<a href="#index.xml-eg-d31e2579" class="anchorlink">⚓</a></pre>
+}<a href="#index.xml-eg-d31e2694" class="anchorlink">⚓</a></pre>
                            </td>
                         </tr>
                      </table>
@@ -1316,7 +1361,7 @@ element abbr
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Example</span></td>
                            <td class="wovenodd-col2">
-                              <div id="index.xml-egXML-d31e3258" class="pre egXML_valid"><span class="element">&lt;app&gt;</span>
+                              <div id="index.xml-egXML-d31e3373" class="pre egXML_valid"><span class="element">&lt;app&gt;</span>
                                   <span class="element">&lt;lem <span class="attribute">wit</span>="<span class="attributevalue">#El #Hg</span>"&gt;</span>Experience<span class="element">&lt;/lem&gt;</span>
                                   <span class="element">&lt;rdg <span class="attribute">wit</span>="<span class="attributevalue">#La</span>" <span class="attribute">type</span>="<span class="attributevalue">substantive</span>"&gt;</span>Experiment<span class="element">&lt;/rdg&gt;</span>
                                   <span class="element">&lt;rdg <span class="attribute">wit</span>="<span class="attributevalue">#Ra2</span>" <span class="attribute">type</span>="<span class="attributevalue">substantive</span>"&gt;</span>Eryment<span class="element">&lt;/rdg&gt;</span>
@@ -1326,7 +1371,7 @@ element abbr
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Example</span></td>
                            <td class="wovenodd-col2">
-                              <div id="index.xml-egXML-d31e3271" class="pre egXML_valid"><span class="element">&lt;app <span class="attribute">type</span>="<span class="attributevalue">substantive</span>"&gt;</span>
+                              <div id="index.xml-egXML-d31e3386" class="pre egXML_valid"><span class="element">&lt;app <span class="attribute">type</span>="<span class="attributevalue">substantive</span>"&gt;</span>
                                   <span class="element">&lt;rdgGrp <span class="attribute">type</span>="<span class="attributevalue">subvariants</span>"&gt;</span>
                                    <span class="element">&lt;lem <span class="attribute">wit</span>="<span class="attributevalue">#El #Hg</span>"&gt;</span>Experience<span class="element">&lt;/lem&gt;</span>
                                    <span class="element">&lt;rdg <span class="attribute">wit</span>="<span class="attributevalue">#Ha4</span>"&gt;</span>Experiens<span class="element">&lt;/rdg&gt;</span>
@@ -1345,7 +1390,7 @@ element abbr
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Example</span></td>
                            <td class="wovenodd-col2">
-                              <div id="index.xml-egXML-d31e3295" class="pre egXML_valid"><span class="element">&lt;app <span class="attribute">loc</span>="<span class="attributevalue">1</span>"&gt;</span>
+                              <div id="index.xml-egXML-d31e3410" class="pre egXML_valid"><span class="element">&lt;app <span class="attribute">loc</span>="<span class="attributevalue">1</span>"&gt;</span>
                                   <span class="element">&lt;rdg <span class="attribute">resp</span>="<span class="attributevalue">#SEG</span>"&gt;</span>TIMΩΔA<span class="element">&lt;/rdg&gt;</span>
                                  <span class="element">&lt;/app&gt;</span></div>
                            </td>
@@ -1353,7 +1398,7 @@ element abbr
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Example</span></td>
                            <td class="wovenodd-col2">
-                              <div id="index.xml-egXML-d31e3304" class="pre egXML_valid"><span class="element">&lt;app <span class="attribute">loc</span>="<span class="attributevalue">1-6</span>"&gt;</span>
+                              <div id="index.xml-egXML-d31e3419" class="pre egXML_valid"><span class="element">&lt;app <span class="attribute">loc</span>="<span class="attributevalue">1-6</span>"&gt;</span>
                                   <span class="element">&lt;note&gt;</span>Too badly worn to yield a text<span class="element">&lt;/note&gt;</span>
                                  <span class="element">&lt;/app&gt;</span></div>
                            </td>
@@ -1361,7 +1406,7 @@ element abbr
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Example</span></td>
                            <td class="wovenodd-col2">
-                              <div id="index.xml-egXML-d31e3312" class="pre egXML_valid"><span class="element">&lt;choice <span class="attribute">xml:id</span>="<span class="attributevalue">choice3</span>"&gt;</span>
+                              <div id="index.xml-egXML-d31e3427" class="pre egXML_valid"><span class="element">&lt;choice <span class="attribute">xml:id</span>="<span class="attributevalue">choice3</span>"&gt;</span>
                                   <span class="element">&lt;reg&gt;</span>σύμπαντα<span class="element">&lt;/reg&gt;</span>
                                   <span class="element">&lt;orig&gt;</span>ΣΙΝΠΑΤΑΝ<span class="element">&lt;/orig&gt;</span>
                                  <span class="element">&lt;/choice&gt;</span>
@@ -1402,7 +1447,7 @@ element abbr
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Content model</span></td>
                            <td class="wovenodd-col2">
-                              <pre id="index.xml-eg-d31e3346" class="pre_eg cdata">
+                              <pre id="index.xml-eg-d31e3461" class="pre_eg cdata">
 &lt;content&gt;
  &lt;sequence minOccurs="1" maxOccurs="1"&gt;
   &lt;elementRef key="lem" minOccurs="0"/&gt;
@@ -1416,13 +1461,13 @@ element abbr
   &lt;/alternate&gt;
  &lt;/sequence&gt;
 &lt;/content&gt;
-    <a href="#index.xml-eg-d31e3346" class="anchorlink">⚓</a></pre>
+    <a href="#index.xml-eg-d31e3461" class="anchorlink">⚓</a></pre>
                            </td>
                         </tr>
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Schema Declaration</span></td>
                            <td class="wovenodd-col2">
-                              <pre id="index.xml-eg-d31e3353" class="pre_eg">
+                              <pre id="index.xml-eg-d31e3468" class="pre_eg">
 element app
 {
    tei_att.global.attributes,
@@ -1438,7 +1483,7 @@ element app
       tei_lem?,
       ( tei_model.rdgLike | tei_model.noteLike | witDetail | wit | rdgGrp )*
    )
-}<a href="#index.xml-eg-d31e3353" class="anchorlink">⚓</a></pre>
+}<a href="#index.xml-eg-d31e3468" class="anchorlink">⚓</a></pre>
                            </td>
                         </tr>
                      </table>
@@ -1488,7 +1533,7 @@ element app
                                  <div class="specChild"><span class="specChildModule">linking: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.seg" title="&lt;seg&gt;">seg</a></span></div>
                                  <div class="specChild"><span class="specChildModule">namesdates: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.orgName" title="&lt;orgName&gt;">orgName</a> <a class="link_odd_elementSpec" href="#TEI.persName" title="&lt;persName&gt;">persName</a> <a class="link_odd_elementSpec" href="#TEI.placeName" title="&lt;placeName&gt;">placeName</a></span></div>
                                  <div class="specChild"><span class="specChildModule">textcrit: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.app" title="&lt;app&gt;">app</a></span></div>
-                                 <div class="specChild"><span class="specChildModule">transcr: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.fw" title="&lt;fw&gt;">fw</a></span></div>
+                                 <div class="specChild"><span class="specChildModule">transcr: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.fw" title="&lt;fw&gt;">fw</a> <a class="link_odd_elementSpec" href="#TEI.listTranspose" title="&lt;listTranspose&gt;">listTranspose</a></span></div>
                                  <div class="specChild">character data</div>
                               </div>
                            </td>
@@ -1510,7 +1555,7 @@ element app
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Example</span></td>
                            <td class="wovenodd-col2">
-                              <div id="index.xml-egXML-d31e3808" class="pre egXML_valid"><span class="element">&lt;author&gt;</span>British Broadcasting Corporation<span class="element">&lt;/author&gt;</span>
+                              <div id="index.xml-egXML-d31e3927" class="pre egXML_valid"><span class="element">&lt;author&gt;</span>British Broadcasting Corporation<span class="element">&lt;/author&gt;</span>
                                  <span class="element">&lt;author&gt;</span>La Fayette, Marie Madeleine Pioche de la Vergne, comtesse de (1634–1693)<span class="element">&lt;/author&gt;</span>
                                  <span class="element">&lt;author&gt;</span>Anonymous<span class="element">&lt;/author&gt;</span>
                                  <span class="element">&lt;author&gt;</span>Bill and Melinda Gates Foundation<span class="element">&lt;/author&gt;</span>
@@ -1527,24 +1572,24 @@ element app
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Content model</span></td>
                            <td class="wovenodd-col2">
-                              <pre id="index.xml-eg-d31e3826" class="pre_eg cdata">
+                              <pre id="index.xml-eg-d31e3945" class="pre_eg cdata">
 &lt;content&gt;
  &lt;macroRef key="macro.phraseSeq"/&gt;
 &lt;/content&gt;
-    <a href="#index.xml-eg-d31e3826" class="anchorlink">⚓</a></pre>
+    <a href="#index.xml-eg-d31e3945" class="anchorlink">⚓</a></pre>
                            </td>
                         </tr>
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Schema Declaration</span></td>
                            <td class="wovenodd-col2">
-                              <pre id="index.xml-eg-d31e3833" class="pre_eg">
+                              <pre id="index.xml-eg-d31e3952" class="pre_eg">
 element author
 {
    tei_att.global.attributes,
    tei_att.naming.attributes,
    tei_att.datable.attributes,
    tei_macro.phraseSeq
-}<a href="#index.xml-eg-d31e3833" class="anchorlink">⚓</a></pre>
+}<a href="#index.xml-eg-d31e3952" class="anchorlink">⚓</a></pre>
                            </td>
                         </tr>
                      </table>
@@ -1591,7 +1636,7 @@ element author
                                  <div class="specChild"><span class="specChildModule">figures: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.figure" title="&lt;figure&gt;">figure</a></span></div>
                                  <div class="specChild"><span class="specChildModule">namesdates: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.orgName" title="&lt;orgName&gt;">orgName</a> <a class="link_odd_elementSpec" href="#TEI.persName" title="&lt;persName&gt;">persName</a> <a class="link_odd_elementSpec" href="#TEI.placeName" title="&lt;placeName&gt;">placeName</a></span></div>
                                  <div class="specChild"><span class="specChildModule">textcrit: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.app" title="&lt;app&gt;">app</a></span></div>
-                                 <div class="specChild"><span class="specChildModule">transcr: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.fw" title="&lt;fw&gt;">fw</a></span></div>
+                                 <div class="specChild"><span class="specChildModule">transcr: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.fw" title="&lt;fw&gt;">fw</a> <a class="link_odd_elementSpec" href="#TEI.listTranspose" title="&lt;listTranspose&gt;">listTranspose</a></span></div>
                                  <div class="specChild">character data</div>
                               </div>
                            </td>
@@ -1599,29 +1644,29 @@ element author
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Example</span></td>
                            <td class="wovenodd-col2">
-                              <div id="index.xml-egXML-d31e4129" class="pre egXML_valid"><span class="element">&lt;authority&gt;</span>John Smith<span class="element">&lt;/authority&gt;</span></div>
+                              <div id="index.xml-egXML-d31e4252" class="pre egXML_valid"><span class="element">&lt;authority&gt;</span>John Smith<span class="element">&lt;/authority&gt;</span></div>
                            </td>
                         </tr>
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Content model</span></td>
                            <td class="wovenodd-col2">
-                              <pre id="index.xml-eg-d31e4136" class="pre_eg cdata">
+                              <pre id="index.xml-eg-d31e4259" class="pre_eg cdata">
 &lt;content&gt;
  &lt;macroRef key="macro.phraseSeq.limited"/&gt;
 &lt;/content&gt;
-    <a href="#index.xml-eg-d31e4136" class="anchorlink">⚓</a></pre>
+    <a href="#index.xml-eg-d31e4259" class="anchorlink">⚓</a></pre>
                            </td>
                         </tr>
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Schema Declaration</span></td>
                            <td class="wovenodd-col2">
-                              <pre id="index.xml-eg-d31e4143" class="pre_eg">
+                              <pre id="index.xml-eg-d31e4266" class="pre_eg">
 element authority
 {
    tei_att.global.attributes,
    tei_att.canonical.attributes,
    tei_macro.phraseSeq.limited
-}<a href="#index.xml-eg-d31e4143" class="anchorlink">⚓</a></pre>
+}<a href="#index.xml-eg-d31e4266" class="anchorlink">⚓</a></pre>
                            </td>
                         </tr>
                      </table>
@@ -1660,7 +1705,7 @@ element authority
                                  <div class="specChild"><span class="specChildModule">figures: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.figure" title="&lt;figure&gt;">figure</a></span></div>
                                  <div class="specChild"><span class="specChildModule">textcrit: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.app" title="&lt;app&gt;">app</a> <a class="link_odd_elementSpec" href="#TEI.listWit" title="&lt;listWit&gt;">listWit</a></span></div>
                                  <div class="specChild"><span class="specChildModule">textstructure: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.byline" title="&lt;byline&gt;">byline</a> <a class="link_odd_elementSpec" href="#TEI.div" title="&lt;div&gt;">div</a> <a class="link_odd_elementSpec" href="#TEI.docImprint" title="&lt;docImprint&gt;">docImprint</a> <a class="link_odd_elementSpec" href="#TEI.docTitle" title="&lt;docTitle&gt;">docTitle</a> <a class="link_odd_elementSpec" href="#TEI.epigraph" title="&lt;epigraph&gt;">epigraph</a> <a class="link_odd_elementSpec" href="#TEI.signed" title="&lt;signed&gt;">signed</a> <a class="link_odd_elementSpec" href="#TEI.titlePage" title="&lt;titlePage&gt;">titlePage</a> <a class="link_odd_elementSpec" href="#TEI.titlePart" title="&lt;titlePart&gt;">titlePart</a> <a class="link_odd_elementSpec" href="#TEI.trailer" title="&lt;trailer&gt;">trailer</a></span></div>
-                                 <div class="specChild"><span class="specChildModule">transcr: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.fw" title="&lt;fw&gt;">fw</a></span></div>
+                                 <div class="specChild"><span class="specChildModule">transcr: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.fw" title="&lt;fw&gt;">fw</a> <a class="link_odd_elementSpec" href="#TEI.listTranspose" title="&lt;listTranspose&gt;">listTranspose</a></span></div>
                               </div>
                            </td>
                         </tr>
@@ -1674,7 +1719,7 @@ element authority
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Example</span></td>
                            <td class="wovenodd-col2">
-                              <div id="index.xml-egXML-d31e4428" class="pre egXML_valid"><span class="element">&lt;back&gt;</span>
+                              <div id="index.xml-egXML-d31e4555" class="pre egXML_valid"><span class="element">&lt;back&gt;</span>
                                   <span class="element">&lt;div <span class="attribute">type</span>="<span class="attributevalue">appendix</span>"&gt;</span>
                                    <span class="element">&lt;head&gt;</span>The Golden Dream or, the Ingenuous Confession<span class="element">&lt;/head&gt;</span>
                                    <span class="element">&lt;p&gt;</span>TO shew the Depravity of human Nature, and how apt the Mind is to be misled by Trinkets
@@ -1721,7 +1766,7 @@ element authority
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Content model</span></td>
                            <td class="wovenodd-col2">
-                              <pre id="index.xml-eg-d31e4465" class="pre_eg cdata">
+                              <pre id="index.xml-eg-d31e4592" class="pre_eg cdata">
 &lt;content&gt;
  &lt;sequence&gt;
   &lt;alternate minOccurs="0"
@@ -1762,13 +1807,13 @@ element authority
   &lt;/sequence&gt;
  &lt;/sequence&gt;
 &lt;/content&gt;
-    <a href="#index.xml-eg-d31e4465" class="anchorlink">⚓</a></pre>
+    <a href="#index.xml-eg-d31e4592" class="anchorlink">⚓</a></pre>
                            </td>
                         </tr>
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Schema Declaration</span></td>
                            <td class="wovenodd-col2">
-                              <pre id="index.xml-eg-d31e4472" class="pre_eg">
+                              <pre id="index.xml-eg-d31e4599" class="pre_eg">
 element back
 {
    tei_att.global.attributes,
@@ -1796,7 +1841,7 @@ element back
          ( tei_model.divBottomPart | tei_model.global )*
       )?
    )
-}<a href="#index.xml-eg-d31e4472" class="anchorlink">⚓</a></pre>
+}<a href="#index.xml-eg-d31e4599" class="anchorlink">⚓</a></pre>
                            </td>
                         </tr>
                      </table>
@@ -1860,7 +1905,7 @@ element back
                                     <div class="specChild"><span class="specChildModule">core: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.bibl" title="&lt;bibl&gt;">bibl</a> <a class="link_odd_elementSpec" href="#TEI.cit" title="&lt;cit&gt;">cit</a> <a class="link_odd_elementSpec" href="#TEI.emph" title="&lt;emph&gt;">emph</a> <a class="link_odd_elementSpec" href="#TEI.foreign" title="&lt;foreign&gt;">foreign</a> <a class="link_odd_elementSpec" href="#TEI.head" title="&lt;head&gt;">head</a> <a class="link_odd_elementSpec" href="#TEI.hi" title="&lt;hi&gt;">hi</a> <a class="link_odd_elementSpec" href="#TEI.item" title="&lt;item&gt;">item</a> <a class="link_odd_elementSpec" href="#TEI.l" title="&lt;l&gt;">l</a> <a class="link_odd_elementSpec" href="#TEI.listBibl" title="&lt;listBibl&gt;">listBibl</a> <a class="link_odd_elementSpec" href="#TEI.note" title="&lt;note&gt;">note</a> <a class="link_odd_elementSpec" href="#TEI.p" title="&lt;p&gt;">p</a> <a class="link_odd_elementSpec" href="#TEI.q" title="&lt;q&gt;">q</a> <a class="link_odd_elementSpec" href="#TEI.quote" title="&lt;quote&gt;">quote</a> <a class="link_odd_elementSpec" href="#TEI.ref" title="&lt;ref&gt;">ref</a> <a class="link_odd_elementSpec" href="#TEI.title" title="&lt;title&gt;">title</a></span></div>
                                     <div class="specChild"><span class="specChildModule">figures: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.figDesc" title="&lt;figDesc&gt;">figDesc</a> <a class="link_odd_elementSpec" href="#TEI.figure" title="&lt;figure&gt;">figure</a></span></div>
                                     <div class="specChild"><span class="specChildModule">header: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.change" title="&lt;change&gt;">change</a> <a class="link_odd_elementSpec" href="#TEI.licence" title="&lt;licence&gt;">licence</a> <a class="link_odd_elementSpec" href="#TEI.sourceDesc" title="&lt;sourceDesc&gt;">sourceDesc</a></span></div>
-                                    <div class="specChild"><span class="specChildModule">linking: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.seg" title="&lt;seg&gt;">seg</a></span></div>
+                                    <div class="specChild"><span class="specChildModule">linking: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.seg" title="&lt;seg&gt;">seg</a> <a class="link_odd_elementSpec" href="#TEI.standOff" title="&lt;standOff&gt;">standOff</a></span></div>
                                     <div class="specChild"><span class="specChildModule">textcrit: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.lem" title="&lt;lem&gt;">lem</a> <a class="link_odd_elementSpec" href="#TEI.rdg" title="&lt;rdg&gt;">rdg</a> <a class="link_odd_elementSpec" href="#TEI.witness" title="&lt;witness&gt;">witness</a></span></div>
                                     <div class="specChild"><span class="specChildModule">textstructure: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.body" title="&lt;body&gt;">body</a> <a class="link_odd_elementSpec" href="#TEI.div" title="&lt;div&gt;">div</a> <a class="link_odd_elementSpec" href="#TEI.epigraph" title="&lt;epigraph&gt;">epigraph</a> <a class="link_odd_elementSpec" href="#TEI.imprimatur" title="&lt;imprimatur&gt;">imprimatur</a> <a class="link_odd_elementSpec" href="#TEI.signed" title="&lt;signed&gt;">signed</a> <a class="link_odd_elementSpec" href="#TEI.titlePart" title="&lt;titlePart&gt;">titlePart</a> <a class="link_odd_elementSpec" href="#TEI.trailer" title="&lt;trailer&gt;">trailer</a></span></div>
                                  </div>
@@ -1878,7 +1923,7 @@ element back
                                  <div class="specChild"><span class="specChildModule">linking: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.seg" title="&lt;seg&gt;">seg</a></span></div>
                                  <div class="specChild"><span class="specChildModule">namesdates: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.orgName" title="&lt;orgName&gt;">orgName</a> <a class="link_odd_elementSpec" href="#TEI.persName" title="&lt;persName&gt;">persName</a> <a class="link_odd_elementSpec" href="#TEI.placeName" title="&lt;placeName&gt;">placeName</a></span></div>
                                  <div class="specChild"><span class="specChildModule">textcrit: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.app" title="&lt;app&gt;">app</a></span></div>
-                                 <div class="specChild"><span class="specChildModule">transcr: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.fw" title="&lt;fw&gt;">fw</a></span></div>
+                                 <div class="specChild"><span class="specChildModule">transcr: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.fw" title="&lt;fw&gt;">fw</a> <a class="link_odd_elementSpec" href="#TEI.listTranspose" title="&lt;listTranspose&gt;">listTranspose</a></span></div>
                                  <div class="specChild">character data</div>
                               </div>
                            </td>
@@ -1892,14 +1937,14 @@ element back
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Example</span></td>
                            <td class="wovenodd-col2">
-                              <div id="index.xml-egXML-d31e5016" class="pre egXML_valid"><span class="element">&lt;bibl&gt;</span>Blain, Clements and Grundy: Feminist Companion to Literature in English (Yale,
+                              <div id="index.xml-egXML-d31e5151" class="pre egXML_valid"><span class="element">&lt;bibl&gt;</span>Blain, Clements and Grundy: Feminist Companion to Literature in English (Yale,
                                   1990)<span class="element">&lt;/bibl&gt;</span></div>
                            </td>
                         </tr>
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Example</span></td>
                            <td class="wovenodd-col2">
-                              <div id="index.xml-egXML-d31e5023" class="pre egXML_valid"><span class="element">&lt;bibl&gt;</span>
+                              <div id="index.xml-egXML-d31e5158" class="pre egXML_valid"><span class="element">&lt;bibl&gt;</span>
                                   <span class="element">&lt;title <span class="attribute">level</span>="<span class="attributevalue">a</span>"&gt;</span>The Interesting story of the Children in the Wood<span class="element">&lt;/title&gt;</span>. In
                                  <span class="element">&lt;author&gt;</span>Victor E Neuberg<span class="element">&lt;/author&gt;</span>, <span class="element">&lt;title&gt;</span>The Penny Histories<span class="element">&lt;/title&gt;</span>.
                                  <span class="element">&lt;publisher&gt;</span>OUP<span class="element">&lt;/publisher&gt;</span>
@@ -1910,7 +1955,7 @@ element back
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Example</span></td>
                            <td class="wovenodd-col2">
-                              <div id="index.xml-egXML-d31e5040" class="pre egXML_valid"><span class="element">&lt;bibl <span class="attribute">type</span>="<span class="attributevalue">article</span>" <span class="attribute">subtype</span>="<span class="attributevalue">book_chapter</span>"
+                              <div id="index.xml-egXML-d31e5175" class="pre egXML_valid"><span class="element">&lt;bibl <span class="attribute">type</span>="<span class="attributevalue">article</span>" <span class="attribute">subtype</span>="<span class="attributevalue">book_chapter</span>"
                                      <span class="attribute">xml:id</span>="<span class="attributevalue">carlin_2003</span>"&gt;</span>
                                   <span class="element">&lt;author&gt;</span>
                                    <span class="element">&lt;name&gt;</span>
@@ -1944,7 +1989,7 @@ element back
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Content model</span></td>
                            <td class="wovenodd-col2">
-                              <pre id="index.xml-eg-d31e5078" class="pre_eg cdata">
+                              <pre id="index.xml-eg-d31e5213" class="pre_eg cdata">
 &lt;content&gt;
  &lt;alternate minOccurs="0"
   maxOccurs="unbounded"&gt;
@@ -1959,13 +2004,13 @@ element back
   &lt;classRef key="model.global"/&gt;
  &lt;/alternate&gt;
 &lt;/content&gt;
-    <a href="#index.xml-eg-d31e5078" class="anchorlink">⚓</a></pre>
+    <a href="#index.xml-eg-d31e5213" class="anchorlink">⚓</a></pre>
                            </td>
                         </tr>
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Schema Declaration</span></td>
                            <td class="wovenodd-col2">
-                              <pre id="index.xml-eg-d31e5086" class="pre_eg">
+                              <pre id="index.xml-eg-d31e5221" class="pre_eg">
 element bibl
 {
    tei_att.global.attribute.xmlid,
@@ -2005,7 +2050,7 @@ element bibl
     | tei_model.biblPart
     | tei_model.global
    )*
-}<a href="#index.xml-eg-d31e5086" class="anchorlink">⚓</a></pre>
+}<a href="#index.xml-eg-d31e5221" class="anchorlink">⚓</a></pre>
                            </td>
                         </tr>
                      </table>
@@ -2041,7 +2086,7 @@ element bibl
                                     <div class="specChild"><span class="specChildModule">core: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.cit" title="&lt;cit&gt;">cit</a> <a class="link_odd_elementSpec" href="#TEI.emph" title="&lt;emph&gt;">emph</a> <a class="link_odd_elementSpec" href="#TEI.foreign" title="&lt;foreign&gt;">foreign</a> <a class="link_odd_elementSpec" href="#TEI.head" title="&lt;head&gt;">head</a> <a class="link_odd_elementSpec" href="#TEI.hi" title="&lt;hi&gt;">hi</a> <a class="link_odd_elementSpec" href="#TEI.item" title="&lt;item&gt;">item</a> <a class="link_odd_elementSpec" href="#TEI.l" title="&lt;l&gt;">l</a> <a class="link_odd_elementSpec" href="#TEI.listBibl" title="&lt;listBibl&gt;">listBibl</a> <a class="link_odd_elementSpec" href="#TEI.note" title="&lt;note&gt;">note</a> <a class="link_odd_elementSpec" href="#TEI.p" title="&lt;p&gt;">p</a> <a class="link_odd_elementSpec" href="#TEI.q" title="&lt;q&gt;">q</a> <a class="link_odd_elementSpec" href="#TEI.quote" title="&lt;quote&gt;">quote</a> <a class="link_odd_elementSpec" href="#TEI.ref" title="&lt;ref&gt;">ref</a> <a class="link_odd_elementSpec" href="#TEI.title" title="&lt;title&gt;">title</a></span></div>
                                     <div class="specChild"><span class="specChildModule">figures: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.figDesc" title="&lt;figDesc&gt;">figDesc</a> <a class="link_odd_elementSpec" href="#TEI.figure" title="&lt;figure&gt;">figure</a></span></div>
                                     <div class="specChild"><span class="specChildModule">header: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.change" title="&lt;change&gt;">change</a> <a class="link_odd_elementSpec" href="#TEI.licence" title="&lt;licence&gt;">licence</a> <a class="link_odd_elementSpec" href="#TEI.sourceDesc" title="&lt;sourceDesc&gt;">sourceDesc</a></span></div>
-                                    <div class="specChild"><span class="specChildModule">linking: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.seg" title="&lt;seg&gt;">seg</a></span></div>
+                                    <div class="specChild"><span class="specChildModule">linking: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.seg" title="&lt;seg&gt;">seg</a> <a class="link_odd_elementSpec" href="#TEI.standOff" title="&lt;standOff&gt;">standOff</a></span></div>
                                     <div class="specChild"><span class="specChildModule">textcrit: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.lem" title="&lt;lem&gt;">lem</a> <a class="link_odd_elementSpec" href="#TEI.rdg" title="&lt;rdg&gt;">rdg</a> <a class="link_odd_elementSpec" href="#TEI.witness" title="&lt;witness&gt;">witness</a></span></div>
                                     <div class="specChild"><span class="specChildModule">textstructure: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.body" title="&lt;body&gt;">body</a> <a class="link_odd_elementSpec" href="#TEI.div" title="&lt;div&gt;">div</a> <a class="link_odd_elementSpec" href="#TEI.epigraph" title="&lt;epigraph&gt;">epigraph</a> <a class="link_odd_elementSpec" href="#TEI.imprimatur" title="&lt;imprimatur&gt;">imprimatur</a> <a class="link_odd_elementSpec" href="#TEI.signed" title="&lt;signed&gt;">signed</a> <a class="link_odd_elementSpec" href="#TEI.titlePart" title="&lt;titlePart&gt;">titlePart</a> <a class="link_odd_elementSpec" href="#TEI.trailer" title="&lt;trailer&gt;">trailer</a></span></div>
                                  </div>
@@ -2059,7 +2104,7 @@ element bibl
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Example</span></td>
                            <td class="wovenodd-col2">
-                              <div id="index.xml-egXML-d31e5543" class="pre egXML_valid"><span class="element">&lt;biblStruct&gt;</span>
+                              <div id="index.xml-egXML-d31e5682" class="pre egXML_valid"><span class="element">&lt;biblStruct&gt;</span>
                                   <span class="element">&lt;monogr&gt;</span>
                                    <span class="element">&lt;author&gt;</span>Blain, Virginia<span class="element">&lt;/author&gt;</span>
                                    <span class="element">&lt;author&gt;</span>Clements, Patricia<span class="element">&lt;/author&gt;</span>
@@ -2079,7 +2124,7 @@ element bibl
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Content model</span></td>
                            <td class="wovenodd-col2">
-                              <pre id="index.xml-eg-d31e5560" class="pre_eg cdata">
+                              <pre id="index.xml-eg-d31e5699" class="pre_eg cdata">
 &lt;content&gt;
  &lt;sequence&gt;
   &lt;elementRef key="analytic" minOccurs="0"
@@ -2099,13 +2144,13 @@ element bibl
   &lt;/alternate&gt;
  &lt;/sequence&gt;
 &lt;/content&gt;
-    <a href="#index.xml-eg-d31e5560" class="anchorlink">⚓</a></pre>
+    <a href="#index.xml-eg-d31e5699" class="anchorlink">⚓</a></pre>
                            </td>
                         </tr>
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Schema Declaration</span></td>
                            <td class="wovenodd-col2">
-                              <pre id="index.xml-eg-d31e5567" class="pre_eg">
+                              <pre id="index.xml-eg-d31e5706" class="pre_eg">
 element biblStruct
 {
    tei_att.global.attributes,
@@ -2118,7 +2163,7 @@ element biblStruct
       ( tei_monogr, series* )+,
       ( tei_model.noteLike | tei_model.ptrLike | relatedItem | citedRange )*
    )
-}<a href="#index.xml-eg-d31e5567" class="anchorlink">⚓</a></pre>
+}<a href="#index.xml-eg-d31e5706" class="anchorlink">⚓</a></pre>
                            </td>
                         </tr>
                      </table>
@@ -2157,14 +2202,14 @@ element biblStruct
                                  <div class="specChild"><span class="specChildModule">figures: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.figure" title="&lt;figure&gt;">figure</a></span></div>
                                  <div class="specChild"><span class="specChildModule">textcrit: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.app" title="&lt;app&gt;">app</a> <a class="link_odd_elementSpec" href="#TEI.listWit" title="&lt;listWit&gt;">listWit</a></span></div>
                                  <div class="specChild"><span class="specChildModule">textstructure: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.byline" title="&lt;byline&gt;">byline</a> <a class="link_odd_elementSpec" href="#TEI.div" title="&lt;div&gt;">div</a> <a class="link_odd_elementSpec" href="#TEI.epigraph" title="&lt;epigraph&gt;">epigraph</a> <a class="link_odd_elementSpec" href="#TEI.signed" title="&lt;signed&gt;">signed</a> <a class="link_odd_elementSpec" href="#TEI.trailer" title="&lt;trailer&gt;">trailer</a></span></div>
-                                 <div class="specChild"><span class="specChildModule">transcr: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.fw" title="&lt;fw&gt;">fw</a></span></div>
+                                 <div class="specChild"><span class="specChildModule">transcr: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.fw" title="&lt;fw&gt;">fw</a> <a class="link_odd_elementSpec" href="#TEI.listTranspose" title="&lt;listTranspose&gt;">listTranspose</a></span></div>
                               </div>
                            </td>
                         </tr>
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Example</span></td>
                            <td class="wovenodd-col2">
-                              <div id="index.xml-egXML-d31e5876" class="pre egXML_valid"><span class="element">&lt;body&gt;</span>
+                              <div id="index.xml-egXML-d31e6019" class="pre egXML_valid"><span class="element">&lt;body&gt;</span>
                                   <span class="element">&lt;l&gt;</span>Nu scylun hergan hefaenricaes uard<span class="element">&lt;/l&gt;</span>
                                   <span class="element">&lt;l&gt;</span>metudæs maecti end his modgidanc<span class="element">&lt;/l&gt;</span>
                                   <span class="element">&lt;l&gt;</span>uerc uuldurfadur sue he uundra gihuaes<span class="element">&lt;/l&gt;</span>
@@ -2181,7 +2226,7 @@ element biblStruct
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Content model</span></td>
                            <td class="wovenodd-col2">
-                              <pre id="index.xml-eg-d31e5893" class="pre_eg cdata">
+                              <pre id="index.xml-eg-d31e6036" class="pre_eg cdata">
 &lt;content&gt;
  &lt;sequence&gt;
   &lt;classRef key="model.global"
@@ -2261,13 +2306,13 @@ element biblStruct
   &lt;/sequence&gt;
  &lt;/sequence&gt;
 &lt;/content&gt;
-    <a href="#index.xml-eg-d31e5893" class="anchorlink">⚓</a></pre>
+    <a href="#index.xml-eg-d31e6036" class="anchorlink">⚓</a></pre>
                            </td>
                         </tr>
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Schema Declaration</span></td>
                            <td class="wovenodd-col2">
-                              <pre id="index.xml-eg-d31e5900" class="pre_eg">
+                              <pre id="index.xml-eg-d31e6043" class="pre_eg">
 element body
 {
    tei_att.global.attributes,
@@ -2295,7 +2340,7 @@ element body
       ),
       ( tei_model.divBottom, tei_model.global* )*
    )
-}<a href="#index.xml-eg-d31e5900" class="anchorlink">⚓</a></pre>
+}<a href="#index.xml-eg-d31e6043" class="anchorlink">⚓</a></pre>
                            </td>
                         </tr>
                      </table>
@@ -2346,7 +2391,7 @@ element body
                                  <div class="specChild"><span class="specChildModule">linking: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.seg" title="&lt;seg&gt;">seg</a></span></div>
                                  <div class="specChild"><span class="specChildModule">namesdates: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.orgName" title="&lt;orgName&gt;">orgName</a> <a class="link_odd_elementSpec" href="#TEI.persName" title="&lt;persName&gt;">persName</a> <a class="link_odd_elementSpec" href="#TEI.placeName" title="&lt;placeName&gt;">placeName</a></span></div>
                                  <div class="specChild"><span class="specChildModule">textcrit: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.app" title="&lt;app&gt;">app</a></span></div>
-                                 <div class="specChild"><span class="specChildModule">transcr: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.fw" title="&lt;fw&gt;">fw</a></span></div>
+                                 <div class="specChild"><span class="specChildModule">transcr: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.fw" title="&lt;fw&gt;">fw</a> <a class="link_odd_elementSpec" href="#TEI.listTranspose" title="&lt;listTranspose&gt;">listTranspose</a></span></div>
                                  <div class="specChild">character data</div>
                               </div>
                            </td>
@@ -2361,26 +2406,26 @@ element body
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Example</span></td>
                            <td class="wovenodd-col2">
-                              <div id="index.xml-egXML-d31e6332" class="pre egXML_valid"><span class="element">&lt;byline&gt;</span>Written by a CITIZEN who continued all the
+                              <div id="index.xml-egXML-d31e6479" class="pre egXML_valid"><span class="element">&lt;byline&gt;</span>Written by a CITIZEN who continued all the
                                   while in London. Never made publick before.<span class="element">&lt;/byline&gt;</span></div>
                            </td>
                         </tr>
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Example</span></td>
                            <td class="wovenodd-col2">
-                              <div id="index.xml-egXML-d31e6339" class="pre egXML_valid"><span class="element">&lt;byline&gt;</span>Written from her own MEMORANDUMS<span class="element">&lt;/byline&gt;</span></div>
+                              <div id="index.xml-egXML-d31e6486" class="pre egXML_valid"><span class="element">&lt;byline&gt;</span>Written from her own MEMORANDUMS<span class="element">&lt;/byline&gt;</span></div>
                            </td>
                         </tr>
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Example</span></td>
                            <td class="wovenodd-col2">
-                              <div id="index.xml-egXML-d31e6346" class="pre egXML_valid"><span class="element">&lt;byline&gt;</span>By George Jones, Political Editor, in Washington<span class="element">&lt;/byline&gt;</span></div>
+                              <div id="index.xml-egXML-d31e6493" class="pre egXML_valid"><span class="element">&lt;byline&gt;</span>By George Jones, Political Editor, in Washington<span class="element">&lt;/byline&gt;</span></div>
                            </td>
                         </tr>
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Example</span></td>
                            <td class="wovenodd-col2">
-                              <div id="index.xml-egXML-d31e6353" class="pre egXML_valid"><span class="element">&lt;byline&gt;</span>BY
+                              <div id="index.xml-egXML-d31e6500" class="pre egXML_valid"><span class="element">&lt;byline&gt;</span>BY
                                  <span class="element">&lt;docAuthor&gt;</span>THOMAS PHILIPOTT,<span class="element">&lt;/docAuthor&gt;</span>
                                   Master of Arts,
                                   (Somtimes)
@@ -2390,7 +2435,7 @@ element body
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Content model</span></td>
                            <td class="wovenodd-col2">
-                              <pre id="index.xml-eg-d31e6364" class="pre_eg cdata">
+                              <pre id="index.xml-eg-d31e6511" class="pre_eg cdata">
 &lt;content&gt;
  &lt;alternate minOccurs="0"
   maxOccurs="unbounded"&gt;
@@ -2401,18 +2446,18 @@ element body
   &lt;classRef key="model.global"/&gt;
  &lt;/alternate&gt;
 &lt;/content&gt;
-    <a href="#index.xml-eg-d31e6364" class="anchorlink">⚓</a></pre>
+    <a href="#index.xml-eg-d31e6511" class="anchorlink">⚓</a></pre>
                            </td>
                         </tr>
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Schema Declaration</span></td>
                            <td class="wovenodd-col2">
-                              <pre id="index.xml-eg-d31e6371" class="pre_eg">
+                              <pre id="index.xml-eg-d31e6518" class="pre_eg">
 element byline
 {
    tei_att.global.attributes,
    ( text | tei_model.gLike | tei_model.phrase | docAuthor | tei_model.global )*
-}<a href="#index.xml-eg-d31e6371" class="anchorlink">⚓</a></pre>
+}<a href="#index.xml-eg-d31e6518" class="anchorlink">⚓</a></pre>
                            </td>
                         </tr>
                      </table>
@@ -2511,7 +2556,7 @@ element byline
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Example</span></td>
                            <td class="wovenodd-col2">Markup of an early English dictionary printed in two columns:
-                              <div id="index.xml-egXML-d31e6843" class="pre egXML_valid"><span class="element">&lt;pb/&gt;</span>
+                              <div id="index.xml-egXML-d31e6990" class="pre egXML_valid"><span class="element">&lt;pb/&gt;</span>
                                  <span class="element">&lt;cb <span class="attribute">n</span>="<span class="attributevalue">1</span>"/&gt;</span>
                                  <span class="element">&lt;entryFree&gt;</span>
                                   <span class="element">&lt;form&gt;</span>Well<span class="element">&lt;/form&gt;</span>, <span class="element">&lt;sense&gt;</span>a Pit to hold Spring-Water<span class="element">&lt;/sense&gt;</span>:
@@ -2536,17 +2581,17 @@ element byline
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Content model</span></td>
                            <td class="wovenodd-col2">
-                              <pre id="index.xml-eg-d31e6882" class="pre_eg cdata">
+                              <pre id="index.xml-eg-d31e7029" class="pre_eg cdata">
 &lt;content&gt;
  &lt;empty/&gt;
 &lt;/content&gt;
-    <a href="#index.xml-eg-d31e6882" class="anchorlink">⚓</a></pre>
+    <a href="#index.xml-eg-d31e7029" class="anchorlink">⚓</a></pre>
                            </td>
                         </tr>
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Schema Declaration</span></td>
                            <td class="wovenodd-col2">
-                              <pre id="index.xml-eg-d31e6889" class="pre_eg">
+                              <pre id="index.xml-eg-d31e7036" class="pre_eg">
 element cb
 {
    tei_att.global.attribute.xmlid,
@@ -2576,7 +2621,7 @@ element cb
    tei_att.breaking.attributes,
    attribute n { "1" | "2" },
    empty
-}<a href="#index.xml-eg-d31e6889" class="anchorlink">⚓</a></pre>
+}<a href="#index.xml-eg-d31e7036" class="anchorlink">⚓</a></pre>
                            </td>
                         </tr>
                      </table>
@@ -2680,7 +2725,7 @@ element cb
                                  <div class="specChild"><span class="specChildModule">linking: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.seg" title="&lt;seg&gt;">seg</a></span></div>
                                  <div class="specChild"><span class="specChildModule">namesdates: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.orgName" title="&lt;orgName&gt;">orgName</a> <a class="link_odd_elementSpec" href="#TEI.persName" title="&lt;persName&gt;">persName</a> <a class="link_odd_elementSpec" href="#TEI.placeName" title="&lt;placeName&gt;">placeName</a></span></div>
                                  <div class="specChild"><span class="specChildModule">textcrit: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.app" title="&lt;app&gt;">app</a> <a class="link_odd_elementSpec" href="#TEI.listWit" title="&lt;listWit&gt;">listWit</a></span></div>
-                                 <div class="specChild"><span class="specChildModule">transcr: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.fw" title="&lt;fw&gt;">fw</a></span></div>
+                                 <div class="specChild"><span class="specChildModule">transcr: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.fw" title="&lt;fw&gt;">fw</a> <a class="link_odd_elementSpec" href="#TEI.listTranspose" title="&lt;listTranspose&gt;">listTranspose</a></span></div>
                                  <div class="specChild">character data</div>
                               </div>
                            </td>
@@ -2697,7 +2742,7 @@ element cb
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Example</span></td>
                            <td class="wovenodd-col2">
-                              <div id="index.xml-egXML-d31e7467" class="pre egXML_valid"><span class="element">&lt;titleStmt&gt;</span>
+                              <div id="index.xml-egXML-d31e7618" class="pre egXML_valid"><span class="element">&lt;titleStmt&gt;</span>
                                   <span class="element">&lt;title&gt;</span> ... <span class="element">&lt;/title&gt;</span>
                                   <span class="element">&lt;editor <span class="attribute">xml:id</span>="<span class="attributevalue">LDB</span>"&gt;</span>Lou Burnard<span class="element">&lt;/editor&gt;</span>
                                   <span class="element">&lt;respStmt <span class="attribute">xml:id</span>="<span class="attributevalue">BZ</span>"&gt;</span>
@@ -2720,7 +2765,7 @@ element cb
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Example</span></td>
                            <td class="wovenodd-col2">
-                              <div id="index.xml-egXML-d31e7490" class="pre egXML_valid"><span class="element">&lt;profileDesc&gt;</span>
+                              <div id="index.xml-egXML-d31e7641" class="pre egXML_valid"><span class="element">&lt;profileDesc&gt;</span>
                                   <span class="element">&lt;creation&gt;</span>
                                    <span class="element">&lt;listChange&gt;</span>
                                     <span class="element">&lt;change <span class="attribute">xml:id</span>="<span class="attributevalue">DRAFT1</span>"&gt;</span>First draft in pencil<span class="element">&lt;/change&gt;</span>
@@ -2738,17 +2783,17 @@ element cb
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Content model</span></td>
                            <td class="wovenodd-col2">
-                              <pre id="index.xml-eg-d31e7505" class="pre_eg cdata">
+                              <pre id="index.xml-eg-d31e7656" class="pre_eg cdata">
 &lt;content&gt;
  &lt;macroRef key="macro.specialPara"/&gt;
 &lt;/content&gt;
-    <a href="#index.xml-eg-d31e7505" class="anchorlink">⚓</a></pre>
+    <a href="#index.xml-eg-d31e7656" class="anchorlink">⚓</a></pre>
                            </td>
                         </tr>
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Schema Declaration</span></td>
                            <td class="wovenodd-col2">
-                              <pre id="index.xml-eg-d31e7512" class="pre_eg">
+                              <pre id="index.xml-eg-d31e7663" class="pre_eg">
 element change
 {
    tei_att.datable.attribute.calendar,
@@ -2776,7 +2821,7 @@ element change
    attribute when { text },
    attribute target { list { + } }?,
    tei_macro.specialPara
-}<a href="#index.xml-eg-d31e7512" class="anchorlink">⚓</a></pre>
+}<a href="#index.xml-eg-d31e7663" class="anchorlink">⚓</a></pre>
                            </td>
                         </tr>
                      </table>
@@ -2831,14 +2876,14 @@ element change
                                  <div class="specChild"><span class="specChildModule">core: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.bibl" title="&lt;bibl&gt;">bibl</a> <a class="link_odd_elementSpec" href="#TEI.biblStruct" title="&lt;biblStruct&gt;">biblStruct</a> <a class="link_odd_elementSpec" href="#TEI.cb" title="&lt;cb&gt;">cb</a> <a class="link_odd_elementSpec" href="#TEI.cit" title="&lt;cit&gt;">cit</a> <a class="link_odd_elementSpec" href="#TEI.graphic" title="&lt;graphic&gt;">graphic</a> <a class="link_odd_elementSpec" href="#TEI.lb" title="&lt;lb&gt;">lb</a> <a class="link_odd_elementSpec" href="#TEI.listBibl" title="&lt;listBibl&gt;">listBibl</a> <a class="link_odd_elementSpec" href="#TEI.note" title="&lt;note&gt;">note</a> <a class="link_odd_elementSpec" href="#TEI.pb" title="&lt;pb&gt;">pb</a> <a class="link_odd_elementSpec" href="#TEI.ptr" title="&lt;ptr&gt;">ptr</a> <a class="link_odd_elementSpec" href="#TEI.q" title="&lt;q&gt;">q</a> <a class="link_odd_elementSpec" href="#TEI.quote" title="&lt;quote&gt;">quote</a> <a class="link_odd_elementSpec" href="#TEI.ref" title="&lt;ref&gt;">ref</a></span></div>
                                  <div class="specChild"><span class="specChildModule">figures: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.figure" title="&lt;figure&gt;">figure</a></span></div>
                                  <div class="specChild"><span class="specChildModule">textcrit: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.app" title="&lt;app&gt;">app</a></span></div>
-                                 <div class="specChild"><span class="specChildModule">transcr: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.fw" title="&lt;fw&gt;">fw</a></span></div>
+                                 <div class="specChild"><span class="specChildModule">transcr: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.fw" title="&lt;fw&gt;">fw</a> <a class="link_odd_elementSpec" href="#TEI.listTranspose" title="&lt;listTranspose&gt;">listTranspose</a></span></div>
                               </div>
                            </td>
                         </tr>
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Example</span></td>
                            <td class="wovenodd-col2">
-                              <div id="index.xml-egXML-d31e8015" class="pre egXML_valid"><span class="element">&lt;cit&gt;</span>
+                              <div id="index.xml-egXML-d31e8170" class="pre egXML_valid"><span class="element">&lt;cit&gt;</span>
                                   <span class="element">&lt;quote&gt;</span>and the breath of the whale is frequently attended with such an insupportable smell,
                                     as to bring on disorder of the brain.<span class="element">&lt;/quote&gt;</span>
                                   <span class="element">&lt;bibl&gt;</span>Ulloa's South America<span class="element">&lt;/bibl&gt;</span>
@@ -2848,7 +2893,7 @@ element change
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Example</span></td>
                            <td class="wovenodd-col2">
-                              <div id="index.xml-egXML-d31e8024" class="pre egXML_valid"><span class="element">&lt;entry&gt;</span>
+                              <div id="index.xml-egXML-d31e8179" class="pre egXML_valid"><span class="element">&lt;entry&gt;</span>
                                   <span class="element">&lt;form&gt;</span>
                                    <span class="element">&lt;orth&gt;</span>horrifier<span class="element">&lt;/orth&gt;</span>
                                   <span class="element">&lt;/form&gt;</span>
@@ -2867,7 +2912,7 @@ element change
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Example</span></td>
                            <td class="wovenodd-col2">
-                              <div id="index.xml-egXML-d31e8039" class="pre egXML_valid"><span class="element">&lt;cit <span class="attribute">type</span>="<span class="attributevalue">example</span>"&gt;</span>
+                              <div id="index.xml-egXML-d31e8194" class="pre egXML_valid"><span class="element">&lt;cit <span class="attribute">type</span>="<span class="attributevalue">example</span>"&gt;</span>
                                   <span class="element">&lt;quote <span class="attribute">xml:lang</span>="<span class="attributevalue">mix</span>"&gt;</span>Ka'an yu tsa'a Pedro.<span class="element">&lt;/quote&gt;</span>
                                   <span class="element">&lt;media <span class="attribute">url</span>="<span class="attributevalue">soundfiles-gen:S_speak_1s_on_behalf_of_Pedro_01_02_03_TS.wav</span>"
                                       <span class="attribute">mimeType</span>="<span class="attributevalue">audio/wav</span>"/&gt;</span>
@@ -2883,7 +2928,7 @@ element change
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Content model</span></td>
                            <td class="wovenodd-col2">
-                              <pre id="index.xml-eg-d31e8055" class="pre_eg cdata">
+                              <pre id="index.xml-eg-d31e8210" class="pre_eg cdata">
 &lt;content&gt;
  &lt;alternate minOccurs="1"
   maxOccurs="unbounded"&gt;
@@ -2898,13 +2943,13 @@ element change
   &lt;elementRef key="q"/&gt;
  &lt;/alternate&gt;
 &lt;/content&gt;
-    <a href="#index.xml-eg-d31e8055" class="anchorlink">⚓</a></pre>
+    <a href="#index.xml-eg-d31e8210" class="anchorlink">⚓</a></pre>
                            </td>
                         </tr>
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Schema Declaration</span></td>
                            <td class="wovenodd-col2">
-                              <pre id="index.xml-eg-d31e8062" class="pre_eg">
+                              <pre id="index.xml-eg-d31e8217" class="pre_eg">
 element cit
 {
    tei_att.global.attributes,
@@ -2920,7 +2965,7 @@ element cit
     | pc
     | tei_q
    )+
-}<a href="#index.xml-eg-d31e8062" class="anchorlink">⚓</a></pre>
+}<a href="#index.xml-eg-d31e8217" class="anchorlink">⚓</a></pre>
                            </td>
                         </tr>
                      </table>
@@ -3004,7 +3049,7 @@ element cit
                                  <div class="specChild"><span class="specChildModule">linking: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.seg" title="&lt;seg&gt;">seg</a></span></div>
                                  <div class="specChild"><span class="specChildModule">namesdates: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.orgName" title="&lt;orgName&gt;">orgName</a> <a class="link_odd_elementSpec" href="#TEI.persName" title="&lt;persName&gt;">persName</a> <a class="link_odd_elementSpec" href="#TEI.placeName" title="&lt;placeName&gt;">placeName</a></span></div>
                                  <div class="specChild"><span class="specChildModule">textcrit: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.app" title="&lt;app&gt;">app</a></span></div>
-                                 <div class="specChild"><span class="specChildModule">transcr: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.fw" title="&lt;fw&gt;">fw</a></span></div>
+                                 <div class="specChild"><span class="specChildModule">transcr: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.fw" title="&lt;fw&gt;">fw</a> <a class="link_odd_elementSpec" href="#TEI.listTranspose" title="&lt;listTranspose&gt;">listTranspose</a></span></div>
                                  <div class="specChild">character data</div>
                               </div>
                            </td>
@@ -3012,13 +3057,13 @@ element cit
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Example</span></td>
                            <td class="wovenodd-col2">
-                              <div id="index.xml-egXML-d31e8729" class="pre egXML_valid"><span class="element">&lt;date <span class="attribute">when</span>="<span class="attributevalue">1980-02</span>"&gt;</span>early February 1980<span class="element">&lt;/date&gt;</span></div>
+                              <div id="index.xml-egXML-d31e8888" class="pre egXML_valid"><span class="element">&lt;date <span class="attribute">when</span>="<span class="attributevalue">1980-02</span>"&gt;</span>early February 1980<span class="element">&lt;/date&gt;</span></div>
                            </td>
                         </tr>
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Example</span></td>
                            <td class="wovenodd-col2">
-                              <div id="index.xml-egXML-d31e8737" class="pre egXML_valid">Given on the <span class="element">&lt;date <span class="attribute">when</span>="<span class="attributevalue">1977-06-12</span>"&gt;</span>Twelfth Day
+                              <div id="index.xml-egXML-d31e8896" class="pre egXML_valid">Given on the <span class="element">&lt;date <span class="attribute">when</span>="<span class="attributevalue">1977-06-12</span>"&gt;</span>Twelfth Day
                                   of June in the Year of Our Lord One Thousand Nine Hundred and Seventy-seven of the
                                  Republic
                                   the Two Hundredth and first and of the University the Eighty-Sixth.<span class="element">&lt;/date&gt;</span></div>
@@ -3027,13 +3072,13 @@ element cit
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Example</span></td>
                            <td class="wovenodd-col2">
-                              <div id="index.xml-egXML-d31e8746" class="pre egXML_valid"><span class="element">&lt;date <span class="attribute">when</span>="<span class="attributevalue">1990-09</span>"&gt;</span>September 1990<span class="element">&lt;/date&gt;</span></div>
+                              <div id="index.xml-egXML-d31e8905" class="pre egXML_valid"><span class="element">&lt;date <span class="attribute">when</span>="<span class="attributevalue">1990-09</span>"&gt;</span>September 1990<span class="element">&lt;/date&gt;</span></div>
                            </td>
                         </tr>
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Content model</span></td>
                            <td class="wovenodd-col2">
-                              <pre id="index.xml-eg-d31e8754" class="pre_eg cdata">
+                              <pre id="index.xml-eg-d31e8913" class="pre_eg cdata">
 &lt;content&gt;
  &lt;alternate minOccurs="0"
   maxOccurs="unbounded"&gt;
@@ -3043,13 +3088,13 @@ element cit
   &lt;classRef key="model.global"/&gt;
  &lt;/alternate&gt;
 &lt;/content&gt;
-    <a href="#index.xml-eg-d31e8754" class="anchorlink">⚓</a></pre>
+    <a href="#index.xml-eg-d31e8913" class="anchorlink">⚓</a></pre>
                            </td>
                         </tr>
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Schema Declaration</span></td>
                            <td class="wovenodd-col2">
-                              <pre id="index.xml-eg-d31e8761" class="pre_eg">
+                              <pre id="index.xml-eg-d31e8920" class="pre_eg">
 element date
 {
    tei_att.global.attributes,
@@ -3077,7 +3122,7 @@ element date
    tei_att.typed.attributes,
    attribute when { text },
    ( text | tei_model.gLike | tei_model.phrase | tei_model.global )*
-}<a href="#index.xml-eg-d31e8761" class="anchorlink">⚓</a></pre>
+}<a href="#index.xml-eg-d31e8920" class="anchorlink">⚓</a></pre>
                            </td>
                         </tr>
                      </table>
@@ -3123,14 +3168,14 @@ element date
                                  <div class="specChild"><span class="specChildModule">figures: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.figure" title="&lt;figure&gt;">figure</a></span></div>
                                  <div class="specChild"><span class="specChildModule">textcrit: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.app" title="&lt;app&gt;">app</a> <a class="link_odd_elementSpec" href="#TEI.listWit" title="&lt;listWit&gt;">listWit</a></span></div>
                                  <div class="specChild"><span class="specChildModule">textstructure: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.byline" title="&lt;byline&gt;">byline</a> <a class="link_odd_elementSpec" href="#TEI.div" title="&lt;div&gt;">div</a> <a class="link_odd_elementSpec" href="#TEI.epigraph" title="&lt;epigraph&gt;">epigraph</a> <a class="link_odd_elementSpec" href="#TEI.signed" title="&lt;signed&gt;">signed</a> <a class="link_odd_elementSpec" href="#TEI.trailer" title="&lt;trailer&gt;">trailer</a></span></div>
-                                 <div class="specChild"><span class="specChildModule">transcr: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.fw" title="&lt;fw&gt;">fw</a></span></div>
+                                 <div class="specChild"><span class="specChildModule">transcr: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.fw" title="&lt;fw&gt;">fw</a> <a class="link_odd_elementSpec" href="#TEI.listTranspose" title="&lt;listTranspose&gt;">listTranspose</a></span></div>
                               </div>
                            </td>
                         </tr>
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Example</span></td>
                            <td class="wovenodd-col2">
-                              <div id="index.xml-egXML-d31e9183" class="pre egXML_valid"><span class="element">&lt;body&gt;</span>
+                              <div id="index.xml-egXML-d31e9346" class="pre egXML_valid"><span class="element">&lt;body&gt;</span>
                                   <span class="element">&lt;div <span class="attribute">type</span>="<span class="attributevalue">part</span>"&gt;</span>
                                    <span class="element">&lt;head&gt;</span>Fallacies of Authority<span class="element">&lt;/head&gt;</span>
                                    <span class="element">&lt;p&gt;</span>The subject of which is Authority in various shapes, and the object, to repress all
@@ -3176,7 +3221,7 @@ element date
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Content model</span></td>
                            <td class="wovenodd-col2">
-                              <pre id="index.xml-eg-d31e9216" class="pre_eg cdata">
+                              <pre id="index.xml-eg-d31e9379" class="pre_eg cdata">
 &lt;content&gt;
  &lt;sequence&gt;
   &lt;alternate minOccurs="0"
@@ -3226,13 +3271,13 @@ element date
   &lt;/sequence&gt;
  &lt;/sequence&gt;
 &lt;/content&gt;
-    <a href="#index.xml-eg-d31e9216" class="anchorlink">⚓</a></pre>
+    <a href="#index.xml-eg-d31e9379" class="anchorlink">⚓</a></pre>
                            </td>
                         </tr>
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Schema Declaration</span></td>
                            <td class="wovenodd-col2">
-                              <pre id="index.xml-eg-d31e9223" class="pre_eg">
+                              <pre id="index.xml-eg-d31e9386" class="pre_eg">
 element div
 {
    tei_att.global.attributes,
@@ -3256,7 +3301,7 @@ element div
          ( tei_model.divBottom, tei_model.global* )*
       )?
    )
-}<a href="#index.xml-eg-d31e9223" class="anchorlink">⚓</a></pre>
+}<a href="#index.xml-eg-d31e9386" class="anchorlink">⚓</a></pre>
                            </td>
                         </tr>
                      </table>
@@ -3305,7 +3350,7 @@ element div
                                  <div class="specChild"><span class="specChildModule">linking: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.seg" title="&lt;seg&gt;">seg</a></span></div>
                                  <div class="specChild"><span class="specChildModule">namesdates: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.orgName" title="&lt;orgName&gt;">orgName</a> <a class="link_odd_elementSpec" href="#TEI.persName" title="&lt;persName&gt;">persName</a> <a class="link_odd_elementSpec" href="#TEI.placeName" title="&lt;placeName&gt;">placeName</a></span></div>
                                  <div class="specChild"><span class="specChildModule">textcrit: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.app" title="&lt;app&gt;">app</a></span></div>
-                                 <div class="specChild"><span class="specChildModule">transcr: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.fw" title="&lt;fw&gt;">fw</a></span></div>
+                                 <div class="specChild"><span class="specChildModule">transcr: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.fw" title="&lt;fw&gt;">fw</a> <a class="link_odd_elementSpec" href="#TEI.listTranspose" title="&lt;listTranspose&gt;">listTranspose</a></span></div>
                                  <div class="specChild">character data</div>
                               </div>
                            </td>
@@ -3320,8 +3365,8 @@ element div
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Example</span></td>
                            <td class="wovenodd-col2">
-                              <div id="index.xml-egXML-d31e9609" class="pre egXML_valid"><span class="element">&lt;docImprint&gt;</span>Oxford, Clarendon Press, 1987<span class="element">&lt;/docImprint&gt;</span></div>Imprints may be somewhat more complex: 
-                              <div id="index.xml-egXML-d31e9612" class="pre egXML_valid"><span class="element">&lt;docImprint&gt;</span>
+                              <div id="index.xml-egXML-d31e9776" class="pre egXML_valid"><span class="element">&lt;docImprint&gt;</span>Oxford, Clarendon Press, 1987<span class="element">&lt;/docImprint&gt;</span></div>Imprints may be somewhat more complex: 
+                              <div id="index.xml-egXML-d31e9779" class="pre egXML_valid"><span class="element">&lt;docImprint&gt;</span>
                                   <span class="element">&lt;pubPlace&gt;</span>London<span class="element">&lt;/pubPlace&gt;</span>
                                   Printed for <span class="element">&lt;name&gt;</span>E. Nutt<span class="element">&lt;/name&gt;</span>,
                                   at
@@ -3339,7 +3384,7 @@ element div
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Content model</span></td>
                            <td class="wovenodd-col2">
-                              <pre id="index.xml-eg-d31e9638" class="pre_eg cdata">
+                              <pre id="index.xml-eg-d31e9805" class="pre_eg cdata">
 &lt;content&gt;
  &lt;alternate minOccurs="0"
   maxOccurs="unbounded"&gt;
@@ -3352,13 +3397,13 @@ element div
   &lt;classRef key="model.global"/&gt;
  &lt;/alternate&gt;
 &lt;/content&gt;
-    <a href="#index.xml-eg-d31e9638" class="anchorlink">⚓</a></pre>
+    <a href="#index.xml-eg-d31e9805" class="anchorlink">⚓</a></pre>
                            </td>
                         </tr>
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Schema Declaration</span></td>
                            <td class="wovenodd-col2">
-                              <pre id="index.xml-eg-d31e9645" class="pre_eg">
+                              <pre id="index.xml-eg-d31e9812" class="pre_eg">
 element docImprint
 {
    tei_att.global.attributes,
@@ -3371,7 +3416,7 @@ element docImprint
     | tei_publisher
     | tei_model.global
    )*
-}<a href="#index.xml-eg-d31e9645" class="anchorlink">⚓</a></pre>
+}<a href="#index.xml-eg-d31e9812" class="anchorlink">⚓</a></pre>
                            </td>
                         </tr>
                      </table>
@@ -3418,14 +3463,14 @@ element docImprint
                                  <div class="specChild"><span class="specChildModule">figures: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.figure" title="&lt;figure&gt;">figure</a></span></div>
                                  <div class="specChild"><span class="specChildModule">textcrit: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.app" title="&lt;app&gt;">app</a></span></div>
                                  <div class="specChild"><span class="specChildModule">textstructure: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.titlePart" title="&lt;titlePart&gt;">titlePart</a></span></div>
-                                 <div class="specChild"><span class="specChildModule">transcr: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.fw" title="&lt;fw&gt;">fw</a></span></div>
+                                 <div class="specChild"><span class="specChildModule">transcr: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.fw" title="&lt;fw&gt;">fw</a> <a class="link_odd_elementSpec" href="#TEI.listTranspose" title="&lt;listTranspose&gt;">listTranspose</a></span></div>
                               </div>
                            </td>
                         </tr>
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Example</span></td>
                            <td class="wovenodd-col2">
-                              <div id="index.xml-egXML-d31e9907" class="pre egXML_valid"><span class="element">&lt;docTitle&gt;</span>
+                              <div id="index.xml-egXML-d31e10078" class="pre egXML_valid"><span class="element">&lt;docTitle&gt;</span>
                                   <span class="element">&lt;titlePart <span class="attribute">type</span>="<span class="attributevalue">main</span>"&gt;</span>The DUNCIAD, VARIOURVM.<span class="element">&lt;/titlePart&gt;</span>
                                   <span class="element">&lt;titlePart <span class="attribute">type</span>="<span class="attributevalue">sub</span>"&gt;</span>WITH THE PROLEGOMENA of SCRIBLERUS.<span class="element">&lt;/titlePart&gt;</span>
                                  <span class="element">&lt;/docTitle&gt;</span></div>
@@ -3434,7 +3479,7 @@ element docImprint
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Content model</span></td>
                            <td class="wovenodd-col2">
-                              <pre id="index.xml-eg-d31e9918" class="pre_eg cdata">
+                              <pre id="index.xml-eg-d31e10089" class="pre_eg cdata">
 &lt;content&gt;
  &lt;sequence&gt;
   &lt;classRef key="model.global"
@@ -3447,19 +3492,19 @@ element docImprint
   &lt;/sequence&gt;
  &lt;/sequence&gt;
 &lt;/content&gt;
-    <a href="#index.xml-eg-d31e9918" class="anchorlink">⚓</a></pre>
+    <a href="#index.xml-eg-d31e10089" class="anchorlink">⚓</a></pre>
                            </td>
                         </tr>
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Schema Declaration</span></td>
                            <td class="wovenodd-col2">
-                              <pre id="index.xml-eg-d31e9925" class="pre_eg">
+                              <pre id="index.xml-eg-d31e10096" class="pre_eg">
 element docTitle
 {
    tei_att.global.attributes,
    tei_att.canonical.attributes,
    ( tei_model.global*, ( tei_titlePart, tei_model.global* )+ )
-}<a href="#index.xml-eg-d31e9925" class="anchorlink">⚓</a></pre>
+}<a href="#index.xml-eg-d31e10096" class="anchorlink">⚓</a></pre>
                            </td>
                         </tr>
                      </table>
@@ -3507,7 +3552,7 @@ element docTitle
                                  <div class="specChild"><span class="specChildModule">linking: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.seg" title="&lt;seg&gt;">seg</a></span></div>
                                  <div class="specChild"><span class="specChildModule">namesdates: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.orgName" title="&lt;orgName&gt;">orgName</a> <a class="link_odd_elementSpec" href="#TEI.persName" title="&lt;persName&gt;">persName</a> <a class="link_odd_elementSpec" href="#TEI.placeName" title="&lt;placeName&gt;">placeName</a></span></div>
                                  <div class="specChild"><span class="specChildModule">textcrit: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.app" title="&lt;app&gt;">app</a></span></div>
-                                 <div class="specChild"><span class="specChildModule">transcr: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.fw" title="&lt;fw&gt;">fw</a></span></div>
+                                 <div class="specChild"><span class="specChildModule">transcr: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.fw" title="&lt;fw&gt;">fw</a> <a class="link_odd_elementSpec" href="#TEI.listTranspose" title="&lt;listTranspose&gt;">listTranspose</a></span></div>
                                  <div class="specChild">character data</div>
                               </div>
                            </td>
@@ -3515,7 +3560,7 @@ element docTitle
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Example</span></td>
                            <td class="wovenodd-col2">
-                              <div id="index.xml-egXML-d31e10246" class="pre egXML_valid"><span class="element">&lt;edition&gt;</span>First edition <span class="element">&lt;date&gt;</span>Oct 1990<span class="element">&lt;/date&gt;</span>
+                              <div id="index.xml-egXML-d31e10421" class="pre egXML_valid"><span class="element">&lt;edition&gt;</span>First edition <span class="element">&lt;date&gt;</span>Oct 1990<span class="element">&lt;/date&gt;</span>
                                  <span class="element">&lt;/edition&gt;</span>
                                  <span class="element">&lt;edition <span class="attribute">n</span>="<span class="attributevalue">S2</span>"&gt;</span>Students' edition<span class="element">&lt;/edition&gt;</span></div>
                            </td>
@@ -3523,18 +3568,18 @@ element docTitle
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Content model</span></td>
                            <td class="wovenodd-col2">
-                              <pre id="index.xml-eg-d31e10257" class="pre_eg cdata">
+                              <pre id="index.xml-eg-d31e10432" class="pre_eg cdata">
 &lt;content&gt;
  &lt;macroRef key="macro.phraseSeq"/&gt;
 &lt;/content&gt;
-    <a href="#index.xml-eg-d31e10257" class="anchorlink">⚓</a></pre>
+    <a href="#index.xml-eg-d31e10432" class="anchorlink">⚓</a></pre>
                            </td>
                         </tr>
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Schema Declaration</span></td>
                            <td class="wovenodd-col2">
-                              <pre id="index.xml-eg-d31e10264" class="pre_eg">
-element edition { tei_att.global.attributes, tei_macro.phraseSeq }<a href="#index.xml-eg-d31e10264" class="anchorlink">⚓</a></pre>
+                              <pre id="index.xml-eg-d31e10439" class="pre_eg">
+element edition { tei_att.global.attributes, tei_macro.phraseSeq }<a href="#index.xml-eg-d31e10439" class="anchorlink">⚓</a></pre>
                            </td>
                         </tr>
                      </table>
@@ -3577,7 +3622,7 @@ element edition { tei_att.global.attributes, tei_macro.phraseSeq }<a href="#inde
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Example</span></td>
                            <td class="wovenodd-col2">
-                              <div id="index.xml-egXML-d31e10456" class="pre egXML_valid"><span class="element">&lt;editionStmt&gt;</span>
+                              <div id="index.xml-egXML-d31e10631" class="pre egXML_valid"><span class="element">&lt;editionStmt&gt;</span>
                                   <span class="element">&lt;edition <span class="attribute">n</span>="<span class="attributevalue">S2</span>"&gt;</span>Students' edition<span class="element">&lt;/edition&gt;</span>
                                   <span class="element">&lt;respStmt&gt;</span>
                                    <span class="element">&lt;resp&gt;</span>Adapted by <span class="element">&lt;/resp&gt;</span>
@@ -3589,7 +3634,7 @@ element edition { tei_att.global.attributes, tei_macro.phraseSeq }<a href="#inde
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Example</span></td>
                            <td class="wovenodd-col2">
-                              <div id="index.xml-egXML-d31e10468" class="pre egXML_valid"><span class="element">&lt;editionStmt&gt;</span>
+                              <div id="index.xml-egXML-d31e10643" class="pre egXML_valid"><span class="element">&lt;editionStmt&gt;</span>
                                   <span class="element">&lt;p&gt;</span>First edition, <span class="element">&lt;date&gt;</span>Michaelmas Term, 1991.<span class="element">&lt;/date&gt;</span>
                                   <span class="element">&lt;/p&gt;</span>
                                  <span class="element">&lt;/editionStmt&gt;</span></div>
@@ -3598,7 +3643,7 @@ element edition { tei_att.global.attributes, tei_macro.phraseSeq }<a href="#inde
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Content model</span></td>
                            <td class="wovenodd-col2">
-                              <pre id="index.xml-eg-d31e10478" class="pre_eg cdata">
+                              <pre id="index.xml-eg-d31e10653" class="pre_eg cdata">
 &lt;content&gt;
  &lt;alternate&gt;
   &lt;classRef key="model.pLike" minOccurs="1"
@@ -3610,18 +3655,18 @@ element edition { tei_att.global.attributes, tei_macro.phraseSeq }<a href="#inde
   &lt;/sequence&gt;
  &lt;/alternate&gt;
 &lt;/content&gt;
-    <a href="#index.xml-eg-d31e10478" class="anchorlink">⚓</a></pre>
+    <a href="#index.xml-eg-d31e10653" class="anchorlink">⚓</a></pre>
                            </td>
                         </tr>
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Schema Declaration</span></td>
                            <td class="wovenodd-col2">
-                              <pre id="index.xml-eg-d31e10485" class="pre_eg">
+                              <pre id="index.xml-eg-d31e10660" class="pre_eg">
 element editionStmt
 {
    tei_att.global.attributes,
    ( tei_model.pLike+ | ( tei_edition, tei_model.respLike* ) )
-}<a href="#index.xml-eg-d31e10485" class="anchorlink">⚓</a></pre>
+}<a href="#index.xml-eg-d31e10660" class="anchorlink">⚓</a></pre>
                            </td>
                         </tr>
                      </table>
@@ -3677,7 +3722,7 @@ element editionStmt
                                  <div class="specChild"><span class="specChildModule">linking: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.seg" title="&lt;seg&gt;">seg</a></span></div>
                                  <div class="specChild"><span class="specChildModule">namesdates: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.orgName" title="&lt;orgName&gt;">orgName</a> <a class="link_odd_elementSpec" href="#TEI.persName" title="&lt;persName&gt;">persName</a> <a class="link_odd_elementSpec" href="#TEI.placeName" title="&lt;placeName&gt;">placeName</a></span></div>
                                  <div class="specChild"><span class="specChildModule">textcrit: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.app" title="&lt;app&gt;">app</a> <a class="link_odd_elementSpec" href="#TEI.listWit" title="&lt;listWit&gt;">listWit</a></span></div>
-                                 <div class="specChild"><span class="specChildModule">transcr: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.fw" title="&lt;fw&gt;">fw</a></span></div>
+                                 <div class="specChild"><span class="specChildModule">transcr: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.fw" title="&lt;fw&gt;">fw</a> <a class="link_odd_elementSpec" href="#TEI.listTranspose" title="&lt;listTranspose&gt;">listTranspose</a></span></div>
                                  <div class="specChild">character data</div>
                               </div>
                            </td>
@@ -3685,13 +3730,13 @@ element editionStmt
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Example</span></td>
                            <td class="wovenodd-col2">
-                              <div id="index.xml-egXML-d31e11014" class="pre egXML_valid">You took the car and did <span class="element">&lt;emph&gt;</span>what<span class="element">&lt;/emph&gt;</span>?!!</div>
+                              <div id="index.xml-egXML-d31e11193" class="pre egXML_valid">You took the car and did <span class="element">&lt;emph&gt;</span>what<span class="element">&lt;/emph&gt;</span>?!!</div>
                            </td>
                         </tr>
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Example</span></td>
                            <td class="wovenodd-col2">
-                              <div id="index.xml-egXML-d31e11023" class="pre egXML_valid"><span class="element">&lt;q&gt;</span>What it all comes to is this,<span class="element">&lt;/q&gt;</span> he said. 
+                              <div id="index.xml-egXML-d31e11202" class="pre egXML_valid"><span class="element">&lt;q&gt;</span>What it all comes to is this,<span class="element">&lt;/q&gt;</span> he said. 
                                  <span class="element">&lt;q&gt;</span>
                                   <span class="element">&lt;emph&gt;</span>What
                                     does Christopher Robin do in the morning nowadays?<span class="element">&lt;/emph&gt;</span>
@@ -3701,18 +3746,18 @@ element editionStmt
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Content model</span></td>
                            <td class="wovenodd-col2">
-                              <pre id="index.xml-eg-d31e11033" class="pre_eg cdata">
+                              <pre id="index.xml-eg-d31e11212" class="pre_eg cdata">
 &lt;content&gt;
  &lt;macroRef key="macro.paraContent"/&gt;
 &lt;/content&gt;
-    <a href="#index.xml-eg-d31e11033" class="anchorlink">⚓</a></pre>
+    <a href="#index.xml-eg-d31e11212" class="anchorlink">⚓</a></pre>
                            </td>
                         </tr>
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Schema Declaration</span></td>
                            <td class="wovenodd-col2">
-                              <pre id="index.xml-eg-d31e11040" class="pre_eg">
-element emph { tei_att.global.attributes, tei_macro.paraContent }<a href="#index.xml-eg-d31e11040" class="anchorlink">⚓</a></pre>
+                              <pre id="index.xml-eg-d31e11219" class="pre_eg">
+element emph { tei_att.global.attributes, tei_macro.paraContent }<a href="#index.xml-eg-d31e11219" class="anchorlink">⚓</a></pre>
                            </td>
                         </tr>
                      </table>
@@ -3762,7 +3807,7 @@ element emph { tei_att.global.attributes, tei_macro.paraContent }<a href="#index
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Example</span></td>
                            <td class="wovenodd-col2">
-                              <div id="index.xml-egXML-d31e11224" class="pre egXML_valid"><span class="element">&lt;encodingDesc&gt;</span>
+                              <div id="index.xml-egXML-d31e11403" class="pre egXML_valid"><span class="element">&lt;encodingDesc&gt;</span>
                                   <span class="element">&lt;p&gt;</span>Basic encoding, capturing lexical information only. All
                                     hyphenation, punctuation, and variant spellings normalized. No
                                     formatting or layout information preserved.<span class="element">&lt;/p&gt;</span>
@@ -3772,7 +3817,7 @@ element emph { tei_att.global.attributes, tei_macro.paraContent }<a href="#index
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Content model</span></td>
                            <td class="wovenodd-col2">
-                              <pre id="index.xml-eg-d31e11232" class="pre_eg cdata">
+                              <pre id="index.xml-eg-d31e11411" class="pre_eg cdata">
 &lt;content&gt;
  &lt;alternate minOccurs="1"
   maxOccurs="unbounded"&gt;
@@ -3780,18 +3825,18 @@ element emph { tei_att.global.attributes, tei_macro.paraContent }<a href="#index
   &lt;classRef key="model.pLike"/&gt;
  &lt;/alternate&gt;
 &lt;/content&gt;
-    <a href="#index.xml-eg-d31e11232" class="anchorlink">⚓</a></pre>
+    <a href="#index.xml-eg-d31e11411" class="anchorlink">⚓</a></pre>
                            </td>
                         </tr>
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Schema Declaration</span></td>
                            <td class="wovenodd-col2">
-                              <pre id="index.xml-eg-d31e11239" class="pre_eg">
+                              <pre id="index.xml-eg-d31e11418" class="pre_eg">
 element encodingDesc
 {
    tei_att.global.attributes,
    ( tei_model.encodingDescPart | tei_model.pLike )+
-}<a href="#index.xml-eg-d31e11239" class="anchorlink">⚓</a></pre>
+}<a href="#index.xml-eg-d31e11418" class="anchorlink">⚓</a></pre>
                            </td>
                         </tr>
                      </table>
@@ -3839,14 +3884,14 @@ element encodingDesc
                                  <div class="specChild"><span class="specChildModule">core: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.bibl" title="&lt;bibl&gt;">bibl</a> <a class="link_odd_elementSpec" href="#TEI.biblStruct" title="&lt;biblStruct&gt;">biblStruct</a> <a class="link_odd_elementSpec" href="#TEI.cb" title="&lt;cb&gt;">cb</a> <a class="link_odd_elementSpec" href="#TEI.cit" title="&lt;cit&gt;">cit</a> <a class="link_odd_elementSpec" href="#TEI.l" title="&lt;l&gt;">l</a> <a class="link_odd_elementSpec" href="#TEI.lb" title="&lt;lb&gt;">lb</a> <a class="link_odd_elementSpec" href="#TEI.lg" title="&lt;lg&gt;">lg</a> <a class="link_odd_elementSpec" href="#TEI.list" title="&lt;list&gt;">list</a> <a class="link_odd_elementSpec" href="#TEI.listBibl" title="&lt;listBibl&gt;">listBibl</a> <a class="link_odd_elementSpec" href="#TEI.note" title="&lt;note&gt;">note</a> <a class="link_odd_elementSpec" href="#TEI.p" title="&lt;p&gt;">p</a> <a class="link_odd_elementSpec" href="#TEI.pb" title="&lt;pb&gt;">pb</a> <a class="link_odd_elementSpec" href="#TEI.q" title="&lt;q&gt;">q</a> <a class="link_odd_elementSpec" href="#TEI.quote" title="&lt;quote&gt;">quote</a></span></div>
                                  <div class="specChild"><span class="specChildModule">figures: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.figure" title="&lt;figure&gt;">figure</a></span></div>
                                  <div class="specChild"><span class="specChildModule">textcrit: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.app" title="&lt;app&gt;">app</a> <a class="link_odd_elementSpec" href="#TEI.listWit" title="&lt;listWit&gt;">listWit</a></span></div>
-                                 <div class="specChild"><span class="specChildModule">transcr: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.fw" title="&lt;fw&gt;">fw</a></span></div>
+                                 <div class="specChild"><span class="specChildModule">transcr: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.fw" title="&lt;fw&gt;">fw</a> <a class="link_odd_elementSpec" href="#TEI.listTranspose" title="&lt;listTranspose&gt;">listTranspose</a></span></div>
                               </div>
                            </td>
                         </tr>
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Example</span></td>
                            <td class="wovenodd-col2">
-                              <div id="index.xml-egXML-d31e11552" class="pre egXML_valid"><span class="element">&lt;epigraph <span class="attribute">xml:lang</span>="<span class="attributevalue">la</span>"&gt;</span>
+                              <div id="index.xml-egXML-d31e11735" class="pre egXML_valid"><span class="element">&lt;epigraph <span class="attribute">xml:lang</span>="<span class="attributevalue">la</span>"&gt;</span>
                                   <span class="element">&lt;cit&gt;</span>
                                    <span class="element">&lt;bibl&gt;</span>Lucret.<span class="element">&lt;/bibl&gt;</span>
                                    <span class="element">&lt;quote&gt;</span>
@@ -3860,7 +3905,7 @@ element encodingDesc
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Content model</span></td>
                            <td class="wovenodd-col2">
-                              <pre id="index.xml-eg-d31e11565" class="pre_eg cdata">
+                              <pre id="index.xml-eg-d31e11748" class="pre_eg cdata">
 &lt;content&gt;
  &lt;alternate minOccurs="0"
   maxOccurs="unbounded"&gt;
@@ -3868,18 +3913,18 @@ element encodingDesc
   &lt;classRef key="model.global"/&gt;
  &lt;/alternate&gt;
 &lt;/content&gt;
-    <a href="#index.xml-eg-d31e11565" class="anchorlink">⚓</a></pre>
+    <a href="#index.xml-eg-d31e11748" class="anchorlink">⚓</a></pre>
                            </td>
                         </tr>
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Schema Declaration</span></td>
                            <td class="wovenodd-col2">
-                              <pre id="index.xml-eg-d31e11572" class="pre_eg">
+                              <pre id="index.xml-eg-d31e11755" class="pre_eg">
 element epigraph
 {
    tei_att.global.attributes,
    ( tei_model.common | tei_model.global )*
-}<a href="#index.xml-eg-d31e11572" class="anchorlink">⚓</a></pre>
+}<a href="#index.xml-eg-d31e11755" class="anchorlink">⚓</a></pre>
                            </td>
                         </tr>
                      </table>
@@ -3933,7 +3978,7 @@ element epigraph
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Example</span></td>
                            <td class="wovenodd-col2">
-                              <div id="index.xml-egXML-d31e11846" class="pre egXML_valid"><span class="element">&lt;figure&gt;</span>
+                              <div id="index.xml-egXML-d31e12029" class="pre egXML_valid"><span class="element">&lt;figure&gt;</span>
                                   <span class="element">&lt;graphic <span class="attribute">url</span>="<span class="attributevalue">emblem1.png</span>"/&gt;</span>
                                   <span class="element">&lt;head&gt;</span>Emblemi d'Amore<span class="element">&lt;/head&gt;</span>
                                   <span class="element">&lt;figDesc&gt;</span>A pair of naked winged cupids, each holding a
@@ -3944,18 +3989,18 @@ element epigraph
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Content model</span></td>
                            <td class="wovenodd-col2">
-                              <pre id="index.xml-eg-d31e11856" class="pre_eg cdata">
+                              <pre id="index.xml-eg-d31e12039" class="pre_eg cdata">
 &lt;content&gt;
  &lt;macroRef key="macro.limitedContent"/&gt;
 &lt;/content&gt;
-    <a href="#index.xml-eg-d31e11856" class="anchorlink">⚓</a></pre>
+    <a href="#index.xml-eg-d31e12039" class="anchorlink">⚓</a></pre>
                            </td>
                         </tr>
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Schema Declaration</span></td>
                            <td class="wovenodd-col2">
-                              <pre id="index.xml-eg-d31e11863" class="pre_eg">
-element figDesc { tei_att.global.attributes, tei_macro.limitedContent }<a href="#index.xml-eg-d31e11863" class="anchorlink">⚓</a></pre>
+                              <pre id="index.xml-eg-d31e12046" class="pre_eg">
+element figDesc { tei_att.global.attributes, tei_macro.limitedContent }<a href="#index.xml-eg-d31e12046" class="anchorlink">⚓</a></pre>
                            </td>
                         </tr>
                      </table>
@@ -4009,14 +4054,14 @@ element figDesc { tei_att.global.attributes, tei_macro.limitedContent }<a href="
                                  <div class="specChild"><span class="specChildModule">figures: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.figDesc" title="&lt;figDesc&gt;">figDesc</a> <a class="link_odd_elementSpec" href="#TEI.figure" title="&lt;figure&gt;">figure</a></span></div>
                                  <div class="specChild"><span class="specChildModule">textcrit: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.app" title="&lt;app&gt;">app</a> <a class="link_odd_elementSpec" href="#TEI.listWit" title="&lt;listWit&gt;">listWit</a></span></div>
                                  <div class="specChild"><span class="specChildModule">textstructure: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.byline" title="&lt;byline&gt;">byline</a> <a class="link_odd_elementSpec" href="#TEI.epigraph" title="&lt;epigraph&gt;">epigraph</a> <a class="link_odd_elementSpec" href="#TEI.signed" title="&lt;signed&gt;">signed</a> <a class="link_odd_elementSpec" href="#TEI.trailer" title="&lt;trailer&gt;">trailer</a></span></div>
-                                 <div class="specChild"><span class="specChildModule">transcr: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.fw" title="&lt;fw&gt;">fw</a></span></div>
+                                 <div class="specChild"><span class="specChildModule">transcr: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.fw" title="&lt;fw&gt;">fw</a> <a class="link_odd_elementSpec" href="#TEI.listTranspose" title="&lt;listTranspose&gt;">listTranspose</a></span></div>
                               </div>
                            </td>
                         </tr>
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Example</span></td>
                            <td class="wovenodd-col2">
-                              <div id="index.xml-egXML-d31e12414" class="pre egXML_valid"><span class="element">&lt;figure&gt;</span>
+                              <div id="index.xml-egXML-d31e12601" class="pre egXML_valid"><span class="element">&lt;figure&gt;</span>
                                   <span class="element">&lt;head&gt;</span>The View from the Bridge<span class="element">&lt;/head&gt;</span>
                                   <span class="element">&lt;figDesc&gt;</span>A Whistleresque view showing four or five sailing boats in the foreground, and a
                                     series of buoys strung out between them.<span class="element">&lt;/figDesc&gt;</span>
@@ -4028,7 +4073,7 @@ element figDesc { tei_att.global.attributes, tei_macro.limitedContent }<a href="
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Content model</span></td>
                            <td class="wovenodd-col2">
-                              <pre id="index.xml-eg-d31e12424" class="pre_eg cdata">
+                              <pre id="index.xml-eg-d31e12611" class="pre_eg cdata">
 &lt;content&gt;
  &lt;alternate minOccurs="0"
   maxOccurs="unbounded"&gt;
@@ -4040,13 +4085,13 @@ element figDesc { tei_att.global.attributes, tei_macro.limitedContent }<a href="
   &lt;classRef key="model.divBottom"/&gt;
  &lt;/alternate&gt;
 &lt;/content&gt;
-    <a href="#index.xml-eg-d31e12424" class="anchorlink">⚓</a></pre>
+    <a href="#index.xml-eg-d31e12611" class="anchorlink">⚓</a></pre>
                            </td>
                         </tr>
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Schema Declaration</span></td>
                            <td class="wovenodd-col2">
-                              <pre id="index.xml-eg-d31e12431" class="pre_eg">
+                              <pre id="index.xml-eg-d31e12618" class="pre_eg">
 element figure
 {
    tei_att.global.attributes,
@@ -4061,7 +4106,7 @@ element figure
     | tei_model.global
     | tei_model.divBottom
    )*
-}<a href="#index.xml-eg-d31e12431" class="anchorlink">⚓</a></pre>
+}<a href="#index.xml-eg-d31e12618" class="anchorlink">⚓</a></pre>
                            </td>
                         </tr>
                      </table>
@@ -4114,7 +4159,7 @@ element figure
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Example</span></td>
                            <td class="wovenodd-col2">
-                              <div id="index.xml-egXML-d31e12646" class="pre egXML_valid"><span class="element">&lt;fileDesc&gt;</span>
+                              <div id="index.xml-egXML-d31e12833" class="pre egXML_valid"><span class="element">&lt;fileDesc&gt;</span>
                                   <span class="element">&lt;titleStmt&gt;</span>
                                    <span class="element">&lt;title&gt;</span>The shortest possible TEI document<span class="element">&lt;/title&gt;</span>
                                   <span class="element">&lt;/titleStmt&gt;</span>
@@ -4130,7 +4175,7 @@ element figure
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Content model</span></td>
                            <td class="wovenodd-col2">
-                              <pre id="index.xml-eg-d31e12659" class="pre_eg cdata">
+                              <pre id="index.xml-eg-d31e12846" class="pre_eg cdata">
 &lt;content&gt;
  &lt;sequence&gt;
   &lt;sequence&gt;
@@ -4148,13 +4193,13 @@ element figure
    minOccurs="1" maxOccurs="unbounded"/&gt;
  &lt;/sequence&gt;
 &lt;/content&gt;
-    <a href="#index.xml-eg-d31e12659" class="anchorlink">⚓</a></pre>
+    <a href="#index.xml-eg-d31e12846" class="anchorlink">⚓</a></pre>
                            </td>
                         </tr>
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Schema Declaration</span></td>
                            <td class="wovenodd-col2">
-                              <pre id="index.xml-eg-d31e12666" class="pre_eg">
+                              <pre id="index.xml-eg-d31e12853" class="pre_eg">
 element fileDesc
 {
    tei_att.global.attributes,
@@ -4169,7 +4214,7 @@ element fileDesc
       ),
       tei_sourceDesc+
    )
-}<a href="#index.xml-eg-d31e12666" class="anchorlink">⚓</a></pre>
+}<a href="#index.xml-eg-d31e12853" class="anchorlink">⚓</a></pre>
                            </td>
                         </tr>
                      </table>
@@ -4250,7 +4295,7 @@ element fileDesc
                                  <div class="specChild"><span class="specChildModule">linking: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.seg" title="&lt;seg&gt;">seg</a></span></div>
                                  <div class="specChild"><span class="specChildModule">namesdates: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.orgName" title="&lt;orgName&gt;">orgName</a> <a class="link_odd_elementSpec" href="#TEI.persName" title="&lt;persName&gt;">persName</a> <a class="link_odd_elementSpec" href="#TEI.placeName" title="&lt;placeName&gt;">placeName</a></span></div>
                                  <div class="specChild"><span class="specChildModule">textcrit: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.app" title="&lt;app&gt;">app</a> <a class="link_odd_elementSpec" href="#TEI.listWit" title="&lt;listWit&gt;">listWit</a></span></div>
-                                 <div class="specChild"><span class="specChildModule">transcr: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.fw" title="&lt;fw&gt;">fw</a></span></div>
+                                 <div class="specChild"><span class="specChildModule">transcr: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.fw" title="&lt;fw&gt;">fw</a> <a class="link_odd_elementSpec" href="#TEI.listTranspose" title="&lt;listTranspose&gt;">listTranspose</a></span></div>
                                  <div class="specChild">character data</div>
                               </div>
                            </td>
@@ -4270,7 +4315,7 @@ element fileDesc
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Example</span></td>
                            <td class="wovenodd-col2">
-                              <div id="index.xml-egXML-d31e13202" class="pre egXML_valid">This is
+                              <div id="index.xml-egXML-d31e13393" class="pre egXML_valid">This is
                                   heathen Greek to you still? Your <span class="element">&lt;foreign <span class="attribute">xml:lang</span>="<span class="attributevalue">la</span>"&gt;</span>lapis
                                   philosophicus<span class="element">&lt;/foreign&gt;</span>?</div>
                            </td>
@@ -4278,17 +4323,17 @@ element fileDesc
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Content model</span></td>
                            <td class="wovenodd-col2">
-                              <pre id="index.xml-eg-d31e13212" class="pre_eg cdata">
+                              <pre id="index.xml-eg-d31e13403" class="pre_eg cdata">
 &lt;content&gt;
  &lt;macroRef key="macro.paraContent"/&gt;
 &lt;/content&gt;
-    <a href="#index.xml-eg-d31e13212" class="anchorlink">⚓</a></pre>
+    <a href="#index.xml-eg-d31e13403" class="anchorlink">⚓</a></pre>
                            </td>
                         </tr>
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Schema Declaration</span></td>
                            <td class="wovenodd-col2">
-                              <pre id="index.xml-eg-d31e13219" class="pre_eg">
+                              <pre id="index.xml-eg-d31e13410" class="pre_eg">
 element foreign
 {
    tei_att.global.attribute.xmlid,
@@ -4314,7 +4359,7 @@ element foreign
    tei_att.global.source.attribute.source,
    attribute xml:lang { text }?,
    tei_macro.paraContent
-}<a href="#index.xml-eg-d31e13219" class="anchorlink">⚓</a></pre>
+}<a href="#index.xml-eg-d31e13410" class="anchorlink">⚓</a></pre>
                            </td>
                         </tr>
                      </table>
@@ -4354,7 +4399,7 @@ element foreign
                                  <div class="specChild"><span class="specChildModule">figures: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.figure" title="&lt;figure&gt;">figure</a></span></div>
                                  <div class="specChild"><span class="specChildModule">textcrit: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.app" title="&lt;app&gt;">app</a></span></div>
                                  <div class="specChild"><span class="specChildModule">textstructure: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.byline" title="&lt;byline&gt;">byline</a> <a class="link_odd_elementSpec" href="#TEI.div" title="&lt;div&gt;">div</a> <a class="link_odd_elementSpec" href="#TEI.docImprint" title="&lt;docImprint&gt;">docImprint</a> <a class="link_odd_elementSpec" href="#TEI.docTitle" title="&lt;docTitle&gt;">docTitle</a> <a class="link_odd_elementSpec" href="#TEI.epigraph" title="&lt;epigraph&gt;">epigraph</a> <a class="link_odd_elementSpec" href="#TEI.signed" title="&lt;signed&gt;">signed</a> <a class="link_odd_elementSpec" href="#TEI.titlePage" title="&lt;titlePage&gt;">titlePage</a> <a class="link_odd_elementSpec" href="#TEI.titlePart" title="&lt;titlePart&gt;">titlePart</a> <a class="link_odd_elementSpec" href="#TEI.trailer" title="&lt;trailer&gt;">trailer</a></span></div>
-                                 <div class="specChild"><span class="specChildModule">transcr: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.fw" title="&lt;fw&gt;">fw</a></span></div>
+                                 <div class="specChild"><span class="specChildModule">transcr: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.fw" title="&lt;fw&gt;">fw</a> <a class="link_odd_elementSpec" href="#TEI.listTranspose" title="&lt;listTranspose&gt;">listTranspose</a></span></div>
                               </div>
                            </td>
                         </tr>
@@ -4368,7 +4413,7 @@ element foreign
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Example</span></td>
                            <td class="wovenodd-col2">
-                              <div id="index.xml-egXML-d31e13556" class="pre egXML_valid"><span class="element">&lt;front&gt;</span>
+                              <div id="index.xml-egXML-d31e13751" class="pre egXML_valid"><span class="element">&lt;front&gt;</span>
                                   <span class="element">&lt;epigraph&gt;</span>
                                    <span class="element">&lt;quote&gt;</span>Nam Sibyllam quidem Cumis ego ipse oculis meis vidi in ampulla
                                       pendere, et cum illi pueri dicerent: <span class="element">&lt;q <span class="attribute">xml:lang</span>="<span class="attributevalue">grc</span>"&gt;</span>Σίβυλλα τί
@@ -4385,7 +4430,7 @@ element foreign
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Example</span></td>
                            <td class="wovenodd-col2">
-                              <div id="index.xml-egXML-d31e13576" class="pre egXML_valid"><span class="element">&lt;front&gt;</span>
+                              <div id="index.xml-egXML-d31e13771" class="pre egXML_valid"><span class="element">&lt;front&gt;</span>
                                   <span class="element">&lt;div <span class="attribute">type</span>="<span class="attributevalue">dedication</span>"&gt;</span>
                                    <span class="element">&lt;p&gt;</span>To our three selves<span class="element">&lt;/p&gt;</span>
                                   <span class="element">&lt;/div&gt;</span>
@@ -4401,7 +4446,7 @@ element foreign
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Example</span></td>
                            <td class="wovenodd-col2">
-                              <div id="index.xml-egXML-d31e13588" class="pre egXML_valid"><span class="element">&lt;front&gt;</span>
+                              <div id="index.xml-egXML-d31e13783" class="pre egXML_valid"><span class="element">&lt;front&gt;</span>
                                   <span class="element">&lt;div <span class="attribute">type</span>="<span class="attributevalue">abstract</span>"&gt;</span>
                                    <span class="element">&lt;div&gt;</span>
                                     <span class="element">&lt;head&gt;</span> BACKGROUND:<span class="element">&lt;/head&gt;</span>
@@ -4450,7 +4495,7 @@ element foreign
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Content model</span></td>
                            <td class="wovenodd-col2">
-                              <pre id="index.xml-eg-d31e13611" class="pre_eg cdata">
+                              <pre id="index.xml-eg-d31e13806" class="pre_eg cdata">
 &lt;content&gt;
  &lt;sequence&gt;
   &lt;alternate minOccurs="0"
@@ -4492,13 +4537,13 @@ element foreign
   &lt;/sequence&gt;
  &lt;/sequence&gt;
 &lt;/content&gt;
-    <a href="#index.xml-eg-d31e13611" class="anchorlink">⚓</a></pre>
+    <a href="#index.xml-eg-d31e13806" class="anchorlink">⚓</a></pre>
                            </td>
                         </tr>
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Schema Declaration</span></td>
                            <td class="wovenodd-col2">
-                              <pre id="index.xml-eg-d31e13618" class="pre_eg">
+                              <pre id="index.xml-eg-d31e13813" class="pre_eg">
 element front
 {
    tei_att.global.attributes,
@@ -4524,7 +4569,7 @@ element front
          ( tei_model.divBottom, ( tei_model.divBottom | tei_model.global )* )?
       )?
    )
-}<a href="#index.xml-eg-d31e13618" class="anchorlink">⚓</a></pre>
+}<a href="#index.xml-eg-d31e13813" class="anchorlink">⚓</a></pre>
                            </td>
                         </tr>
                      </table>
@@ -4571,7 +4616,7 @@ element front
                                  <div class="specChild"><span class="specChildModule">figures: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.figure" title="&lt;figure&gt;">figure</a></span></div>
                                  <div class="specChild"><span class="specChildModule">namesdates: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.orgName" title="&lt;orgName&gt;">orgName</a> <a class="link_odd_elementSpec" href="#TEI.persName" title="&lt;persName&gt;">persName</a> <a class="link_odd_elementSpec" href="#TEI.placeName" title="&lt;placeName&gt;">placeName</a></span></div>
                                  <div class="specChild"><span class="specChildModule">textcrit: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.app" title="&lt;app&gt;">app</a></span></div>
-                                 <div class="specChild"><span class="specChildModule">transcr: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.fw" title="&lt;fw&gt;">fw</a></span></div>
+                                 <div class="specChild"><span class="specChildModule">transcr: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.fw" title="&lt;fw&gt;">fw</a> <a class="link_odd_elementSpec" href="#TEI.listTranspose" title="&lt;listTranspose&gt;">listTranspose</a></span></div>
                                  <div class="specChild">character data</div>
                               </div>
                            </td>
@@ -4585,7 +4630,7 @@ element front
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Example</span></td>
                            <td class="wovenodd-col2">
-                              <div id="index.xml-egXML-d31e14051" class="pre egXML_valid"><span class="element">&lt;funder&gt;</span>The National Endowment for the Humanities, an independent federal agency<span class="element">&lt;/funder&gt;</span>
+                              <div id="index.xml-egXML-d31e14250" class="pre egXML_valid"><span class="element">&lt;funder&gt;</span>The National Endowment for the Humanities, an independent federal agency<span class="element">&lt;/funder&gt;</span>
                                  <span class="element">&lt;funder&gt;</span>Directorate General XIII of the Commission of the European Communities<span class="element">&lt;/funder&gt;</span>
                                  <span class="element">&lt;funder&gt;</span>The Andrew W. Mellon Foundation<span class="element">&lt;/funder&gt;</span>
                                  <span class="element">&lt;funder&gt;</span>The Social Sciences and Humanities Research Council of Canada<span class="element">&lt;/funder&gt;</span></div>
@@ -4594,24 +4639,24 @@ element front
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Content model</span></td>
                            <td class="wovenodd-col2">
-                              <pre id="index.xml-eg-d31e14061" class="pre_eg cdata">
+                              <pre id="index.xml-eg-d31e14260" class="pre_eg cdata">
 &lt;content&gt;
  &lt;macroRef key="macro.phraseSeq.limited"/&gt;
 &lt;/content&gt;
-    <a href="#index.xml-eg-d31e14061" class="anchorlink">⚓</a></pre>
+    <a href="#index.xml-eg-d31e14260" class="anchorlink">⚓</a></pre>
                            </td>
                         </tr>
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Schema Declaration</span></td>
                            <td class="wovenodd-col2">
-                              <pre id="index.xml-eg-d31e14068" class="pre_eg">
+                              <pre id="index.xml-eg-d31e14267" class="pre_eg">
 element funder
 {
    tei_att.global.attributes,
    tei_att.canonical.attributes,
    tei_att.datable.attributes,
    tei_macro.phraseSeq.limited
-}<a href="#index.xml-eg-d31e14068" class="anchorlink">⚓</a></pre>
+}<a href="#index.xml-eg-d31e14267" class="anchorlink">⚓</a></pre>
                            </td>
                         </tr>
                      </table>
@@ -4716,7 +4761,7 @@ element funder
                                  <div class="specChild"><span class="specChildModule">linking: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.seg" title="&lt;seg&gt;">seg</a></span></div>
                                  <div class="specChild"><span class="specChildModule">namesdates: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.orgName" title="&lt;orgName&gt;">orgName</a> <a class="link_odd_elementSpec" href="#TEI.persName" title="&lt;persName&gt;">persName</a> <a class="link_odd_elementSpec" href="#TEI.placeName" title="&lt;placeName&gt;">placeName</a></span></div>
                                  <div class="specChild"><span class="specChildModule">textcrit: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.app" title="&lt;app&gt;">app</a></span></div>
-                                 <div class="specChild"><span class="specChildModule">transcr: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.fw" title="&lt;fw&gt;">fw</a></span></div>
+                                 <div class="specChild"><span class="specChildModule">transcr: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.fw" title="&lt;fw&gt;">fw</a> <a class="link_odd_elementSpec" href="#TEI.listTranspose" title="&lt;listTranspose&gt;">listTranspose</a></span></div>
                                  <div class="specChild">character data</div>
                               </div>
                            </td>
@@ -4733,23 +4778,23 @@ element funder
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Example</span></td>
                            <td class="wovenodd-col2">
-                              <div id="index.xml-egXML-d31e14761" class="pre egXML_valid"><span class="element">&lt;fw <span class="attribute">type</span>="<span class="attributevalue">sig</span>" <span class="attribute">place</span>="<span class="attributevalue">bottom</span>"&gt;</span>C3<span class="element">&lt;/fw&gt;</span></div>
+                              <div id="index.xml-egXML-d31e14964" class="pre egXML_valid"><span class="element">&lt;fw <span class="attribute">type</span>="<span class="attributevalue">sig</span>" <span class="attribute">place</span>="<span class="attributevalue">bottom</span>"&gt;</span>C3<span class="element">&lt;/fw&gt;</span></div>
                            </td>
                         </tr>
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Content model</span></td>
                            <td class="wovenodd-col2">
-                              <pre id="index.xml-eg-d31e14769" class="pre_eg cdata">
+                              <pre id="index.xml-eg-d31e14972" class="pre_eg cdata">
 &lt;content&gt;
  &lt;macroRef key="macro.phraseSeq"/&gt;
 &lt;/content&gt;
-    <a href="#index.xml-eg-d31e14769" class="anchorlink">⚓</a></pre>
+    <a href="#index.xml-eg-d31e14972" class="anchorlink">⚓</a></pre>
                            </td>
                         </tr>
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Schema Declaration</span></td>
                            <td class="wovenodd-col2">
-                              <pre id="index.xml-eg-d31e14776" class="pre_eg">
+                              <pre id="index.xml-eg-d31e14979" class="pre_eg">
 element fw
 {
    tei_att.global.attributes,
@@ -4768,7 +4813,7 @@ element fw
     | "ornament"
    },
    tei_macro.phraseSeq
-}<a href="#index.xml-eg-d31e14776" class="anchorlink">⚓</a></pre>
+}<a href="#index.xml-eg-d31e14979" class="anchorlink">⚓</a></pre>
                            </td>
                         </tr>
                      </table>
@@ -4824,7 +4869,7 @@ element fw
                                  <div class="specChild"><span class="specChildModule">linking: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.seg" title="&lt;seg&gt;">seg</a></span></div>
                                  <div class="specChild"><span class="specChildModule">namesdates: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.orgName" title="&lt;orgName&gt;">orgName</a> <a class="link_odd_elementSpec" href="#TEI.persName" title="&lt;persName&gt;">persName</a> <a class="link_odd_elementSpec" href="#TEI.placeName" title="&lt;placeName&gt;">placeName</a></span></div>
                                  <div class="specChild"><span class="specChildModule">textcrit: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.app" title="&lt;app&gt;">app</a></span></div>
-                                 <div class="specChild"><span class="specChildModule">transcr: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.fw" title="&lt;fw&gt;">fw</a></span></div>
+                                 <div class="specChild"><span class="specChildModule">transcr: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.fw" title="&lt;fw&gt;">fw</a> <a class="link_odd_elementSpec" href="#TEI.listTranspose" title="&lt;listTranspose&gt;">listTranspose</a></span></div>
                                  <div class="specChild">character data</div>
                               </div>
                            </td>
@@ -4838,7 +4883,7 @@ element fw
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Example</span></td>
                            <td class="wovenodd-col2">
-                              <div id="index.xml-egXML-d31e15336" class="pre egXML_valid">We may define <span class="element">&lt;term <span class="attribute">xml:id</span>="<span class="attributevalue">tdpv</span>" <span class="attribute">rend</span>="<span class="attributevalue">sc</span>"&gt;</span>discoursal point of view<span class="element">&lt;/term&gt;</span> as 
+                              <div id="index.xml-egXML-d31e15543" class="pre egXML_valid">We may define <span class="element">&lt;term <span class="attribute">xml:id</span>="<span class="attributevalue">tdpv</span>" <span class="attribute">rend</span>="<span class="attributevalue">sc</span>"&gt;</span>discoursal point of view<span class="element">&lt;/term&gt;</span> as 
                                  <span class="element">&lt;gloss <span class="attribute">target</span>="<span class="attributevalue">#tdpv</span>"&gt;</span>the relationship, expressed
                                   through discourse structure, between the implied author or some other addresser, and
                                  the
@@ -4848,17 +4893,17 @@ element fw
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Content model</span></td>
                            <td class="wovenodd-col2">
-                              <pre id="index.xml-eg-d31e15348" class="pre_eg cdata">
+                              <pre id="index.xml-eg-d31e15555" class="pre_eg cdata">
 &lt;content&gt;
  &lt;macroRef key="macro.phraseSeq"/&gt;
 &lt;/content&gt;
-    <a href="#index.xml-eg-d31e15348" class="anchorlink">⚓</a></pre>
+    <a href="#index.xml-eg-d31e15555" class="anchorlink">⚓</a></pre>
                            </td>
                         </tr>
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Schema Declaration</span></td>
                            <td class="wovenodd-col2">
-                              <pre id="index.xml-eg-d31e15355" class="pre_eg">
+                              <pre id="index.xml-eg-d31e15562" class="pre_eg">
 element gloss
 {
    tei_att.global.attributes,
@@ -4867,7 +4912,7 @@ element gloss
    tei_att.pointing.attributes,
    tei_att.cReferencing.attributes,
    tei_macro.phraseSeq
-}<a href="#index.xml-eg-d31e15355" class="anchorlink">⚓</a></pre>
+}<a href="#index.xml-eg-d31e15562" class="anchorlink">⚓</a></pre>
                            </td>
                         </tr>
                      </table>
@@ -4930,7 +4975,7 @@ element gloss
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Example</span></td>
                            <td class="wovenodd-col2">
-                              <div id="index.xml-egXML-d31e15797" class="pre egXML_valid"><span class="element">&lt;figure&gt;</span>
+                              <div id="index.xml-egXML-d31e16004" class="pre egXML_valid"><span class="element">&lt;figure&gt;</span>
                                   <span class="element">&lt;graphic <span class="attribute">url</span>="<span class="attributevalue">fig1.png</span>"/&gt;</span>
                                   <span class="element">&lt;head&gt;</span>Figure One: The View from the Bridge<span class="element">&lt;/head&gt;</span>
                                   <span class="element">&lt;figDesc&gt;</span>A Whistleresque view showing four or five sailing boats in the foreground, and a
@@ -4941,7 +4986,7 @@ element gloss
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Example</span></td>
                            <td class="wovenodd-col2">
-                              <div id="index.xml-egXML-d31e15807" class="pre egXML_valid"><span class="element">&lt;facsimile&gt;</span>
+                              <div id="index.xml-egXML-d31e16014" class="pre egXML_valid"><span class="element">&lt;facsimile&gt;</span>
                                   <span class="element">&lt;surfaceGrp <span class="attribute">n</span>="<span class="attributevalue">leaf1</span>"&gt;</span>
                                    <span class="element">&lt;surface&gt;</span>
                                     <span class="element">&lt;graphic <span class="attribute">url</span>="<span class="attributevalue">page1.png</span>"/&gt;</span>
@@ -4957,7 +5002,7 @@ element gloss
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Example</span></td>
                            <td class="wovenodd-col2">
-                              <div id="index.xml-egXML-d31e15820" class="pre egXML_valid"><span class="element">&lt;facsimile&gt;</span>
+                              <div id="index.xml-egXML-d31e16027" class="pre egXML_valid"><span class="element">&lt;facsimile&gt;</span>
                                   <span class="element">&lt;surfaceGrp <span class="attribute">n</span>="<span class="attributevalue">leaf1</span>" <span class="attribute">xml:id</span>="<span class="attributevalue">spi001</span>"&gt;</span>
                                    <span class="element">&lt;surface <span class="attribute">xml:id</span>="<span class="attributevalue">spi001r</span>"&gt;</span>
                                     <span class="element">&lt;graphic <span class="attribute">type</span>="<span class="attributevalue">normal</span>"
@@ -5006,18 +5051,18 @@ element gloss
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Content model</span></td>
                            <td class="wovenodd-col2">
-                              <pre id="index.xml-eg-d31e15846" class="pre_eg cdata">
+                              <pre id="index.xml-eg-d31e16053" class="pre_eg cdata">
 &lt;content&gt;
  &lt;classRef key="model.descLike"
   minOccurs="0" maxOccurs="unbounded"/&gt;
 &lt;/content&gt;
-    <a href="#index.xml-eg-d31e15846" class="anchorlink">⚓</a></pre>
+    <a href="#index.xml-eg-d31e16053" class="anchorlink">⚓</a></pre>
                            </td>
                         </tr>
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Schema Declaration</span></td>
                            <td class="wovenodd-col2">
-                              <pre id="index.xml-eg-d31e15854" class="pre_eg">
+                              <pre id="index.xml-eg-d31e16061" class="pre_eg">
 element graphic
 {
    tei_att.global.attributes,
@@ -5026,7 +5071,7 @@ element graphic
    tei_att.declaring.attributes,
    tei_att.typed.attributes,
    tei_model.descLike*
-}<a href="#index.xml-eg-d31e15854" class="anchorlink">⚓</a></pre>
+}<a href="#index.xml-eg-d31e16061" class="anchorlink">⚓</a></pre>
                            </td>
                         </tr>
                      </table>
@@ -5077,7 +5122,7 @@ element graphic
                                  <div class="specChild"><span class="specChildModule">linking: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.seg" title="&lt;seg&gt;">seg</a></span></div>
                                  <div class="specChild"><span class="specChildModule">namesdates: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.orgName" title="&lt;orgName&gt;">orgName</a> <a class="link_odd_elementSpec" href="#TEI.persName" title="&lt;persName&gt;">persName</a> <a class="link_odd_elementSpec" href="#TEI.placeName" title="&lt;placeName&gt;">placeName</a></span></div>
                                  <div class="specChild"><span class="specChildModule">textcrit: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.app" title="&lt;app&gt;">app</a> <a class="link_odd_elementSpec" href="#TEI.listWit" title="&lt;listWit&gt;">listWit</a></span></div>
-                                 <div class="specChild"><span class="specChildModule">transcr: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.fw" title="&lt;fw&gt;">fw</a></span></div>
+                                 <div class="specChild"><span class="specChildModule">transcr: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.fw" title="&lt;fw&gt;">fw</a> <a class="link_odd_elementSpec" href="#TEI.listTranspose" title="&lt;listTranspose&gt;">listTranspose</a></span></div>
                                  <div class="specChild">character data</div>
                               </div>
                            </td>
@@ -5095,7 +5140,7 @@ element graphic
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Example</span></td>
                            <td class="wovenodd-col2">The most common use for the <a class="link_ref" href="#TEI.head" title="&lt;head&gt;">&lt;head&gt;</a> element is to mark the headings of sections. In older writings, the headings or <span class="term">incipits</span> may be rather longer than usual in modern works. If a section has an explicit ending
                               as well as a heading, it should be marked as a <a class="link_ref" href="#TEI.trailer" title="&lt;trailer&gt;">&lt;trailer&gt;</a>, as in this example:
-                              <div id="index.xml-egXML-d31e16295" class="pre egXML_valid"><span class="element">&lt;div1 <span class="attribute">n</span>="<span class="attributevalue">I</span>" <span class="attribute">type</span>="<span class="attributevalue">book</span>"&gt;</span>
+                              <div id="index.xml-egXML-d31e16506" class="pre egXML_valid"><span class="element">&lt;div1 <span class="attribute">n</span>="<span class="attributevalue">I</span>" <span class="attribute">type</span>="<span class="attributevalue">book</span>"&gt;</span>
                                   <span class="element">&lt;head&gt;</span>In the name of Christ here begins the first book of the ecclesiastical history of
                                     Georgius Florentinus, known as Gregory, Bishop of Tours.<span class="element">&lt;/head&gt;</span>
                                   <span class="element">&lt;div2 <span class="attribute">type</span>="<span class="attributevalue">section</span>"&gt;</span>
@@ -5113,7 +5158,7 @@ element graphic
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Example</span></td>
                            <td class="wovenodd-col2">When headings are not inline with the running text (see e.g. <a class="link_ref" href="http://diglib.hab.de/show_image.php?dir=drucke/ed000364&amp;pointer=34">the heading "Secunda conclusio"</a>) they might however be encoded as if. The actual placement in the source document
                               can be captured with the <span class="att">place</span> attribute.
-                              <div id="index.xml-egXML-d31e16315" class="pre egXML_valid"><span class="element">&lt;div <span class="attribute">type</span>="<span class="attributevalue">subsection</span>"&gt;</span>
+                              <div id="index.xml-egXML-d31e16526" class="pre egXML_valid"><span class="element">&lt;div <span class="attribute">type</span>="<span class="attributevalue">subsection</span>"&gt;</span>
                                   <span class="element">&lt;head <span class="attribute">place</span>="<span class="attributevalue">margin</span>"&gt;</span>Secunda conclusio<span class="element">&lt;/head&gt;</span>
                                   <span class="element">&lt;p&gt;</span>
                                    <span class="element">&lt;lb <span class="attribute">n</span>="<span class="attributevalue">1251</span>"/&gt;</span>
@@ -5128,7 +5173,7 @@ element graphic
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Example</span></td>
                            <td class="wovenodd-col2">The <a class="link_ref" href="#TEI.head" title="&lt;head&gt;">&lt;head&gt;</a> element is also used to mark headings of other units, such as lists:
-                              <div id="index.xml-egXML-d31e16335" class="pre egXML_valid">With a few exceptions, connectives are equally
+                              <div id="index.xml-egXML-d31e16546" class="pre egXML_valid">With a few exceptions, connectives are equally
                                   useful in all kinds of discourse: description, narration, exposition, argument. <span class="element">&lt;list <span class="attribute">rend</span>="<span class="attributevalue">bulleted</span>"&gt;</span>
                                   <span class="element">&lt;head&gt;</span>Connectives<span class="element">&lt;/head&gt;</span>
                                   <span class="element">&lt;item&gt;</span>above<span class="element">&lt;/item&gt;</span>
@@ -5145,7 +5190,7 @@ element graphic
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Content model</span></td>
                            <td class="wovenodd-col2">
-                              <pre id="index.xml-eg-d31e16351" class="pre_eg cdata">
+                              <pre id="index.xml-eg-d31e16562" class="pre_eg cdata">
 &lt;content&gt;
  &lt;alternate minOccurs="0"
   maxOccurs="unbounded"&gt;
@@ -5158,13 +5203,13 @@ element graphic
   &lt;classRef key="model.global"/&gt;
  &lt;/alternate&gt;
 &lt;/content&gt;
-    <a href="#index.xml-eg-d31e16351" class="anchorlink">⚓</a></pre>
+    <a href="#index.xml-eg-d31e16562" class="anchorlink">⚓</a></pre>
                            </td>
                         </tr>
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Schema Declaration</span></td>
                            <td class="wovenodd-col2">
-                              <pre id="index.xml-eg-d31e16359" class="pre_eg">
+                              <pre id="index.xml-eg-d31e16570" class="pre_eg">
 element head
 {
    tei_att.global.attributes,
@@ -5180,7 +5225,7 @@ element head
     | tei_model.lLike
     | tei_model.global
    )*
-}<a href="#index.xml-eg-d31e16359" class="anchorlink">⚓</a></pre>
+}<a href="#index.xml-eg-d31e16570" class="anchorlink">⚓</a></pre>
                            </td>
                         </tr>
                      </table>
@@ -5278,7 +5323,7 @@ element head
                                  <div class="specChild"><span class="specChildModule">linking: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.seg" title="&lt;seg&gt;">seg</a></span></div>
                                  <div class="specChild"><span class="specChildModule">namesdates: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.orgName" title="&lt;orgName&gt;">orgName</a> <a class="link_odd_elementSpec" href="#TEI.persName" title="&lt;persName&gt;">persName</a> <a class="link_odd_elementSpec" href="#TEI.placeName" title="&lt;placeName&gt;">placeName</a></span></div>
                                  <div class="specChild"><span class="specChildModule">textcrit: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.app" title="&lt;app&gt;">app</a> <a class="link_odd_elementSpec" href="#TEI.listWit" title="&lt;listWit&gt;">listWit</a></span></div>
-                                 <div class="specChild"><span class="specChildModule">transcr: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.fw" title="&lt;fw&gt;">fw</a></span></div>
+                                 <div class="specChild"><span class="specChildModule">transcr: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.fw" title="&lt;fw&gt;">fw</a> <a class="link_odd_elementSpec" href="#TEI.listTranspose" title="&lt;listTranspose&gt;">listTranspose</a></span></div>
                                  <div class="specChild">character data</div>
                               </div>
                            </td>
@@ -5286,7 +5331,7 @@ element head
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Example</span></td>
                            <td class="wovenodd-col2">
-                              <div id="index.xml-egXML-d31e16922" class="pre egXML_valid"><span class="element">&lt;hi <span class="attribute">rend</span>="<span class="attributevalue">gothic</span>"&gt;</span>And this Indenture further witnesseth<span class="element">&lt;/hi&gt;</span>
+                              <div id="index.xml-egXML-d31e17137" class="pre egXML_valid"><span class="element">&lt;hi <span class="attribute">rend</span>="<span class="attributevalue">gothic</span>"&gt;</span>And this Indenture further witnesseth<span class="element">&lt;/hi&gt;</span>
                                   that the said <span class="element">&lt;hi <span class="attribute">rend</span>="<span class="attributevalue">italic</span>"&gt;</span>Walter Shandy<span class="element">&lt;/hi&gt;</span>, merchant,
                                   in consideration of the said intended marriage ...</div>
                            </td>
@@ -5302,17 +5347,17 @@ element head
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Content model</span></td>
                            <td class="wovenodd-col2">
-                              <pre id="index.xml-eg-d31e16941" class="pre_eg cdata">
+                              <pre id="index.xml-eg-d31e17156" class="pre_eg cdata">
 &lt;content&gt;
  &lt;macroRef key="macro.paraContent"/&gt;
 &lt;/content&gt;
-    <a href="#index.xml-eg-d31e16941" class="anchorlink">⚓</a></pre>
+    <a href="#index.xml-eg-d31e17156" class="anchorlink">⚓</a></pre>
                            </td>
                         </tr>
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Schema Declaration</span></td>
                            <td class="wovenodd-col2">
-                              <pre id="index.xml-eg-d31e16948" class="pre_eg">
+                              <pre id="index.xml-eg-d31e17163" class="pre_eg">
 element hi
 {
    tei_att.global.attribute.xmlid,
@@ -5339,7 +5384,7 @@ element hi
    tei_att.written.attributes,
    attribute rend { list { + } }?,
    tei_macro.paraContent
-}<a href="#index.xml-eg-d31e16948" class="anchorlink">⚓</a></pre>
+}<a href="#index.xml-eg-d31e17163" class="anchorlink">⚓</a></pre>
                            </td>
                         </tr>
                      </table>
@@ -5388,7 +5433,7 @@ element hi
                                  <div class="specChild"><span class="specChildModule">linking: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.seg" title="&lt;seg&gt;">seg</a></span></div>
                                  <div class="specChild"><span class="specChildModule">namesdates: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.orgName" title="&lt;orgName&gt;">orgName</a> <a class="link_odd_elementSpec" href="#TEI.persName" title="&lt;persName&gt;">persName</a> <a class="link_odd_elementSpec" href="#TEI.placeName" title="&lt;placeName&gt;">placeName</a></span></div>
                                  <div class="specChild"><span class="specChildModule">textcrit: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.app" title="&lt;app&gt;">app</a> <a class="link_odd_elementSpec" href="#TEI.listWit" title="&lt;listWit&gt;">listWit</a></span></div>
-                                 <div class="specChild"><span class="specChildModule">transcr: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.fw" title="&lt;fw&gt;">fw</a></span></div>
+                                 <div class="specChild"><span class="specChildModule">transcr: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.fw" title="&lt;fw&gt;">fw</a> <a class="link_odd_elementSpec" href="#TEI.listTranspose" title="&lt;listTranspose&gt;">listTranspose</a></span></div>
                                  <div class="specChild">character data</div>
                               </div>
                            </td>
@@ -5396,24 +5441,24 @@ element hi
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Example</span></td>
                            <td class="wovenodd-col2">
-                              <div id="index.xml-egXML-d31e17355" class="pre egXML_valid"><span class="element">&lt;imprimatur&gt;</span>Licensed and entred acording to Order.<span class="element">&lt;/imprimatur&gt;</span></div>
+                              <div id="index.xml-egXML-d31e17574" class="pre egXML_valid"><span class="element">&lt;imprimatur&gt;</span>Licensed and entred acording to Order.<span class="element">&lt;/imprimatur&gt;</span></div>
                            </td>
                         </tr>
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Content model</span></td>
                            <td class="wovenodd-col2">
-                              <pre id="index.xml-eg-d31e17362" class="pre_eg cdata">
+                              <pre id="index.xml-eg-d31e17581" class="pre_eg cdata">
 &lt;content&gt;
  &lt;macroRef key="macro.paraContent"/&gt;
 &lt;/content&gt;
-    <a href="#index.xml-eg-d31e17362" class="anchorlink">⚓</a></pre>
+    <a href="#index.xml-eg-d31e17581" class="anchorlink">⚓</a></pre>
                            </td>
                         </tr>
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Schema Declaration</span></td>
                            <td class="wovenodd-col2">
-                              <pre id="index.xml-eg-d31e17369" class="pre_eg">
-element imprimatur { tei_att.global.attributes, tei_macro.paraContent }<a href="#index.xml-eg-d31e17369" class="anchorlink">⚓</a></pre>
+                              <pre id="index.xml-eg-d31e17588" class="pre_eg">
+element imprimatur { tei_att.global.attributes, tei_macro.paraContent }<a href="#index.xml-eg-d31e17588" class="anchorlink">⚓</a></pre>
                            </td>
                         </tr>
                      </table>
@@ -5452,14 +5497,14 @@ element imprimatur { tei_att.global.attributes, tei_macro.paraContent }<a href="
                                  <div class="specChild"><span class="specChildModule">core: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.cb" title="&lt;cb&gt;">cb</a> <a class="link_odd_elementSpec" href="#TEI.date" title="&lt;date&gt;">date</a> <a class="link_odd_elementSpec" href="#TEI.lb" title="&lt;lb&gt;">lb</a> <a class="link_odd_elementSpec" href="#TEI.note" title="&lt;note&gt;">note</a> <a class="link_odd_elementSpec" href="#TEI.pb" title="&lt;pb&gt;">pb</a> <a class="link_odd_elementSpec" href="#TEI.pubPlace" title="&lt;pubPlace&gt;">pubPlace</a> <a class="link_odd_elementSpec" href="#TEI.publisher" title="&lt;publisher&gt;">publisher</a> <a class="link_odd_elementSpec" href="#TEI.respStmt" title="&lt;respStmt&gt;">respStmt</a></span></div>
                                  <div class="specChild"><span class="specChildModule">figures: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.figure" title="&lt;figure&gt;">figure</a></span></div>
                                  <div class="specChild"><span class="specChildModule">textcrit: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.app" title="&lt;app&gt;">app</a></span></div>
-                                 <div class="specChild"><span class="specChildModule">transcr: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.fw" title="&lt;fw&gt;">fw</a></span></div>
+                                 <div class="specChild"><span class="specChildModule">transcr: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.fw" title="&lt;fw&gt;">fw</a> <a class="link_odd_elementSpec" href="#TEI.listTranspose" title="&lt;listTranspose&gt;">listTranspose</a></span></div>
                               </div>
                            </td>
                         </tr>
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Example</span></td>
                            <td class="wovenodd-col2">
-                              <div id="index.xml-egXML-d31e17579" class="pre egXML_valid"><span class="element">&lt;imprint&gt;</span>
+                              <div id="index.xml-egXML-d31e17802" class="pre egXML_valid"><span class="element">&lt;imprint&gt;</span>
                                   <span class="element">&lt;pubPlace&gt;</span>Oxford<span class="element">&lt;/pubPlace&gt;</span>
                                   <span class="element">&lt;publisher&gt;</span>Clarendon Press<span class="element">&lt;/publisher&gt;</span>
                                   <span class="element">&lt;date&gt;</span>1987<span class="element">&lt;/date&gt;</span>
@@ -5469,7 +5514,7 @@ element imprimatur { tei_att.global.attributes, tei_macro.paraContent }<a href="
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Content model</span></td>
                            <td class="wovenodd-col2">
-                              <pre id="index.xml-eg-d31e17589" class="pre_eg cdata">
+                              <pre id="index.xml-eg-d31e17812" class="pre_eg cdata">
 &lt;content&gt;
  &lt;sequence&gt;
   &lt;alternate minOccurs="0"
@@ -5490,13 +5535,13 @@ element imprimatur { tei_att.global.attributes, tei_macro.paraContent }<a href="
   &lt;/sequence&gt;
  &lt;/sequence&gt;
 &lt;/content&gt;
-    <a href="#index.xml-eg-d31e17589" class="anchorlink">⚓</a></pre>
+    <a href="#index.xml-eg-d31e17812" class="anchorlink">⚓</a></pre>
                            </td>
                         </tr>
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Schema Declaration</span></td>
                            <td class="wovenodd-col2">
-                              <pre id="index.xml-eg-d31e17596" class="pre_eg">
+                              <pre id="index.xml-eg-d31e17819" class="pre_eg">
 element imprint
 {
    tei_att.global.attributes,
@@ -5508,7 +5553,7 @@ element imprint
          tei_model.global*
       )+
    )
-}<a href="#index.xml-eg-d31e17596" class="anchorlink">⚓</a></pre>
+}<a href="#index.xml-eg-d31e17819" class="anchorlink">⚓</a></pre>
                            </td>
                         </tr>
                      </table>
@@ -5549,7 +5594,7 @@ element imprint
                                  <div class="specChild"><span class="specChildModule">linking: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.seg" title="&lt;seg&gt;">seg</a></span></div>
                                  <div class="specChild"><span class="specChildModule">namesdates: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.orgName" title="&lt;orgName&gt;">orgName</a> <a class="link_odd_elementSpec" href="#TEI.persName" title="&lt;persName&gt;">persName</a> <a class="link_odd_elementSpec" href="#TEI.placeName" title="&lt;placeName&gt;">placeName</a></span></div>
                                  <div class="specChild"><span class="specChildModule">textcrit: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.app" title="&lt;app&gt;">app</a> <a class="link_odd_elementSpec" href="#TEI.listWit" title="&lt;listWit&gt;">listWit</a></span></div>
-                                 <div class="specChild"><span class="specChildModule">transcr: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.fw" title="&lt;fw&gt;">fw</a></span></div>
+                                 <div class="specChild"><span class="specChildModule">transcr: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.fw" title="&lt;fw&gt;">fw</a> <a class="link_odd_elementSpec" href="#TEI.listTranspose" title="&lt;listTranspose&gt;">listTranspose</a></span></div>
                                  <div class="specChild">character data</div>
                               </div>
                            </td>
@@ -5567,7 +5612,7 @@ element imprint
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Example</span></td>
                            <td class="wovenodd-col2">
-                              <div id="index.xml-egXML-d31e17975" class="pre egXML_valid"><span class="element">&lt;list <span class="attribute">rend</span>="<span class="attributevalue">numbered</span>"&gt;</span>
+                              <div id="index.xml-egXML-d31e18202" class="pre egXML_valid"><span class="element">&lt;list <span class="attribute">rend</span>="<span class="attributevalue">numbered</span>"&gt;</span>
                                   <span class="element">&lt;head&gt;</span>Here begin the chapter headings of Book IV<span class="element">&lt;/head&gt;</span>
                                   <span class="element">&lt;item <span class="attribute">n</span>="<span class="attributevalue">4.1</span>"&gt;</span>The death of Queen Clotild.<span class="element">&lt;/item&gt;</span>
                                   <span class="element">&lt;item <span class="attribute">n</span>="<span class="attributevalue">4.2</span>"&gt;</span>How King Lothar wanted to appropriate one third of the Church revenues.<span class="element">&lt;/item&gt;</span>
@@ -5582,23 +5627,23 @@ element imprint
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Content model</span></td>
                            <td class="wovenodd-col2">
-                              <pre id="index.xml-eg-d31e17996" class="pre_eg cdata">
+                              <pre id="index.xml-eg-d31e18223" class="pre_eg cdata">
 &lt;content&gt;
  &lt;macroRef key="macro.specialPara"/&gt;
 &lt;/content&gt;
-    <a href="#index.xml-eg-d31e17996" class="anchorlink">⚓</a></pre>
+    <a href="#index.xml-eg-d31e18223" class="anchorlink">⚓</a></pre>
                            </td>
                         </tr>
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Schema Declaration</span></td>
                            <td class="wovenodd-col2">
-                              <pre id="index.xml-eg-d31e18003" class="pre_eg">
+                              <pre id="index.xml-eg-d31e18230" class="pre_eg">
 element item
 {
    tei_att.global.attributes,
    tei_att.sortable.attributes,
    tei_macro.specialPara
-}<a href="#index.xml-eg-d31e18003" class="anchorlink">⚓</a></pre>
+}<a href="#index.xml-eg-d31e18230" class="anchorlink">⚓</a></pre>
                            </td>
                         </tr>
                      </table>
@@ -5650,7 +5695,7 @@ element item
                                  <div class="specChild"><span class="specChildModule">linking: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.seg" title="&lt;seg&gt;">seg</a></span></div>
                                  <div class="specChild"><span class="specChildModule">namesdates: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.orgName" title="&lt;orgName&gt;">orgName</a> <a class="link_odd_elementSpec" href="#TEI.persName" title="&lt;persName&gt;">persName</a> <a class="link_odd_elementSpec" href="#TEI.placeName" title="&lt;placeName&gt;">placeName</a></span></div>
                                  <div class="specChild"><span class="specChildModule">textcrit: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.app" title="&lt;app&gt;">app</a> <a class="link_odd_elementSpec" href="#TEI.listWit" title="&lt;listWit&gt;">listWit</a></span></div>
-                                 <div class="specChild"><span class="specChildModule">transcr: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.fw" title="&lt;fw&gt;">fw</a></span></div>
+                                 <div class="specChild"><span class="specChildModule">transcr: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.fw" title="&lt;fw&gt;">fw</a> <a class="link_odd_elementSpec" href="#TEI.listTranspose" title="&lt;listTranspose&gt;">listTranspose</a></span></div>
                                  <div class="specChild">character data</div>
                               </div>
                            </td>
@@ -5658,7 +5703,7 @@ element item
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Example</span></td>
                            <td class="wovenodd-col2">
-                              <div id="index.xml-egXML-d31e18450" class="pre egXML_valid"><span class="element">&lt;l <span class="attribute">met</span>="<span class="attributevalue">x/x/x/x/x/</span>" <span class="attribute">real</span>="<span class="attributevalue">/xx/x/x/x/</span>"&gt;</span>Shall I compare thee to a summer's day?<span class="element">&lt;/l&gt;</span></div>
+                              <div id="index.xml-egXML-d31e18681" class="pre egXML_valid"><span class="element">&lt;l <span class="attribute">met</span>="<span class="attributevalue">x/x/x/x/x/</span>" <span class="attribute">real</span>="<span class="attributevalue">/xx/x/x/x/</span>"&gt;</span>Shall I compare thee to a summer's day?<span class="element">&lt;/l&gt;</span></div>
                            </td>
                         </tr>
                         <tr>
@@ -5673,7 +5718,7 @@ element item
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Content model</span></td>
                            <td class="wovenodd-col2">
-                              <pre id="index.xml-eg-d31e18465" class="pre_eg cdata">
+                              <pre id="index.xml-eg-d31e18696" class="pre_eg cdata">
 &lt;content&gt;
  &lt;alternate minOccurs="0"
   maxOccurs="unbounded"&gt;
@@ -5684,13 +5729,13 @@ element item
   &lt;classRef key="model.global"/&gt;
  &lt;/alternate&gt;
 &lt;/content&gt;
-    <a href="#index.xml-eg-d31e18465" class="anchorlink">⚓</a></pre>
+    <a href="#index.xml-eg-d31e18696" class="anchorlink">⚓</a></pre>
                            </td>
                         </tr>
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Schema Declaration</span></td>
                            <td class="wovenodd-col2">
-                              <pre id="index.xml-eg-d31e18472" class="pre_eg">
+                              <pre id="index.xml-eg-d31e18703" class="pre_eg">
 element l
 {
    tei_att.global.attributes,
@@ -5702,7 +5747,7 @@ element l
     | tei_model.inter
     | tei_model.global
    )*
-}<a href="#index.xml-eg-d31e18472" class="anchorlink">⚓</a></pre>
+}<a href="#index.xml-eg-d31e18703" class="anchorlink">⚓</a></pre>
                            </td>
                         </tr>
                      </table>
@@ -5769,7 +5814,7 @@ element l
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Example</span></td>
                            <td class="wovenodd-col2">This example shows typographical line breaks within metrical lines, where they occur
                               at different places in different editions:
-                              <div id="index.xml-egXML-d31e18979" class="pre egXML_valid"><span class="element">&lt;l&gt;</span>Of Mans First Disobedience,<span class="element">&lt;lb <span class="attribute">ed</span>="<span class="attributevalue">1674</span>"/&gt;</span> and<span class="element">&lt;lb <span class="attribute">ed</span>="<span class="attributevalue">1667</span>"/&gt;</span> the Fruit<span class="element">&lt;/l&gt;</span>
+                              <div id="index.xml-egXML-d31e19210" class="pre egXML_valid"><span class="element">&lt;l&gt;</span>Of Mans First Disobedience,<span class="element">&lt;lb <span class="attribute">ed</span>="<span class="attributevalue">1674</span>"/&gt;</span> and<span class="element">&lt;lb <span class="attribute">ed</span>="<span class="attributevalue">1667</span>"/&gt;</span> the Fruit<span class="element">&lt;/l&gt;</span>
                                  <span class="element">&lt;l&gt;</span>Of that Forbidden Tree, whose<span class="element">&lt;lb <span class="attribute">ed</span>="<span class="attributevalue">1667 1674</span>"/&gt;</span> mortal tast<span class="element">&lt;/l&gt;</span>
                                  <span class="element">&lt;l&gt;</span>Brought Death into the World,<span class="element">&lt;lb <span class="attribute">ed</span>="<span class="attributevalue">1667</span>"/&gt;</span> and all<span class="element">&lt;lb <span class="attribute">ed</span>="<span class="attributevalue">1674</span>"/&gt;</span> our woe,<span class="element">&lt;/l&gt;</span></div>
                            </td>
@@ -5779,7 +5824,7 @@ element l
                            <td class="wovenodd-col2">This example encodes typographical line breaks as a means of preserving the visual
                               appearance of a title page. The <span class="att">break</span> attribute is used to show that the line break does not (as elsewhere) mark the start
                               of a new word.
-                              <div id="index.xml-egXML-d31e19005" class="pre egXML_valid"><span class="element">&lt;titlePart&gt;</span>
+                              <div id="index.xml-egXML-d31e19236" class="pre egXML_valid"><span class="element">&lt;titlePart&gt;</span>
                                   <span class="element">&lt;lb/&gt;</span>With Additions, ne-<span class="element">&lt;lb <span class="attribute">break</span>="<span class="attributevalue">no</span>"/&gt;</span>ver before Printed.
                                  <span class="element">&lt;/titlePart&gt;</span></div>
                            </td>
@@ -5787,17 +5832,17 @@ element l
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Content model</span></td>
                            <td class="wovenodd-col2">
-                              <pre id="index.xml-eg-d31e19016" class="pre_eg cdata">
+                              <pre id="index.xml-eg-d31e19247" class="pre_eg cdata">
 &lt;content&gt;
  &lt;empty/&gt;
 &lt;/content&gt;
-    <a href="#index.xml-eg-d31e19016" class="anchorlink">⚓</a></pre>
+    <a href="#index.xml-eg-d31e19247" class="anchorlink">⚓</a></pre>
                            </td>
                         </tr>
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Schema Declaration</span></td>
                            <td class="wovenodd-col2">
-                              <pre id="index.xml-eg-d31e19023" class="pre_eg">
+                              <pre id="index.xml-eg-d31e19254" class="pre_eg">
 element lb
 {
    tei_att.global.attributes,
@@ -5806,7 +5851,7 @@ element lb
    tei_att.spanning.attributes,
    tei_att.breaking.attributes,
    empty
-}<a href="#index.xml-eg-d31e19023" class="anchorlink">⚓</a></pre>
+}<a href="#index.xml-eg-d31e19254" class="anchorlink">⚓</a></pre>
                            </td>
                         </tr>
                      </table>
@@ -5874,7 +5919,7 @@ element lb
                                  <div class="specChild"><span class="specChildModule">namesdates: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.orgName" title="&lt;orgName&gt;">orgName</a> <a class="link_odd_elementSpec" href="#TEI.persName" title="&lt;persName&gt;">persName</a> <a class="link_odd_elementSpec" href="#TEI.placeName" title="&lt;placeName&gt;">placeName</a></span></div>
                                  <div class="specChild"><span class="specChildModule">textcrit: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.app" title="&lt;app&gt;">app</a> <a class="link_odd_elementSpec" href="#TEI.listWit" title="&lt;listWit&gt;">listWit</a></span></div>
                                  <div class="specChild"><span class="specChildModule">textstructure: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.byline" title="&lt;byline&gt;">byline</a> <a class="link_odd_elementSpec" href="#TEI.div" title="&lt;div&gt;">div</a> <a class="link_odd_elementSpec" href="#TEI.docImprint" title="&lt;docImprint&gt;">docImprint</a> <a class="link_odd_elementSpec" href="#TEI.docTitle" title="&lt;docTitle&gt;">docTitle</a> <a class="link_odd_elementSpec" href="#TEI.epigraph" title="&lt;epigraph&gt;">epigraph</a> <a class="link_odd_elementSpec" href="#TEI.imprimatur" title="&lt;imprimatur&gt;">imprimatur</a> <a class="link_odd_elementSpec" href="#TEI.titlePage" title="&lt;titlePage&gt;">titlePage</a> <a class="link_odd_elementSpec" href="#TEI.titlePart" title="&lt;titlePart&gt;">titlePart</a></span></div>
-                                 <div class="specChild"><span class="specChildModule">transcr: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.fw" title="&lt;fw&gt;">fw</a></span></div>
+                                 <div class="specChild"><span class="specChildModule">transcr: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.fw" title="&lt;fw&gt;">fw</a> <a class="link_odd_elementSpec" href="#TEI.listTranspose" title="&lt;listTranspose&gt;">listTranspose</a></span></div>
                                  <div class="specChild">character data</div>
                               </div>
                            </td>
@@ -5892,7 +5937,7 @@ element lb
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Example</span></td>
                            <td class="wovenodd-col2">
-                              <div id="index.xml-egXML-d31e19473" class="pre egXML_valid"><span class="element">&lt;app&gt;</span>
+                              <div id="index.xml-egXML-d31e19708" class="pre egXML_valid"><span class="element">&lt;app&gt;</span>
                                   <span class="element">&lt;lem <span class="attribute">wit</span>="<span class="attributevalue">#El #Hg</span>"&gt;</span>Experience<span class="element">&lt;/lem&gt;</span>
                                   <span class="element">&lt;rdg <span class="attribute">wit</span>="<span class="attributevalue">#La</span>" <span class="attribute">type</span>="<span class="attributevalue">substantive</span>"&gt;</span>Experiment<span class="element">&lt;/rdg&gt;</span>
                                   <span class="element">&lt;rdg <span class="attribute">wit</span>="<span class="attributevalue">#Ra2</span>" <span class="attribute">type</span>="<span class="attributevalue">substantive</span>"&gt;</span>Eryment<span class="element">&lt;/rdg&gt;</span>
@@ -5902,7 +5947,7 @@ element lb
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Content model</span></td>
                            <td class="wovenodd-col2">
-                              <pre id="index.xml-eg-d31e19486" class="pre_eg cdata">
+                              <pre id="index.xml-eg-d31e19721" class="pre_eg cdata">
 &lt;content&gt;
  &lt;alternate minOccurs="0"
   maxOccurs="unbounded"&gt;
@@ -5931,13 +5976,13 @@ element lb
   &lt;classRef key="model.rdgPart"/&gt;
  &lt;/alternate&gt;
 &lt;/content&gt;
-    <a href="#index.xml-eg-d31e19486" class="anchorlink">⚓</a></pre>
+    <a href="#index.xml-eg-d31e19721" class="anchorlink">⚓</a></pre>
                            </td>
                         </tr>
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Schema Declaration</span></td>
                            <td class="wovenodd-col2">
-                              <pre id="index.xml-eg-d31e19493" class="pre_eg">
+                              <pre id="index.xml-eg-d31e19728" class="pre_eg">
 element lem
 {
    tei_att.global.attributes,
@@ -5968,7 +6013,7 @@ element lem
     | tei_model.global
     | tei_model.rdgPart
    )*
-}<a href="#index.xml-eg-d31e19493" class="anchorlink">⚓</a></pre>
+}<a href="#index.xml-eg-d31e19728" class="anchorlink">⚓</a></pre>
                            </td>
                         </tr>
                      </table>
@@ -6019,7 +6064,7 @@ element lem
                                  <div class="specChild"><span class="specChildModule">figures: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.figure" title="&lt;figure&gt;">figure</a></span></div>
                                  <div class="specChild"><span class="specChildModule">textcrit: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.app" title="&lt;app&gt;">app</a></span></div>
                                  <div class="specChild"><span class="specChildModule">textstructure: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.byline" title="&lt;byline&gt;">byline</a> <a class="link_odd_elementSpec" href="#TEI.epigraph" title="&lt;epigraph&gt;">epigraph</a> <a class="link_odd_elementSpec" href="#TEI.signed" title="&lt;signed&gt;">signed</a> <a class="link_odd_elementSpec" href="#TEI.trailer" title="&lt;trailer&gt;">trailer</a></span></div>
-                                 <div class="specChild"><span class="specChildModule">transcr: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.fw" title="&lt;fw&gt;">fw</a></span></div>
+                                 <div class="specChild"><span class="specChildModule">transcr: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.fw" title="&lt;fw&gt;">fw</a> <a class="link_odd_elementSpec" href="#TEI.listTranspose" title="&lt;listTranspose&gt;">listTranspose</a></span></div>
                               </div>
                            </td>
                         </tr>
@@ -6032,7 +6077,7 @@ element lem
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Example</span></td>
                            <td class="wovenodd-col2">
-                              <div id="index.xml-egXML-d31e19967" class="pre egXML_valid"><span class="element">&lt;lg <span class="attribute">type</span>="<span class="attributevalue">free</span>"&gt;</span>
+                              <div id="index.xml-egXML-d31e20206" class="pre egXML_valid"><span class="element">&lt;lg <span class="attribute">type</span>="<span class="attributevalue">free</span>"&gt;</span>
                                   <span class="element">&lt;l&gt;</span>Let me be my own fool<span class="element">&lt;/l&gt;</span>
                                   <span class="element">&lt;l&gt;</span>of my own making, the sum of it<span class="element">&lt;/l&gt;</span>
                                  <span class="element">&lt;/lg&gt;</span>
@@ -6068,7 +6113,7 @@ element lem
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Content model</span></td>
                            <td class="wovenodd-col2">
-                              <pre id="index.xml-eg-d31e19996" class="pre_eg cdata">
+                              <pre id="index.xml-eg-d31e20235" class="pre_eg cdata">
 &lt;content&gt;
  &lt;sequence&gt;
   &lt;alternate minOccurs="0"
@@ -6098,13 +6143,13 @@ element lem
   &lt;/sequence&gt;
  &lt;/sequence&gt;
 &lt;/content&gt;
-    <a href="#index.xml-eg-d31e19996" class="anchorlink">⚓</a></pre>
+    <a href="#index.xml-eg-d31e20235" class="anchorlink">⚓</a></pre>
                            </td>
                         </tr>
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Schema Declaration</span></td>
                            <td class="wovenodd-col2">
-                              <pre id="index.xml-eg-d31e20004" class="pre_eg">
+                              <pre id="index.xml-eg-d31e20243" class="pre_eg">
 element lg
 {
    tei_att.global.attributes,
@@ -6123,7 +6168,7 @@ element lg
       )*,
       ( tei_model.divBottom, tei_model.global* )*
    )
-}<a href="#index.xml-eg-d31e20004" class="anchorlink">⚓</a></pre>
+}<a href="#index.xml-eg-d31e20243" class="anchorlink">⚓</a></pre>
                            </td>
                         </tr>
                      </table>
@@ -6170,7 +6215,7 @@ element lg
                                  <div class="specChild"><span class="specChildModule">linking: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.seg" title="&lt;seg&gt;">seg</a></span></div>
                                  <div class="specChild"><span class="specChildModule">namesdates: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.orgName" title="&lt;orgName&gt;">orgName</a> <a class="link_odd_elementSpec" href="#TEI.persName" title="&lt;persName&gt;">persName</a> <a class="link_odd_elementSpec" href="#TEI.placeName" title="&lt;placeName&gt;">placeName</a></span></div>
                                  <div class="specChild"><span class="specChildModule">textcrit: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.app" title="&lt;app&gt;">app</a> <a class="link_odd_elementSpec" href="#TEI.listWit" title="&lt;listWit&gt;">listWit</a></span></div>
-                                 <div class="specChild"><span class="specChildModule">transcr: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.fw" title="&lt;fw&gt;">fw</a></span></div>
+                                 <div class="specChild"><span class="specChildModule">transcr: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.fw" title="&lt;fw&gt;">fw</a> <a class="link_odd_elementSpec" href="#TEI.listTranspose" title="&lt;listTranspose&gt;">listTranspose</a></span></div>
                                  <div class="specChild">character data</div>
                               </div>
                            </td>
@@ -6186,14 +6231,14 @@ element lg
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Example</span></td>
                            <td class="wovenodd-col2">
-                              <div id="index.xml-egXML-d31e20500" class="pre egXML_valid"><span class="element">&lt;licence <span class="attribute">target</span>="<span class="attributevalue">http://www.nzetc.org/tm/scholarly/tei-NZETC-Help.html#licensing</span>"&gt;</span> Licence: Creative Commons Attribution-Share Alike 3.0 New Zealand Licence
+                              <div id="index.xml-egXML-d31e20743" class="pre egXML_valid"><span class="element">&lt;licence <span class="attribute">target</span>="<span class="attributevalue">http://www.nzetc.org/tm/scholarly/tei-NZETC-Help.html#licensing</span>"&gt;</span> Licence: Creative Commons Attribution-Share Alike 3.0 New Zealand Licence
                                  <span class="element">&lt;/licence&gt;</span></div>
                            </td>
                         </tr>
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Example</span></td>
                            <td class="wovenodd-col2">
-                              <div id="index.xml-egXML-d31e20508" class="pre egXML_valid"><span class="element">&lt;availability&gt;</span>
+                              <div id="index.xml-egXML-d31e20751" class="pre egXML_valid"><span class="element">&lt;availability&gt;</span>
                                   <span class="element">&lt;licence <span class="attribute">target</span>="<span class="attributevalue">http://creativecommons.org/licenses/by/3.0/</span>"
                                       <span class="attribute">notBefore</span>="<span class="attributevalue">2013-01-01</span>"&gt;</span>
                                    <span class="element">&lt;p&gt;</span>The Creative Commons Attribution 3.0 Unported (CC BY 3.0) Licence
@@ -6206,24 +6251,24 @@ element lg
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Content model</span></td>
                            <td class="wovenodd-col2">
-                              <pre id="index.xml-eg-d31e20518" class="pre_eg cdata">
+                              <pre id="index.xml-eg-d31e20761" class="pre_eg cdata">
 &lt;content&gt;
  &lt;macroRef key="macro.specialPara"/&gt;
 &lt;/content&gt;
-    <a href="#index.xml-eg-d31e20518" class="anchorlink">⚓</a></pre>
+    <a href="#index.xml-eg-d31e20761" class="anchorlink">⚓</a></pre>
                            </td>
                         </tr>
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Schema Declaration</span></td>
                            <td class="wovenodd-col2">
-                              <pre id="index.xml-eg-d31e20525" class="pre_eg">
+                              <pre id="index.xml-eg-d31e20768" class="pre_eg">
 element licence
 {
    tei_att.global.attributes,
    tei_att.pointing.attributes,
    tei_att.datable.attributes,
    tei_macro.specialPara
-}<a href="#index.xml-eg-d31e20525" class="anchorlink">⚓</a></pre>
+}<a href="#index.xml-eg-d31e20768" class="anchorlink">⚓</a></pre>
                            </td>
                         </tr>
                      </table>
@@ -6311,7 +6356,7 @@ element licence
                                     <div class="specChild"><span class="specChildModule">core: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.emph" title="&lt;emph&gt;">emph</a> <a class="link_odd_elementSpec" href="#TEI.foreign" title="&lt;foreign&gt;">foreign</a> <a class="link_odd_elementSpec" href="#TEI.head" title="&lt;head&gt;">head</a> <a class="link_odd_elementSpec" href="#TEI.hi" title="&lt;hi&gt;">hi</a> <a class="link_odd_elementSpec" href="#TEI.item" title="&lt;item&gt;">item</a> <a class="link_odd_elementSpec" href="#TEI.l" title="&lt;l&gt;">l</a> <a class="link_odd_elementSpec" href="#TEI.note" title="&lt;note&gt;">note</a> <a class="link_odd_elementSpec" href="#TEI.p" title="&lt;p&gt;">p</a> <a class="link_odd_elementSpec" href="#TEI.q" title="&lt;q&gt;">q</a> <a class="link_odd_elementSpec" href="#TEI.quote" title="&lt;quote&gt;">quote</a> <a class="link_odd_elementSpec" href="#TEI.ref" title="&lt;ref&gt;">ref</a> <a class="link_odd_elementSpec" href="#TEI.title" title="&lt;title&gt;">title</a></span></div>
                                     <div class="specChild"><span class="specChildModule">figures: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.figDesc" title="&lt;figDesc&gt;">figDesc</a> <a class="link_odd_elementSpec" href="#TEI.figure" title="&lt;figure&gt;">figure</a></span></div>
                                     <div class="specChild"><span class="specChildModule">header: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.change" title="&lt;change&gt;">change</a> <a class="link_odd_elementSpec" href="#TEI.licence" title="&lt;licence&gt;">licence</a> <a class="link_odd_elementSpec" href="#TEI.revisionDesc" title="&lt;revisionDesc&gt;">revisionDesc</a> <a class="link_odd_elementSpec" href="#TEI.sourceDesc" title="&lt;sourceDesc&gt;">sourceDesc</a></span></div>
-                                    <div class="specChild"><span class="specChildModule">linking: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.seg" title="&lt;seg&gt;">seg</a></span></div>
+                                    <div class="specChild"><span class="specChildModule">linking: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.seg" title="&lt;seg&gt;">seg</a> <a class="link_odd_elementSpec" href="#TEI.standOff" title="&lt;standOff&gt;">standOff</a></span></div>
                                     <div class="specChild"><span class="specChildModule">textcrit: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.lem" title="&lt;lem&gt;">lem</a> <a class="link_odd_elementSpec" href="#TEI.rdg" title="&lt;rdg&gt;">rdg</a> <a class="link_odd_elementSpec" href="#TEI.witness" title="&lt;witness&gt;">witness</a></span></div>
                                     <div class="specChild"><span class="specChildModule">textstructure: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.back" title="&lt;back&gt;">back</a> <a class="link_odd_elementSpec" href="#TEI.body" title="&lt;body&gt;">body</a> <a class="link_odd_elementSpec" href="#TEI.div" title="&lt;div&gt;">div</a> <a class="link_odd_elementSpec" href="#TEI.epigraph" title="&lt;epigraph&gt;">epigraph</a> <a class="link_odd_elementSpec" href="#TEI.imprimatur" title="&lt;imprimatur&gt;">imprimatur</a> <a class="link_odd_elementSpec" href="#TEI.signed" title="&lt;signed&gt;">signed</a> <a class="link_odd_elementSpec" href="#TEI.titlePart" title="&lt;titlePart&gt;">titlePart</a> <a class="link_odd_elementSpec" href="#TEI.trailer" title="&lt;trailer&gt;">trailer</a></span></div>
                                  </div>
@@ -6326,7 +6371,7 @@ element licence
                                  <div class="specChild"><span class="specChildModule">figures: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.figure" title="&lt;figure&gt;">figure</a></span></div>
                                  <div class="specChild"><span class="specChildModule">textcrit: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.app" title="&lt;app&gt;">app</a></span></div>
                                  <div class="specChild"><span class="specChildModule">textstructure: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.byline" title="&lt;byline&gt;">byline</a> <a class="link_odd_elementSpec" href="#TEI.epigraph" title="&lt;epigraph&gt;">epigraph</a> <a class="link_odd_elementSpec" href="#TEI.signed" title="&lt;signed&gt;">signed</a> <a class="link_odd_elementSpec" href="#TEI.trailer" title="&lt;trailer&gt;">trailer</a></span></div>
-                                 <div class="specChild"><span class="specChildModule">transcr: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.fw" title="&lt;fw&gt;">fw</a></span></div>
+                                 <div class="specChild"><span class="specChildModule">transcr: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.fw" title="&lt;fw&gt;">fw</a> <a class="link_odd_elementSpec" href="#TEI.listTranspose" title="&lt;listTranspose&gt;">listTranspose</a></span></div>
                               </div>
                            </td>
                         </tr>
@@ -6340,7 +6385,7 @@ element licence
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Example</span></td>
                            <td class="wovenodd-col2">
-                              <div id="index.xml-egXML-d31e21037" class="pre egXML_valid"><span class="element">&lt;list <span class="attribute">rend</span>="<span class="attributevalue">numbered</span>"&gt;</span>
+                              <div id="index.xml-egXML-d31e21288" class="pre egXML_valid"><span class="element">&lt;list <span class="attribute">rend</span>="<span class="attributevalue">numbered</span>"&gt;</span>
                                   <span class="element">&lt;item&gt;</span>a butcher<span class="element">&lt;/item&gt;</span>
                                   <span class="element">&lt;item&gt;</span>a baker<span class="element">&lt;/item&gt;</span>
                                   <span class="element">&lt;item&gt;</span>a candlestick maker, with
@@ -6355,7 +6400,7 @@ element licence
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Example</span></td>
                            <td class="wovenodd-col2">
-                              <div id="index.xml-egXML-d31e21051" class="pre egXML_valid"><span class="element">&lt;list <span class="attribute">type</span>="<span class="attributevalue">syllogism</span>" <span class="attribute">rend</span>="<span class="attributevalue">bulleted</span>"&gt;</span>
+                              <div id="index.xml-egXML-d31e21302" class="pre egXML_valid"><span class="element">&lt;list <span class="attribute">type</span>="<span class="attributevalue">syllogism</span>" <span class="attribute">rend</span>="<span class="attributevalue">bulleted</span>"&gt;</span>
                                   <span class="element">&lt;item&gt;</span>All Cretans are liars.<span class="element">&lt;/item&gt;</span>
                                   <span class="element">&lt;item&gt;</span>Epimenides is a Cretan.<span class="element">&lt;/item&gt;</span>
                                   <span class="element">&lt;item&gt;</span>ERGO Epimenides is a liar.<span class="element">&lt;/item&gt;</span>
@@ -6365,7 +6410,7 @@ element licence
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Example</span></td>
                            <td class="wovenodd-col2">
-                              <div id="index.xml-egXML-d31e21061" class="pre egXML_valid"><span class="element">&lt;list <span class="attribute">type</span>="<span class="attributevalue">litany</span>" <span class="attribute">rend</span>="<span class="attributevalue">simple</span>"&gt;</span>
+                              <div id="index.xml-egXML-d31e21312" class="pre egXML_valid"><span class="element">&lt;list <span class="attribute">type</span>="<span class="attributevalue">litany</span>" <span class="attribute">rend</span>="<span class="attributevalue">simple</span>"&gt;</span>
                                   <span class="element">&lt;item&gt;</span>God save us from drought.<span class="element">&lt;/item&gt;</span>
                                   <span class="element">&lt;item&gt;</span>God save us from pestilence.<span class="element">&lt;/item&gt;</span>
                                   <span class="element">&lt;item&gt;</span>God save us from wickedness in high places.<span class="element">&lt;/item&gt;</span>
@@ -6377,7 +6422,7 @@ element licence
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Example</span></td>
                            <td class="wovenodd-col2">The following example treats the short numbered clauses of Anglo-Saxon legal codes
                               as lists of items. The text is from an ordinance of King Athelstan (924–939):
-                              <div id="index.xml-egXML-d31e21073" class="pre egXML_valid"><span class="element">&lt;div1 <span class="attribute">type</span>="<span class="attributevalue">section</span>"&gt;</span>
+                              <div id="index.xml-egXML-d31e21324" class="pre egXML_valid"><span class="element">&lt;div1 <span class="attribute">type</span>="<span class="attributevalue">section</span>"&gt;</span>
                                   <span class="element">&lt;head&gt;</span>Athelstan's Ordinance<span class="element">&lt;/head&gt;</span>
                                   <span class="element">&lt;list <span class="attribute">rend</span>="<span class="attributevalue">numbered</span>"&gt;</span>
                                    <span class="element">&lt;item <span class="attribute">n</span>="<span class="attributevalue">1</span>"&gt;</span>Concerning thieves. First, that no thief is to be spared who is caught with
@@ -6438,7 +6483,7 @@ element licence
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Example</span></td>
                            <td class="wovenodd-col2">
-                              <div id="index.xml-egXML-d31e21113" class="pre egXML_valid"><span class="element">&lt;p&gt;</span>These decrees, most blessed Pope Hadrian, we propounded in the public council ...
+                              <div id="index.xml-egXML-d31e21364" class="pre egXML_valid"><span class="element">&lt;p&gt;</span>These decrees, most blessed Pope Hadrian, we propounded in the public council ...
                                  and they
                                   confirmed them in our hand in your stead with the sign of the Holy Cross, and afterwards
                                   inscribed with a careful pen on the paper of this page, affixing thus the sign of
@@ -6478,7 +6523,7 @@ element licence
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Content model</span></td>
                            <td class="wovenodd-col2">
-                              <pre id="index.xml-eg-d31e21137" class="pre_eg cdata">
+                              <pre id="index.xml-eg-d31e21388" class="pre_eg cdata">
 &lt;content&gt;
  &lt;sequence&gt;
   &lt;alternate minOccurs="0"
@@ -6519,13 +6564,13 @@ element licence
   &lt;/sequence&gt;
  &lt;/sequence&gt;
 &lt;/content&gt;
-    <a href="#index.xml-eg-d31e21137" class="anchorlink">⚓</a></pre>
+    <a href="#index.xml-eg-d31e21388" class="anchorlink">⚓</a></pre>
                            </td>
                         </tr>
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Schema Declaration</span></td>
                            <td class="wovenodd-col2">
-                              <pre id="index.xml-eg-d31e21144" class="pre_eg">
+                              <pre id="index.xml-eg-d31e21395" class="pre_eg">
 element list
 {
    tei_att.global.attributes,
@@ -6547,7 +6592,7 @@ element list
       ),
       ( tei_model.divBottom, tei_model.global* )*
    )
-}<a href="#index.xml-eg-d31e21144" class="anchorlink">⚓</a></pre>
+}<a href="#index.xml-eg-d31e21395" class="anchorlink">⚓</a></pre>
                            </td>
                         </tr>
                      </table>
@@ -6582,7 +6627,7 @@ element list
                                     <div class="specChild"><span class="specChildModule">core: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.cit" title="&lt;cit&gt;">cit</a> <a class="link_odd_elementSpec" href="#TEI.emph" title="&lt;emph&gt;">emph</a> <a class="link_odd_elementSpec" href="#TEI.foreign" title="&lt;foreign&gt;">foreign</a> <a class="link_odd_elementSpec" href="#TEI.head" title="&lt;head&gt;">head</a> <a class="link_odd_elementSpec" href="#TEI.hi" title="&lt;hi&gt;">hi</a> <a class="link_odd_elementSpec" href="#TEI.item" title="&lt;item&gt;">item</a> <a class="link_odd_elementSpec" href="#TEI.l" title="&lt;l&gt;">l</a> <a class="link_odd_elementSpec" href="#TEI.listBibl" title="&lt;listBibl&gt;">listBibl</a> <a class="link_odd_elementSpec" href="#TEI.note" title="&lt;note&gt;">note</a> <a class="link_odd_elementSpec" href="#TEI.p" title="&lt;p&gt;">p</a> <a class="link_odd_elementSpec" href="#TEI.q" title="&lt;q&gt;">q</a> <a class="link_odd_elementSpec" href="#TEI.quote" title="&lt;quote&gt;">quote</a> <a class="link_odd_elementSpec" href="#TEI.ref" title="&lt;ref&gt;">ref</a> <a class="link_odd_elementSpec" href="#TEI.title" title="&lt;title&gt;">title</a></span></div>
                                     <div class="specChild"><span class="specChildModule">figures: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.figDesc" title="&lt;figDesc&gt;">figDesc</a> <a class="link_odd_elementSpec" href="#TEI.figure" title="&lt;figure&gt;">figure</a></span></div>
                                     <div class="specChild"><span class="specChildModule">header: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.change" title="&lt;change&gt;">change</a> <a class="link_odd_elementSpec" href="#TEI.licence" title="&lt;licence&gt;">licence</a> <a class="link_odd_elementSpec" href="#TEI.sourceDesc" title="&lt;sourceDesc&gt;">sourceDesc</a></span></div>
-                                    <div class="specChild"><span class="specChildModule">linking: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.seg" title="&lt;seg&gt;">seg</a></span></div>
+                                    <div class="specChild"><span class="specChildModule">linking: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.seg" title="&lt;seg&gt;">seg</a> <a class="link_odd_elementSpec" href="#TEI.standOff" title="&lt;standOff&gt;">standOff</a></span></div>
                                     <div class="specChild"><span class="specChildModule">textcrit: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.lem" title="&lt;lem&gt;">lem</a> <a class="link_odd_elementSpec" href="#TEI.rdg" title="&lt;rdg&gt;">rdg</a> <a class="link_odd_elementSpec" href="#TEI.witness" title="&lt;witness&gt;">witness</a></span></div>
                                     <div class="specChild"><span class="specChildModule">textstructure: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.back" title="&lt;back&gt;">back</a> <a class="link_odd_elementSpec" href="#TEI.body" title="&lt;body&gt;">body</a> <a class="link_odd_elementSpec" href="#TEI.div" title="&lt;div&gt;">div</a> <a class="link_odd_elementSpec" href="#TEI.epigraph" title="&lt;epigraph&gt;">epigraph</a> <a class="link_odd_elementSpec" href="#TEI.front" title="&lt;front&gt;">front</a> <a class="link_odd_elementSpec" href="#TEI.imprimatur" title="&lt;imprimatur&gt;">imprimatur</a> <a class="link_odd_elementSpec" href="#TEI.signed" title="&lt;signed&gt;">signed</a> <a class="link_odd_elementSpec" href="#TEI.titlePart" title="&lt;titlePart&gt;">titlePart</a> <a class="link_odd_elementSpec" href="#TEI.trailer" title="&lt;trailer&gt;">trailer</a></span></div>
                                  </div>
@@ -6601,7 +6646,7 @@ element list
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Example</span></td>
                            <td class="wovenodd-col2">
-                              <div id="index.xml-egXML-d31e21569" class="pre egXML_valid"><span class="element">&lt;listBibl&gt;</span>
+                              <div id="index.xml-egXML-d31e21824" class="pre egXML_valid"><span class="element">&lt;listBibl&gt;</span>
                                   <span class="element">&lt;head&gt;</span>Works consulted<span class="element">&lt;/head&gt;</span>
                                   <span class="element">&lt;bibl&gt;</span>Blain, Clements and Grundy: Feminist Companion to
                                     Literature in English (Yale, 1990)
@@ -6625,7 +6670,7 @@ element list
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Content model</span></td>
                            <td class="wovenodd-col2">
-                              <pre id="index.xml-eg-d31e21587" class="pre_eg cdata">
+                              <pre id="index.xml-eg-d31e21842" class="pre_eg cdata">
 &lt;content&gt;
  &lt;sequence&gt;
   &lt;classRef key="model.headLike"
@@ -6657,13 +6702,13 @@ element list
   &lt;/sequence&gt;
  &lt;/sequence&gt;
 &lt;/content&gt;
-    <a href="#index.xml-eg-d31e21587" class="anchorlink">⚓</a></pre>
+    <a href="#index.xml-eg-d31e21842" class="anchorlink">⚓</a></pre>
                            </td>
                         </tr>
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Schema Declaration</span></td>
                            <td class="wovenodd-col2">
-                              <pre id="index.xml-eg-d31e21594" class="pre_eg">
+                              <pre id="index.xml-eg-d31e21849" class="pre_eg">
 element listBibl
 {
    tei_att.global.attributes,
@@ -6679,7 +6724,7 @@ element listBibl
          ( tei_model.milestoneLike | relation | listRelation )*
       )+
    )
-}<a href="#index.xml-eg-d31e21594" class="anchorlink">⚓</a></pre>
+}<a href="#index.xml-eg-d31e21849" class="anchorlink">⚓</a></pre>
                            </td>
                         </tr>
                      </table>
@@ -6727,11 +6772,18 @@ element listBibl
                            </td>
                         </tr>
                         <tr>
+                           <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Member of</span></td>
+                           <td class="wovenodd-col2">
+                              <div class="parent"><a class="link_odd_classSpec" href="#TEI.model.standOffPart" title="model.standOffPart">model.standOffPart</a> </div>
+                           </td>
+                        </tr>
+                        <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Contained by</span></td>
                            <td class="wovenodd-col2">
                               <div class="parent">
                                  <div class="specChildren">
                                     <div class="specChild"><span class="specChildModule">header: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.listChange" title="&lt;listChange&gt;">listChange</a> <a class="link_odd_elementSpec" href="#TEI.revisionDesc" title="&lt;revisionDesc&gt;">revisionDesc</a></span></div>
+                                    <div class="specChild"><span class="specChildModule">linking: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.standOff" title="&lt;standOff&gt;">standOff</a></span></div>
                                  </div>
                               </div>
                            </td>
@@ -6755,7 +6807,7 @@ element listBibl
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Example</span></td>
                            <td class="wovenodd-col2">
-                              <div id="index.xml-egXML-d31e21874" class="pre egXML_valid"><span class="element">&lt;revisionDesc&gt;</span>
+                              <div id="index.xml-egXML-d31e22145" class="pre egXML_valid"><span class="element">&lt;revisionDesc&gt;</span>
                                   <span class="element">&lt;listChange&gt;</span>
                                    <span class="element">&lt;change <span class="attribute">when</span>="<span class="attributevalue">1991-11-11</span>" <span class="attribute">who</span>="<span class="attributevalue">#LB</span>"&gt;</span> deleted chapter 10 <span class="element">&lt;/change&gt;</span>
                                    <span class="element">&lt;change <span class="attribute">when</span>="<span class="attributevalue">1991-11-02</span>" <span class="attribute">who</span>="<span class="attributevalue">#MSM</span>"&gt;</span> completed first draft <span class="element">&lt;/change&gt;</span>
@@ -6766,7 +6818,7 @@ element listBibl
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Example</span></td>
                            <td class="wovenodd-col2">
-                              <div id="index.xml-egXML-d31e21886" class="pre egXML_valid"><span class="element">&lt;profileDesc&gt;</span>
+                              <div id="index.xml-egXML-d31e22157" class="pre egXML_valid"><span class="element">&lt;profileDesc&gt;</span>
                                   <span class="element">&lt;creation&gt;</span>
                                    <span class="element">&lt;listChange <span class="attribute">ordered</span>="<span class="attributevalue">true</span>"&gt;</span>
                                     <span class="element">&lt;change <span class="attribute">xml:id</span>="<span class="attributevalue">CHG-1</span>"&gt;</span>First stage, written in ink by a writer<span class="element">&lt;/change&gt;</span>
@@ -6783,7 +6835,7 @@ element listBibl
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Content model</span></td>
                            <td class="wovenodd-col2">
-                              <pre id="index.xml-eg-d31e21903" class="pre_eg cdata">
+                              <pre id="index.xml-eg-d31e22174" class="pre_eg cdata">
 &lt;content&gt;
  &lt;sequence&gt;
   &lt;elementRef key="desc" minOccurs="0"
@@ -6795,13 +6847,13 @@ element listBibl
   &lt;/alternate&gt;
  &lt;/sequence&gt;
 &lt;/content&gt;
-    <a href="#index.xml-eg-d31e21903" class="anchorlink">⚓</a></pre>
+    <a href="#index.xml-eg-d31e22174" class="anchorlink">⚓</a></pre>
                            </td>
                         </tr>
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Schema Declaration</span></td>
                            <td class="wovenodd-col2">
-                              <pre id="index.xml-eg-d31e21910" class="pre_eg">
+                              <pre id="index.xml-eg-d31e22181" class="pre_eg">
 element listChange
 {
    tei_att.global.attributes,
@@ -6809,14 +6861,130 @@ element listChange
    tei_att.typed.attributes,
    attribute ordered { text }?,
    ( desc*, ( tei_listChange | tei_change )+ )
-}<a href="#index.xml-eg-d31e21910" class="anchorlink">⚓</a></pre>
+}<a href="#index.xml-eg-d31e22181" class="anchorlink">⚓</a></pre>
+                           </td>
+                        </tr>
+                     </table>
+                  </div>
+               </div>
+               <div class="refdoc" id="TEI.listTranspose">
+                  <h3><span class="headingNumber">5.1.45. </span><span class="head">&lt;listTranspose&gt;</span></h3>
+                  <div class="table">
+                     <table class="wovenodd">
+                        <tr>
+                           <td colspan="2" class="wovenodd-col2"><span class="label">&lt;listTranspose&gt; </span><span xml:lang="en" lang="en">supplies a list of transpositions, each of which is indicated at some point in a document
+                                 typically by means of metamarks.</span> [<a class="link_ref" href="https://www.tei-c.org/release/doc/tei-p5-doc/en/html/PH.html#transpo">11.3.4.5. Transpositions</a>]</td>
+                        </tr>
+                        <tr>
+                           <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Module</span></td>
+                           <td class="wovenodd-col2">transcr</td>
+                        </tr>
+                        <tr>
+                           <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Attributes</span></td>
+                           <td class="wovenodd-col2"><a class="link_ref" href="#TEI.att.global" title="att.global">att.global</a> (<span class="attribute">@xml:id</span>, <span class="attribute">@n</span>, <span class="attribute">@xml:lang</span>, <span class="attribute">@xml:base</span>, <span class="attribute">@xml:space</span>)  (<a class="link_ref" href="#TEI.att.global.rendition" title="att.global.rendition">att.global.rendition</a> (<span class="attribute">@rend</span>, <span class="attribute">@style</span>, <span class="attribute">@rendition</span>)) (<a class="link_ref" href="#TEI.att.global.linking" title="att.global.linking">att.global.linking</a> (<span class="attribute">@corresp</span>, <span class="attribute">@synch</span>, <span class="attribute">@sameAs</span>, <span class="attribute">@copyOf</span>, <span class="attribute">@next</span>, <span class="attribute">@prev</span>, <span class="attribute">@exclude</span>, <span class="attribute">@select</span>)) (<a class="link_ref" href="#TEI.att.global.analytic" title="att.global.analytic">att.global.analytic</a> (<span class="attribute">@ana</span>)) (<a class="link_ref" href="#TEI.att.global.facs" title="att.global.facs">att.global.facs</a> (<span class="attribute">@facs</span>)) (<a class="link_ref" href="#TEI.att.global.change" title="att.global.change">att.global.change</a> (<span class="attribute">@change</span>)) (<a class="link_ref" href="#TEI.att.global.responsibility" title="att.global.responsibility">att.global.responsibility</a> (<span class="attribute">@cert</span>, <span class="attribute">@resp</span>)) (<a class="link_ref" href="#TEI.att.global.source" title="att.global.source">att.global.source</a> (<span class="attribute">@source</span>)) 
+                              <div class="table">
+                                 <table class="attList">
+                                    <tr>
+                                       <td class="odd_label">wit</td>
+                                       <td class="odd_value">(<span xml:lang="en" lang="en">witness or witnesses</span>) <span xml:lang="en" lang="en">contains a space-delimited list of one or more pointers indicating the witnesses which
+                                             attest to a given reading.</span><div class="table">
+                                             <table class="attDef">
+                                                <tr>
+                                                   <td class="odd_label"><span xml:lang="en" lang="en" class="label">Derived from</span></td>
+                                                   <td class="odd_value">att.witnessed</td>
+                                                </tr>
+                                                <tr>
+                                                   <td class="odd_label"><span xml:lang="en" lang="en" class="label">Status</span></td>
+                                                   <td class="odd_value"><span xml:lang="en" lang="en"><span class="required">Required</span></span></td>
+                                                </tr>
+                                                <tr>
+                                                   <td class="odd_label"><span xml:lang="en" lang="en" class="label">Datatype</span></td>
+                                                   <td class="odd_value">1–∞ <span xml:lang="en" lang="en">occurrences of</span> <a class="link_ref" href="#TEI.teidata.pointer" title="teidata.pointer">teidata.pointer</a> <span xml:lang="en" lang="en">separated by whitespace</span></td>
+                                                </tr>
+                                             </table>
+                                          </div>
+                                       </td>
+                                    </tr>
+                                 </table>
+                              </div>
+                           </td>
+                        </tr>
+                        <tr>
+                           <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Member of</span></td>
+                           <td class="wovenodd-col2">
+                              <div class="parent"><a class="link_odd_classSpec" href="#TEI.model.global.meta" title="model.global.meta">model.global.meta</a></div>
+                           </td>
+                        </tr>
+                        <tr>
+                           <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Contained by</span></td>
+                           <td class="wovenodd-col2">
+                              <div class="parent">
+                                 <div class="specChildren">
+                                    <div class="specChild"><span class="specChildModule">analysis: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.s" title="&lt;s&gt;">s</a> <a class="link_odd_elementSpec" href="#TEI.w" title="&lt;w&gt;">w</a></span></div>
+                                    <div class="specChild"><span class="specChildModule">core: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.abbr" title="&lt;abbr&gt;">abbr</a> <a class="link_odd_elementSpec" href="#TEI.author" title="&lt;author&gt;">author</a> <a class="link_odd_elementSpec" href="#TEI.bibl" title="&lt;bibl&gt;">bibl</a> <a class="link_odd_elementSpec" href="#TEI.cit" title="&lt;cit&gt;">cit</a> <a class="link_odd_elementSpec" href="#TEI.date" title="&lt;date&gt;">date</a> <a class="link_odd_elementSpec" href="#TEI.emph" title="&lt;emph&gt;">emph</a> <a class="link_odd_elementSpec" href="#TEI.foreign" title="&lt;foreign&gt;">foreign</a> <a class="link_odd_elementSpec" href="#TEI.gloss" title="&lt;gloss&gt;">gloss</a> <a class="link_odd_elementSpec" href="#TEI.head" title="&lt;head&gt;">head</a> <a class="link_odd_elementSpec" href="#TEI.hi" title="&lt;hi&gt;">hi</a> <a class="link_odd_elementSpec" href="#TEI.imprint" title="&lt;imprint&gt;">imprint</a> <a class="link_odd_elementSpec" href="#TEI.item" title="&lt;item&gt;">item</a> <a class="link_odd_elementSpec" href="#TEI.l" title="&lt;l&gt;">l</a> <a class="link_odd_elementSpec" href="#TEI.lg" title="&lt;lg&gt;">lg</a> <a class="link_odd_elementSpec" href="#TEI.list" title="&lt;list&gt;">list</a> <a class="link_odd_elementSpec" href="#TEI.name" title="&lt;name&gt;">name</a> <a class="link_odd_elementSpec" href="#TEI.note" title="&lt;note&gt;">note</a> <a class="link_odd_elementSpec" href="#TEI.p" title="&lt;p&gt;">p</a> <a class="link_odd_elementSpec" href="#TEI.pubPlace" title="&lt;pubPlace&gt;">pubPlace</a> <a class="link_odd_elementSpec" href="#TEI.publisher" title="&lt;publisher&gt;">publisher</a> <a class="link_odd_elementSpec" href="#TEI.q" title="&lt;q&gt;">q</a> <a class="link_odd_elementSpec" href="#TEI.quote" title="&lt;quote&gt;">quote</a> <a class="link_odd_elementSpec" href="#TEI.ref" title="&lt;ref&gt;">ref</a> <a class="link_odd_elementSpec" href="#TEI.resp" title="&lt;resp&gt;">resp</a> <a class="link_odd_elementSpec" href="#TEI.term" title="&lt;term&gt;">term</a> <a class="link_odd_elementSpec" href="#TEI.title" title="&lt;title&gt;">title</a></span></div>
+                                    <div class="specChild"><span class="specChildModule">figures: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.figure" title="&lt;figure&gt;">figure</a></span></div>
+                                    <div class="specChild"><span class="specChildModule">header: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.authority" title="&lt;authority&gt;">authority</a> <a class="link_odd_elementSpec" href="#TEI.change" title="&lt;change&gt;">change</a> <a class="link_odd_elementSpec" href="#TEI.edition" title="&lt;edition&gt;">edition</a> <a class="link_odd_elementSpec" href="#TEI.funder" title="&lt;funder&gt;">funder</a> <a class="link_odd_elementSpec" href="#TEI.licence" title="&lt;licence&gt;">licence</a> <a class="link_odd_elementSpec" href="#TEI.principal" title="&lt;principal&gt;">principal</a></span></div>
+                                    <div class="specChild"><span class="specChildModule">linking: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.seg" title="&lt;seg&gt;">seg</a> <a class="link_odd_elementSpec" href="#TEI.standOff" title="&lt;standOff&gt;">standOff</a></span></div>
+                                    <div class="specChild"><span class="specChildModule">namesdates: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.orgName" title="&lt;orgName&gt;">orgName</a> <a class="link_odd_elementSpec" href="#TEI.persName" title="&lt;persName&gt;">persName</a> <a class="link_odd_elementSpec" href="#TEI.placeName" title="&lt;placeName&gt;">placeName</a></span></div>
+                                    <div class="specChild"><span class="specChildModule">textcrit: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.lem" title="&lt;lem&gt;">lem</a> <a class="link_odd_elementSpec" href="#TEI.rdg" title="&lt;rdg&gt;">rdg</a></span></div>
+                                    <div class="specChild"><span class="specChildModule">textstructure: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.back" title="&lt;back&gt;">back</a> <a class="link_odd_elementSpec" href="#TEI.body" title="&lt;body&gt;">body</a> <a class="link_odd_elementSpec" href="#TEI.byline" title="&lt;byline&gt;">byline</a> <a class="link_odd_elementSpec" href="#TEI.div" title="&lt;div&gt;">div</a> <a class="link_odd_elementSpec" href="#TEI.docImprint" title="&lt;docImprint&gt;">docImprint</a> <a class="link_odd_elementSpec" href="#TEI.docTitle" title="&lt;docTitle&gt;">docTitle</a> <a class="link_odd_elementSpec" href="#TEI.epigraph" title="&lt;epigraph&gt;">epigraph</a> <a class="link_odd_elementSpec" href="#TEI.front" title="&lt;front&gt;">front</a> <a class="link_odd_elementSpec" href="#TEI.imprimatur" title="&lt;imprimatur&gt;">imprimatur</a> <a class="link_odd_elementSpec" href="#TEI.signed" title="&lt;signed&gt;">signed</a> <a class="link_odd_elementSpec" href="#TEI.text" title="&lt;text&gt;">text</a> <a class="link_odd_elementSpec" href="#TEI.titlePage" title="&lt;titlePage&gt;">titlePage</a> <a class="link_odd_elementSpec" href="#TEI.titlePart" title="&lt;titlePart&gt;">titlePart</a> <a class="link_odd_elementSpec" href="#TEI.trailer" title="&lt;trailer&gt;">trailer</a></span></div>
+                                    <div class="specChild"><span class="specChildModule">transcr: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.fw" title="&lt;fw&gt;">fw</a></span></div>
+                                 </div>
+                              </div>
+                           </td>
+                        </tr>
+                        <tr>
+                           <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">May contain</span></td>
+                           <td class="wovenodd-col2">
+                              <div class="specChildren">
+                                 <div class="specChild"><span class="specChildModule">transcr: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.transpose" title="&lt;transpose&gt;">transpose</a></span></div>
+                              </div>
+                           </td>
+                        </tr>
+                        <tr>
+                           <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Example</span></td>
+                           <td class="wovenodd-col2">
+                              <div id="index.xml-egXML-d31e22657" class="pre egXML_valid"><span class="element">&lt;listTranspose&gt;</span>
+                                  <span class="element">&lt;transpose&gt;</span>
+                                   <span class="element">&lt;ptr <span class="attribute">target</span>="<span class="attributevalue">#ib02</span>"/&gt;</span>
+                                   <span class="element">&lt;ptr <span class="attribute">target</span>="<span class="attributevalue">#ib01</span>"/&gt;</span>
+                                  <span class="element">&lt;/transpose&gt;</span>
+                                 <span class="element">&lt;/listTranspose&gt;</span></div>This example might be used for a source document which indicates in some way that
+                              the elements identified by <code>ib02</code> and code <code>ib01</code> should be read in that order (ib02 followed by ib01), rather than in the reading order
+                              in which they are presented in the source.</td>
+                        </tr>
+                        <tr>
+                           <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Content model</span></td>
+                           <td class="wovenodd-col2">
+                              <pre id="index.xml-eg-d31e22674" class="pre_eg cdata">
+&lt;content&gt;
+ &lt;sequence minOccurs="1" maxOccurs="1"&gt;
+  &lt;elementRef key="desc" minOccurs="0"
+   maxOccurs="unbounded"/&gt;
+  &lt;elementRef key="transpose" minOccurs="1"
+   maxOccurs="unbounded"/&gt;
+ &lt;/sequence&gt;
+&lt;/content&gt;
+    <a href="#index.xml-eg-d31e22674" class="anchorlink">⚓</a></pre>
+                           </td>
+                        </tr>
+                        <tr>
+                           <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Schema Declaration</span></td>
+                           <td class="wovenodd-col2">
+                              <pre id="index.xml-eg-d31e22681" class="pre_eg">
+element listTranspose
+{
+   tei_att.global.attributes,
+   attribute wit { list { + } },
+   ( desc*, tei_transpose+ )
+}<a href="#index.xml-eg-d31e22681" class="anchorlink">⚓</a></pre>
                            </td>
                         </tr>
                      </table>
                   </div>
                </div>
                <div class="refdoc" id="TEI.listWit">
-                  <h3><span class="headingNumber">5.1.45. </span><span class="head">&lt;listWit&gt;</span></h3>
+                  <h3><span class="headingNumber">5.1.46. </span><span class="head">&lt;listWit&gt;</span></h3>
                   <div class="table">
                      <table class="wovenodd">
                         <tr>
@@ -6845,7 +7013,7 @@ element listChange
                                     <div class="specChild"><span class="specChildModule">core: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.emph" title="&lt;emph&gt;">emph</a> <a class="link_odd_elementSpec" href="#TEI.foreign" title="&lt;foreign&gt;">foreign</a> <a class="link_odd_elementSpec" href="#TEI.head" title="&lt;head&gt;">head</a> <a class="link_odd_elementSpec" href="#TEI.hi" title="&lt;hi&gt;">hi</a> <a class="link_odd_elementSpec" href="#TEI.item" title="&lt;item&gt;">item</a> <a class="link_odd_elementSpec" href="#TEI.l" title="&lt;l&gt;">l</a> <a class="link_odd_elementSpec" href="#TEI.note" title="&lt;note&gt;">note</a> <a class="link_odd_elementSpec" href="#TEI.p" title="&lt;p&gt;">p</a> <a class="link_odd_elementSpec" href="#TEI.q" title="&lt;q&gt;">q</a> <a class="link_odd_elementSpec" href="#TEI.quote" title="&lt;quote&gt;">quote</a> <a class="link_odd_elementSpec" href="#TEI.ref" title="&lt;ref&gt;">ref</a> <a class="link_odd_elementSpec" href="#TEI.title" title="&lt;title&gt;">title</a></span></div>
                                     <div class="specChild"><span class="specChildModule">figures: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.figDesc" title="&lt;figDesc&gt;">figDesc</a> <a class="link_odd_elementSpec" href="#TEI.figure" title="&lt;figure&gt;">figure</a></span></div>
                                     <div class="specChild"><span class="specChildModule">header: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.change" title="&lt;change&gt;">change</a> <a class="link_odd_elementSpec" href="#TEI.licence" title="&lt;licence&gt;">licence</a> <a class="link_odd_elementSpec" href="#TEI.sourceDesc" title="&lt;sourceDesc&gt;">sourceDesc</a></span></div>
-                                    <div class="specChild"><span class="specChildModule">linking: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.seg" title="&lt;seg&gt;">seg</a></span></div>
+                                    <div class="specChild"><span class="specChildModule">linking: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.seg" title="&lt;seg&gt;">seg</a> <a class="link_odd_elementSpec" href="#TEI.standOff" title="&lt;standOff&gt;">standOff</a></span></div>
                                     <div class="specChild"><span class="specChildModule">textcrit: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.lem" title="&lt;lem&gt;">lem</a> <a class="link_odd_elementSpec" href="#TEI.listWit" title="&lt;listWit&gt;">listWit</a> <a class="link_odd_elementSpec" href="#TEI.rdg" title="&lt;rdg&gt;">rdg</a> <a class="link_odd_elementSpec" href="#TEI.witness" title="&lt;witness&gt;">witness</a></span></div>
                                     <div class="specChild"><span class="specChildModule">textstructure: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.back" title="&lt;back&gt;">back</a> <a class="link_odd_elementSpec" href="#TEI.body" title="&lt;body&gt;">body</a> <a class="link_odd_elementSpec" href="#TEI.div" title="&lt;div&gt;">div</a> <a class="link_odd_elementSpec" href="#TEI.epigraph" title="&lt;epigraph&gt;">epigraph</a> <a class="link_odd_elementSpec" href="#TEI.imprimatur" title="&lt;imprimatur&gt;">imprimatur</a> <a class="link_odd_elementSpec" href="#TEI.signed" title="&lt;signed&gt;">signed</a> <a class="link_odd_elementSpec" href="#TEI.titlePart" title="&lt;titlePart&gt;">titlePart</a> <a class="link_odd_elementSpec" href="#TEI.trailer" title="&lt;trailer&gt;">trailer</a></span></div>
                                  </div>
@@ -6880,7 +7048,7 @@ element listChange
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Example</span></td>
                            <td class="wovenodd-col2">
-                              <div id="index.xml-egXML-d31e22281" class="pre egXML_valid"><span class="element">&lt;listWit&gt;</span>
+                              <div id="index.xml-egXML-d31e23046" class="pre egXML_valid"><span class="element">&lt;listWit&gt;</span>
                                   <span class="element">&lt;witness <span class="attribute">xml:id</span>="<span class="attributevalue">HL26</span>"&gt;</span>Ellesmere, Huntingdon Library 26.C.9<span class="element">&lt;/witness&gt;</span>
                                   <span class="element">&lt;witness <span class="attribute">xml:id</span>="<span class="attributevalue">PN392</span>"&gt;</span>Hengwrt, National Library of Wales,
                                     Aberystwyth, Peniarth 392D<span class="element">&lt;/witness&gt;</span>
@@ -6892,7 +7060,7 @@ element listChange
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Content model</span></td>
                            <td class="wovenodd-col2">
-                              <pre id="index.xml-eg-d31e22296" class="pre_eg cdata">
+                              <pre id="index.xml-eg-d31e23061" class="pre_eg cdata">
 &lt;content&gt;
  &lt;sequence&gt;
   &lt;classRef key="model.headLike"
@@ -6906,26 +7074,26 @@ element listChange
   &lt;/alternate&gt;
  &lt;/sequence&gt;
 &lt;/content&gt;
-    <a href="#index.xml-eg-d31e22296" class="anchorlink">⚓</a></pre>
+    <a href="#index.xml-eg-d31e23061" class="anchorlink">⚓</a></pre>
                            </td>
                         </tr>
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Schema Declaration</span></td>
                            <td class="wovenodd-col2">
-                              <pre id="index.xml-eg-d31e22303" class="pre_eg">
+                              <pre id="index.xml-eg-d31e23068" class="pre_eg">
 element listWit
 {
    tei_att.global.attributes,
    tei_att.sortable.attributes,
    ( tei_model.headLike?, desc*, ( tei_witness | tei_listWit )+ )
-}<a href="#index.xml-eg-d31e22303" class="anchorlink">⚓</a></pre>
+}<a href="#index.xml-eg-d31e23068" class="anchorlink">⚓</a></pre>
                            </td>
                         </tr>
                      </table>
                   </div>
                </div>
                <div class="refdoc" id="TEI.monogr">
-                  <h3><span class="headingNumber">5.1.46. </span><span class="head">&lt;monogr&gt;</span></h3>
+                  <h3><span class="headingNumber">5.1.47. </span><span class="head">&lt;monogr&gt;</span></h3>
                   <div class="table">
                      <table class="wovenodd">
                         <tr>
@@ -6970,7 +7138,7 @@ element listWit
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Example</span></td>
                            <td class="wovenodd-col2">
-                              <div id="index.xml-egXML-d31e22538" class="pre egXML_valid"><span class="element">&lt;biblStruct&gt;</span>
+                              <div id="index.xml-egXML-d31e23303" class="pre egXML_valid"><span class="element">&lt;biblStruct&gt;</span>
                                   <span class="element">&lt;analytic&gt;</span>
                                    <span class="element">&lt;author&gt;</span>Chesnutt, David<span class="element">&lt;/author&gt;</span>
                                    <span class="element">&lt;title&gt;</span>Historical Editions in the States<span class="element">&lt;/title&gt;</span>
@@ -6989,7 +7157,7 @@ element listWit
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Example</span></td>
                            <td class="wovenodd-col2">
-                              <div id="index.xml-egXML-d31e22557" class="pre egXML_valid"><span class="element">&lt;biblStruct <span class="attribute">type</span>="<span class="attributevalue">book</span>"&gt;</span>
+                              <div id="index.xml-egXML-d31e23322" class="pre egXML_valid"><span class="element">&lt;biblStruct <span class="attribute">type</span>="<span class="attributevalue">book</span>"&gt;</span>
                                   <span class="element">&lt;monogr&gt;</span>
                                    <span class="element">&lt;author&gt;</span>
                                     <span class="element">&lt;persName&gt;</span>
@@ -7015,7 +7183,7 @@ element listWit
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Content model</span></td>
                            <td class="wovenodd-col2">
-                              <pre id="index.xml-eg-d31e22580" class="pre_eg cdata">
+                              <pre id="index.xml-eg-d31e23345" class="pre_eg cdata">
 &lt;content&gt;
  &lt;sequence&gt;
   &lt;alternate minOccurs="0"&gt;
@@ -7091,13 +7259,13 @@ element listWit
   &lt;/alternate&gt;
  &lt;/sequence&gt;
 &lt;/content&gt;
-    <a href="#index.xml-eg-d31e22580" class="anchorlink">⚓</a></pre>
+    <a href="#index.xml-eg-d31e23345" class="anchorlink">⚓</a></pre>
                            </td>
                         </tr>
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Schema Declaration</span></td>
                            <td class="wovenodd-col2">
-                              <pre id="index.xml-eg-d31e22587" class="pre_eg">
+                              <pre id="index.xml-eg-d31e23352" class="pre_eg">
 element monogr
 {
    tei_att.global.attributes,
@@ -7131,14 +7299,14 @@ element monogr
       tei_imprint,
       ( tei_imprint | extent | biblScope )*
    )
-}<a href="#index.xml-eg-d31e22587" class="anchorlink">⚓</a></pre>
+}<a href="#index.xml-eg-d31e23352" class="anchorlink">⚓</a></pre>
                            </td>
                         </tr>
                      </table>
                   </div>
                </div>
                <div class="refdoc" id="TEI.name">
-                  <h3><span class="headingNumber">5.1.47. </span><span class="head">&lt;name&gt;</span></h3>
+                  <h3><span class="headingNumber">5.1.48. </span><span class="head">&lt;name&gt;</span></h3>
                   <div class="table">
                      <table class="wovenodd">
                         <tr>
@@ -7186,7 +7354,7 @@ element monogr
                                  <div class="specChild"><span class="specChildModule">linking: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.seg" title="&lt;seg&gt;">seg</a></span></div>
                                  <div class="specChild"><span class="specChildModule">namesdates: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.orgName" title="&lt;orgName&gt;">orgName</a> <a class="link_odd_elementSpec" href="#TEI.persName" title="&lt;persName&gt;">persName</a> <a class="link_odd_elementSpec" href="#TEI.placeName" title="&lt;placeName&gt;">placeName</a></span></div>
                                  <div class="specChild"><span class="specChildModule">textcrit: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.app" title="&lt;app&gt;">app</a></span></div>
-                                 <div class="specChild"><span class="specChildModule">transcr: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.fw" title="&lt;fw&gt;">fw</a></span></div>
+                                 <div class="specChild"><span class="specChildModule">transcr: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.fw" title="&lt;fw&gt;">fw</a> <a class="link_odd_elementSpec" href="#TEI.listTranspose" title="&lt;listTranspose&gt;">listTranspose</a></span></div>
                                  <div class="specChild">character data</div>
                               </div>
                            </td>
@@ -7201,7 +7369,7 @@ element monogr
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Example</span></td>
                            <td class="wovenodd-col2">
-                              <div id="index.xml-egXML-d31e23345" class="pre egXML_valid"><span class="element">&lt;name <span class="attribute">type</span>="<span class="attributevalue">person</span>"&gt;</span>Thomas Hoccleve<span class="element">&lt;/name&gt;</span>
+                              <div id="index.xml-egXML-d31e24114" class="pre egXML_valid"><span class="element">&lt;name <span class="attribute">type</span>="<span class="attributevalue">person</span>"&gt;</span>Thomas Hoccleve<span class="element">&lt;/name&gt;</span>
                                  <span class="element">&lt;name <span class="attribute">type</span>="<span class="attributevalue">place</span>"&gt;</span>Villingaholt<span class="element">&lt;/name&gt;</span>
                                  <span class="element">&lt;name <span class="attribute">type</span>="<span class="attributevalue">org</span>"&gt;</span>Vetus Latina Institut<span class="element">&lt;/name&gt;</span>
                                  <span class="element">&lt;name <span class="attribute">type</span>="<span class="attributevalue">person</span>" <span class="attribute">ref</span>="<span class="attributevalue">#HOC001</span>"&gt;</span>Occleve<span class="element">&lt;/name&gt;</span></div>
@@ -7210,17 +7378,17 @@ element monogr
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Content model</span></td>
                            <td class="wovenodd-col2">
-                              <pre id="index.xml-eg-d31e23359" class="pre_eg cdata">
+                              <pre id="index.xml-eg-d31e24128" class="pre_eg cdata">
 &lt;content&gt;
  &lt;macroRef key="macro.phraseSeq"/&gt;
 &lt;/content&gt;
-    <a href="#index.xml-eg-d31e23359" class="anchorlink">⚓</a></pre>
+    <a href="#index.xml-eg-d31e24128" class="anchorlink">⚓</a></pre>
                            </td>
                         </tr>
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Schema Declaration</span></td>
                            <td class="wovenodd-col2">
-                              <pre id="index.xml-eg-d31e23366" class="pre_eg">
+                              <pre id="index.xml-eg-d31e24135" class="pre_eg">
 element name
 {
    tei_att.global.attributes,
@@ -7229,14 +7397,14 @@ element name
    tei_att.editLike.attributes,
    tei_att.typed.attributes,
    tei_macro.phraseSeq
-}<a href="#index.xml-eg-d31e23366" class="anchorlink">⚓</a></pre>
+}<a href="#index.xml-eg-d31e24135" class="anchorlink">⚓</a></pre>
                            </td>
                         </tr>
                      </table>
                   </div>
                </div>
                <div class="refdoc" id="TEI.note">
-                  <h3><span class="headingNumber">5.1.48. </span><span class="head">&lt;note&gt;</span></h3>
+                  <h3><span class="headingNumber">5.1.49. </span><span class="head">&lt;note&gt;</span></h3>
                   <div class="table">
                      <table class="wovenodd">
                         <tr>
@@ -7387,7 +7555,7 @@ element name
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Member of</span></td>
                            <td class="wovenodd-col2">
-                              <div class="parent"><a class="link_odd_classSpec" href="#TEI.model.noteLike" title="model.noteLike">model.noteLike</a> </div>
+                              <div class="parent"><a class="link_odd_classSpec" href="#TEI.model.annotationLike" title="model.annotationLike">model.annotationLike</a> <a class="link_odd_classSpec" href="#TEI.model.noteLike" title="model.noteLike">model.noteLike</a> </div>
                            </td>
                         </tr>
                         <tr>
@@ -7399,7 +7567,7 @@ element name
                                     <div class="specChild"><span class="specChildModule">core: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.abbr" title="&lt;abbr&gt;">abbr</a> <a class="link_odd_elementSpec" href="#TEI.author" title="&lt;author&gt;">author</a> <a class="link_odd_elementSpec" href="#TEI.bibl" title="&lt;bibl&gt;">bibl</a> <a class="link_odd_elementSpec" href="#TEI.biblStruct" title="&lt;biblStruct&gt;">biblStruct</a> <a class="link_odd_elementSpec" href="#TEI.cit" title="&lt;cit&gt;">cit</a> <a class="link_odd_elementSpec" href="#TEI.date" title="&lt;date&gt;">date</a> <a class="link_odd_elementSpec" href="#TEI.emph" title="&lt;emph&gt;">emph</a> <a class="link_odd_elementSpec" href="#TEI.foreign" title="&lt;foreign&gt;">foreign</a> <a class="link_odd_elementSpec" href="#TEI.gloss" title="&lt;gloss&gt;">gloss</a> <a class="link_odd_elementSpec" href="#TEI.head" title="&lt;head&gt;">head</a> <a class="link_odd_elementSpec" href="#TEI.hi" title="&lt;hi&gt;">hi</a> <a class="link_odd_elementSpec" href="#TEI.imprint" title="&lt;imprint&gt;">imprint</a> <a class="link_odd_elementSpec" href="#TEI.item" title="&lt;item&gt;">item</a> <a class="link_odd_elementSpec" href="#TEI.l" title="&lt;l&gt;">l</a> <a class="link_odd_elementSpec" href="#TEI.lg" title="&lt;lg&gt;">lg</a> <a class="link_odd_elementSpec" href="#TEI.list" title="&lt;list&gt;">list</a> <a class="link_odd_elementSpec" href="#TEI.monogr" title="&lt;monogr&gt;">monogr</a> <a class="link_odd_elementSpec" href="#TEI.name" title="&lt;name&gt;">name</a> <a class="link_odd_elementSpec" href="#TEI.note" title="&lt;note&gt;">note</a> <a class="link_odd_elementSpec" href="#TEI.p" title="&lt;p&gt;">p</a> <a class="link_odd_elementSpec" href="#TEI.pubPlace" title="&lt;pubPlace&gt;">pubPlace</a> <a class="link_odd_elementSpec" href="#TEI.publisher" title="&lt;publisher&gt;">publisher</a> <a class="link_odd_elementSpec" href="#TEI.q" title="&lt;q&gt;">q</a> <a class="link_odd_elementSpec" href="#TEI.quote" title="&lt;quote&gt;">quote</a> <a class="link_odd_elementSpec" href="#TEI.ref" title="&lt;ref&gt;">ref</a> <a class="link_odd_elementSpec" href="#TEI.resp" title="&lt;resp&gt;">resp</a> <a class="link_odd_elementSpec" href="#TEI.respStmt" title="&lt;respStmt&gt;">respStmt</a> <a class="link_odd_elementSpec" href="#TEI.term" title="&lt;term&gt;">term</a> <a class="link_odd_elementSpec" href="#TEI.title" title="&lt;title&gt;">title</a></span></div>
                                     <div class="specChild"><span class="specChildModule">figures: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.figure" title="&lt;figure&gt;">figure</a></span></div>
                                     <div class="specChild"><span class="specChildModule">header: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.authority" title="&lt;authority&gt;">authority</a> <a class="link_odd_elementSpec" href="#TEI.change" title="&lt;change&gt;">change</a> <a class="link_odd_elementSpec" href="#TEI.edition" title="&lt;edition&gt;">edition</a> <a class="link_odd_elementSpec" href="#TEI.funder" title="&lt;funder&gt;">funder</a> <a class="link_odd_elementSpec" href="#TEI.licence" title="&lt;licence&gt;">licence</a> <a class="link_odd_elementSpec" href="#TEI.principal" title="&lt;principal&gt;">principal</a></span></div>
-                                    <div class="specChild"><span class="specChildModule">linking: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.seg" title="&lt;seg&gt;">seg</a></span></div>
+                                    <div class="specChild"><span class="specChildModule">linking: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.seg" title="&lt;seg&gt;">seg</a> <a class="link_odd_elementSpec" href="#TEI.standOff" title="&lt;standOff&gt;">standOff</a></span></div>
                                     <div class="specChild"><span class="specChildModule">namesdates: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.orgName" title="&lt;orgName&gt;">orgName</a> <a class="link_odd_elementSpec" href="#TEI.persName" title="&lt;persName&gt;">persName</a> <a class="link_odd_elementSpec" href="#TEI.placeName" title="&lt;placeName&gt;">placeName</a></span></div>
                                     <div class="specChild"><span class="specChildModule">textcrit: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.app" title="&lt;app&gt;">app</a> <a class="link_odd_elementSpec" href="#TEI.lem" title="&lt;lem&gt;">lem</a> <a class="link_odd_elementSpec" href="#TEI.rdg" title="&lt;rdg&gt;">rdg</a> <a class="link_odd_elementSpec" href="#TEI.witness" title="&lt;witness&gt;">witness</a></span></div>
                                     <div class="specChild"><span class="specChildModule">textstructure: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.back" title="&lt;back&gt;">back</a> <a class="link_odd_elementSpec" href="#TEI.body" title="&lt;body&gt;">body</a> <a class="link_odd_elementSpec" href="#TEI.byline" title="&lt;byline&gt;">byline</a> <a class="link_odd_elementSpec" href="#TEI.div" title="&lt;div&gt;">div</a> <a class="link_odd_elementSpec" href="#TEI.docImprint" title="&lt;docImprint&gt;">docImprint</a> <a class="link_odd_elementSpec" href="#TEI.docTitle" title="&lt;docTitle&gt;">docTitle</a> <a class="link_odd_elementSpec" href="#TEI.epigraph" title="&lt;epigraph&gt;">epigraph</a> <a class="link_odd_elementSpec" href="#TEI.front" title="&lt;front&gt;">front</a> <a class="link_odd_elementSpec" href="#TEI.imprimatur" title="&lt;imprimatur&gt;">imprimatur</a> <a class="link_odd_elementSpec" href="#TEI.signed" title="&lt;signed&gt;">signed</a> <a class="link_odd_elementSpec" href="#TEI.text" title="&lt;text&gt;">text</a> <a class="link_odd_elementSpec" href="#TEI.titlePage" title="&lt;titlePage&gt;">titlePage</a> <a class="link_odd_elementSpec" href="#TEI.titlePart" title="&lt;titlePart&gt;">titlePart</a> <a class="link_odd_elementSpec" href="#TEI.trailer" title="&lt;trailer&gt;">trailer</a></span></div>
@@ -7418,7 +7586,7 @@ element name
                                  <div class="specChild"><span class="specChildModule">linking: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.seg" title="&lt;seg&gt;">seg</a></span></div>
                                  <div class="specChild"><span class="specChildModule">namesdates: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.orgName" title="&lt;orgName&gt;">orgName</a> <a class="link_odd_elementSpec" href="#TEI.persName" title="&lt;persName&gt;">persName</a> <a class="link_odd_elementSpec" href="#TEI.placeName" title="&lt;placeName&gt;">placeName</a></span></div>
                                  <div class="specChild"><span class="specChildModule">textcrit: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.app" title="&lt;app&gt;">app</a> <a class="link_odd_elementSpec" href="#TEI.listWit" title="&lt;listWit&gt;">listWit</a></span></div>
-                                 <div class="specChild"><span class="specChildModule">transcr: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.fw" title="&lt;fw&gt;">fw</a></span></div>
+                                 <div class="specChild"><span class="specChildModule">transcr: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.fw" title="&lt;fw&gt;">fw</a> <a class="link_odd_elementSpec" href="#TEI.listTranspose" title="&lt;listTranspose&gt;">listTranspose</a></span></div>
                                  <div class="specChild">character data</div>
                               </div>
                            </td>
@@ -7427,7 +7595,7 @@ element name
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Example</span></td>
                            <td class="wovenodd-col2">In the following example, the translator has supplied a footnote containing an explanation
                               of the term translated as "painterly":
-                              <div id="index.xml-egXML-d31e24180" class="pre egXML_valid">And yet it is not only
+                              <div id="index.xml-egXML-d31e24961" class="pre egXML_valid">And yet it is not only
                                   in the great line of Italian renaissance art, but even in the
                                   painterly <span class="element">&lt;note <span class="attribute">place</span>="<span class="attributevalue">bottom</span>" <span class="attribute">type</span>="<span class="attributevalue">gloss</span>"
                                      <span class="attribute">resp</span>="<span class="attributevalue">#MDMH</span>"&gt;</span>
@@ -7452,7 +7620,7 @@ element name
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Example</span></td>
                            <td class="wovenodd-col2">The global <span class="att">n</span> attribute may be used to supply the symbol or number used to mark the note's point
                               of attachment in the source text, as in the following example:
-                              <div id="index.xml-egXML-d31e24208" class="pre egXML_valid">Mevorakh b. Saadya's mother, the matriarch of the
+                              <div id="index.xml-egXML-d31e24989" class="pre egXML_valid">Mevorakh b. Saadya's mother, the matriarch of the
                                   family during the second half of the eleventh century, <span class="element">&lt;note <span class="attribute">n</span>="<span class="attributevalue">126</span>" <span class="attribute">anchored</span>="<span class="attributevalue">true</span>"&gt;</span> The
                                   alleged mention of Judah Nagid's mother in a letter from 1071 is, in fact, a reference
                                  to
@@ -7473,17 +7641,17 @@ element name
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Content model</span></td>
                            <td class="wovenodd-col2">
-                              <pre id="index.xml-eg-d31e24226" class="pre_eg cdata">
+                              <pre id="index.xml-eg-d31e25007" class="pre_eg cdata">
 &lt;content&gt;
  &lt;macroRef key="macro.specialPara"/&gt;
 &lt;/content&gt;
-    <a href="#index.xml-eg-d31e24226" class="anchorlink">⚓</a></pre>
+    <a href="#index.xml-eg-d31e25007" class="anchorlink">⚓</a></pre>
                            </td>
                         </tr>
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Schema Declaration</span></td>
                            <td class="wovenodd-col2">
-                              <pre id="index.xml-eg-d31e24233" class="pre_eg">
+                              <pre id="index.xml-eg-d31e25014" class="pre_eg">
 element note
 {
    tei_att.global.attribute.n,
@@ -7518,14 +7686,14 @@ element note
       "summary" | "bibliographic" | "gloss" | "other" | "certainty"
    },
    tei_macro.specialPara
-}<a href="#index.xml-eg-d31e24233" class="anchorlink">⚓</a></pre>
+}<a href="#index.xml-eg-d31e25014" class="anchorlink">⚓</a></pre>
                            </td>
                         </tr>
                      </table>
                   </div>
                </div>
                <div class="refdoc" id="TEI.orgName">
-                  <h3><span class="headingNumber">5.1.49. </span><span class="head">&lt;orgName&gt;</span></h3>
+                  <h3><span class="headingNumber">5.1.50. </span><span class="head">&lt;orgName&gt;</span></h3>
                   <div class="table">
                      <table class="wovenodd">
                         <tr>
@@ -7573,7 +7741,7 @@ element note
                                  <div class="specChild"><span class="specChildModule">linking: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.seg" title="&lt;seg&gt;">seg</a></span></div>
                                  <div class="specChild"><span class="specChildModule">namesdates: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.orgName" title="&lt;orgName&gt;">orgName</a> <a class="link_odd_elementSpec" href="#TEI.persName" title="&lt;persName&gt;">persName</a> <a class="link_odd_elementSpec" href="#TEI.placeName" title="&lt;placeName&gt;">placeName</a></span></div>
                                  <div class="specChild"><span class="specChildModule">textcrit: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.app" title="&lt;app&gt;">app</a></span></div>
-                                 <div class="specChild"><span class="specChildModule">transcr: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.fw" title="&lt;fw&gt;">fw</a></span></div>
+                                 <div class="specChild"><span class="specChildModule">transcr: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.fw" title="&lt;fw&gt;">fw</a> <a class="link_odd_elementSpec" href="#TEI.listTranspose" title="&lt;listTranspose&gt;">listTranspose</a></span></div>
                                  <div class="specChild">character data</div>
                               </div>
                            </td>
@@ -7581,7 +7749,7 @@ element note
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Example</span></td>
                            <td class="wovenodd-col2">
-                              <div id="index.xml-egXML-d31e24933" class="pre egXML_valid">About a year back, a question of considerable interest was agitated in the <span class="element">&lt;orgName <span class="attribute">key</span>="<span class="attributevalue">PAS1</span>" <span class="attribute">type</span>="<span class="attributevalue">voluntary</span>"&gt;</span>
+                              <div id="index.xml-egXML-d31e25718" class="pre egXML_valid">About a year back, a question of considerable interest was agitated in the <span class="element">&lt;orgName <span class="attribute">key</span>="<span class="attributevalue">PAS1</span>" <span class="attribute">type</span>="<span class="attributevalue">voluntary</span>"&gt;</span>
                                   <span class="element">&lt;placeName <span class="attribute">key</span>="<span class="attributevalue">PEN</span>"&gt;</span>Pennsyla.<span class="element">&lt;/placeName&gt;</span> Abolition Society
                                  <span class="element">&lt;/orgName&gt;</span> [...]</div>
                            </td>
@@ -7589,17 +7757,17 @@ element note
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Content model</span></td>
                            <td class="wovenodd-col2">
-                              <pre id="index.xml-eg-d31e24945" class="pre_eg cdata">
+                              <pre id="index.xml-eg-d31e25730" class="pre_eg cdata">
 &lt;content&gt;
  &lt;macroRef key="macro.phraseSeq"/&gt;
 &lt;/content&gt;
-    <a href="#index.xml-eg-d31e24945" class="anchorlink">⚓</a></pre>
+    <a href="#index.xml-eg-d31e25730" class="anchorlink">⚓</a></pre>
                            </td>
                         </tr>
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Schema Declaration</span></td>
                            <td class="wovenodd-col2">
-                              <pre id="index.xml-eg-d31e24952" class="pre_eg">
+                              <pre id="index.xml-eg-d31e25737" class="pre_eg">
 element orgName
 {
    tei_att.global.attributes,
@@ -7608,14 +7776,14 @@ element orgName
    tei_att.personal.attributes,
    tei_att.typed.attributes,
    tei_macro.phraseSeq
-}<a href="#index.xml-eg-d31e24952" class="anchorlink">⚓</a></pre>
+}<a href="#index.xml-eg-d31e25737" class="anchorlink">⚓</a></pre>
                            </td>
                         </tr>
                      </table>
                   </div>
                </div>
                <div class="refdoc" id="TEI.p">
-                  <h3><span class="headingNumber">5.1.50. </span><span class="head">&lt;p&gt;</span></h3>
+                  <h3><span class="headingNumber">5.1.51. </span><span class="head">&lt;p&gt;</span></h3>
                   <div class="table">
                      <table class="wovenodd">
                         <tr>
@@ -7659,7 +7827,7 @@ element orgName
                                  <div class="specChild"><span class="specChildModule">linking: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.seg" title="&lt;seg&gt;">seg</a></span></div>
                                  <div class="specChild"><span class="specChildModule">namesdates: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.orgName" title="&lt;orgName&gt;">orgName</a> <a class="link_odd_elementSpec" href="#TEI.persName" title="&lt;persName&gt;">persName</a> <a class="link_odd_elementSpec" href="#TEI.placeName" title="&lt;placeName&gt;">placeName</a></span></div>
                                  <div class="specChild"><span class="specChildModule">textcrit: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.app" title="&lt;app&gt;">app</a> <a class="link_odd_elementSpec" href="#TEI.listWit" title="&lt;listWit&gt;">listWit</a></span></div>
-                                 <div class="specChild"><span class="specChildModule">transcr: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.fw" title="&lt;fw&gt;">fw</a></span></div>
+                                 <div class="specChild"><span class="specChildModule">transcr: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.fw" title="&lt;fw&gt;">fw</a> <a class="link_odd_elementSpec" href="#TEI.listTranspose" title="&lt;listTranspose&gt;">listTranspose</a></span></div>
                                  <div class="specChild">character data</div>
                               </div>
                            </td>
@@ -7667,7 +7835,7 @@ element orgName
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Example</span></td>
                            <td class="wovenodd-col2">
-                              <div id="index.xml-egXML-d31e25398" class="pre egXML_valid"><span class="element">&lt;p&gt;</span>Hallgerd was outside. <span class="element">&lt;q&gt;</span>There is blood on your axe,<span class="element">&lt;/q&gt;</span> she said. <span class="element">&lt;q&gt;</span>What have you
+                              <div id="index.xml-egXML-d31e26187" class="pre egXML_valid"><span class="element">&lt;p&gt;</span>Hallgerd was outside. <span class="element">&lt;q&gt;</span>There is blood on your axe,<span class="element">&lt;/q&gt;</span> she said. <span class="element">&lt;q&gt;</span>What have you
                                     done?<span class="element">&lt;/q&gt;</span>
                                  <span class="element">&lt;/p&gt;</span>
                                  <span class="element">&lt;p&gt;</span>
@@ -7709,17 +7877,17 @@ element orgName
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Content model</span></td>
                            <td class="wovenodd-col2">
-                              <pre id="index.xml-eg-d31e25433" class="pre_eg cdata">
+                              <pre id="index.xml-eg-d31e26222" class="pre_eg cdata">
 &lt;content&gt;
  &lt;macroRef key="macro.paraContent"/&gt;
 &lt;/content&gt;
-    <a href="#index.xml-eg-d31e25433" class="anchorlink">⚓</a></pre>
+    <a href="#index.xml-eg-d31e26222" class="anchorlink">⚓</a></pre>
                            </td>
                         </tr>
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Schema Declaration</span></td>
                            <td class="wovenodd-col2">
-                              <pre id="index.xml-eg-d31e25440" class="pre_eg">
+                              <pre id="index.xml-eg-d31e26229" class="pre_eg">
 element p
 {
    tei_att.global.attributes,
@@ -7727,14 +7895,14 @@ element p
    tei_att.fragmentable.attributes,
    tei_att.written.attributes,
    tei_macro.paraContent
-}<a href="#index.xml-eg-d31e25440" class="anchorlink">⚓</a></pre>
+}<a href="#index.xml-eg-d31e26229" class="anchorlink">⚓</a></pre>
                            </td>
                         </tr>
                      </table>
                   </div>
                </div>
                <div class="refdoc" id="TEI.pb">
-                  <h3><span class="headingNumber">5.1.51. </span><span class="head">&lt;pb&gt;</span></h3>
+                  <h3><span class="headingNumber">5.1.52. </span><span class="head">&lt;pb&gt;</span></h3>
                   <div class="table">
                      <table class="wovenodd">
                         <tr>
@@ -7790,7 +7958,7 @@ element p
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Example</span></td>
                            <td class="wovenodd-col2">Page numbers may vary in different editions of a text.
-                              <div id="index.xml-egXML-d31e25937" class="pre egXML_valid"><span class="element">&lt;p&gt;</span> ... <span class="element">&lt;pb <span class="attribute">n</span>="<span class="attributevalue">145</span>" <span class="attribute">ed</span>="<span class="attributevalue">ed2</span>"/&gt;</span>
+                              <div id="index.xml-egXML-d31e26726" class="pre egXML_valid"><span class="element">&lt;p&gt;</span> ... <span class="element">&lt;pb <span class="attribute">n</span>="<span class="attributevalue">145</span>" <span class="attribute">ed</span>="<span class="attributevalue">ed2</span>"/&gt;</span>
                                  <span class="comment">&lt;!-- Page 145 in edition "ed2" starts here --&gt;</span> ... <span class="element">&lt;pb <span class="attribute">n</span>="<span class="attributevalue">283</span>" <span class="attribute">ed</span>="<span class="attributevalue">ed1</span>"/&gt;</span>
                                  <span class="comment">&lt;!-- Page 283 in edition "ed1" starts here--&gt;</span> ... <span class="element">&lt;/p&gt;</span></div>
                            </td>
@@ -7799,7 +7967,7 @@ element p
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Example</span></td>
                            <td class="wovenodd-col2">A page break may be associated with a facsimile image of the page it introduces by
                               means of the <span class="att">facs</span> attribute
-                              <div id="index.xml-egXML-d31e25955" class="pre egXML_valid"><span class="element">&lt;body&gt;</span>
+                              <div id="index.xml-egXML-d31e26744" class="pre egXML_valid"><span class="element">&lt;body&gt;</span>
                                   <span class="element">&lt;pb <span class="attribute">n</span>="<span class="attributevalue">1</span>" <span class="attribute">facs</span>="<span class="attributevalue">page1.png</span>"/&gt;</span>
                                  <span class="comment">&lt;!-- page1.png contains an image of the page;
                                     the text it contains is encoded here --&gt;</span>
@@ -7817,17 +7985,17 @@ element p
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Content model</span></td>
                            <td class="wovenodd-col2">
-                              <pre id="index.xml-eg-d31e25970" class="pre_eg cdata">
+                              <pre id="index.xml-eg-d31e26759" class="pre_eg cdata">
 &lt;content&gt;
  &lt;empty/&gt;
 &lt;/content&gt;
-    <a href="#index.xml-eg-d31e25970" class="anchorlink">⚓</a></pre>
+    <a href="#index.xml-eg-d31e26759" class="anchorlink">⚓</a></pre>
                            </td>
                         </tr>
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Schema Declaration</span></td>
                            <td class="wovenodd-col2">
-                              <pre id="index.xml-eg-d31e25977" class="pre_eg">
+                              <pre id="index.xml-eg-d31e26766" class="pre_eg">
 element pb
 {
    tei_att.global.attributes,
@@ -7836,14 +8004,14 @@ element pb
    tei_att.spanning.attributes,
    tei_att.breaking.attributes,
    empty
-}<a href="#index.xml-eg-d31e25977" class="anchorlink">⚓</a></pre>
+}<a href="#index.xml-eg-d31e26766" class="anchorlink">⚓</a></pre>
                            </td>
                         </tr>
                      </table>
                   </div>
                </div>
                <div class="refdoc" id="TEI.persName">
-                  <h3><span class="headingNumber">5.1.52. </span><span class="head">&lt;persName&gt;</span></h3>
+                  <h3><span class="headingNumber">5.1.53. </span><span class="head">&lt;persName&gt;</span></h3>
                   <div class="table">
                      <table class="wovenodd">
                         <tr>
@@ -7892,7 +8060,7 @@ element pb
                                  <div class="specChild"><span class="specChildModule">linking: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.seg" title="&lt;seg&gt;">seg</a></span></div>
                                  <div class="specChild"><span class="specChildModule">namesdates: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.orgName" title="&lt;orgName&gt;">orgName</a> <a class="link_odd_elementSpec" href="#TEI.persName" title="&lt;persName&gt;">persName</a> <a class="link_odd_elementSpec" href="#TEI.placeName" title="&lt;placeName&gt;">placeName</a></span></div>
                                  <div class="specChild"><span class="specChildModule">textcrit: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.app" title="&lt;app&gt;">app</a></span></div>
-                                 <div class="specChild"><span class="specChildModule">transcr: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.fw" title="&lt;fw&gt;">fw</a></span></div>
+                                 <div class="specChild"><span class="specChildModule">transcr: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.fw" title="&lt;fw&gt;">fw</a> <a class="link_odd_elementSpec" href="#TEI.listTranspose" title="&lt;listTranspose&gt;">listTranspose</a></span></div>
                                  <div class="specChild">character data</div>
                               </div>
                            </td>
@@ -7900,7 +8068,7 @@ element pb
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Example</span></td>
                            <td class="wovenodd-col2">
-                              <div id="index.xml-egXML-d31e26613" class="pre egXML_valid"><span class="element">&lt;persName&gt;</span>
+                              <div id="index.xml-egXML-d31e27406" class="pre egXML_valid"><span class="element">&lt;persName&gt;</span>
                                   <span class="element">&lt;forename&gt;</span>Edward<span class="element">&lt;/forename&gt;</span>
                                   <span class="element">&lt;forename&gt;</span>George<span class="element">&lt;/forename&gt;</span>
                                   <span class="element">&lt;surname <span class="attribute">type</span>="<span class="attributevalue">linked</span>"&gt;</span>Bulwer-Lytton<span class="element">&lt;/surname&gt;</span>, <span class="element">&lt;roleName&gt;</span>Baron Lytton of
@@ -7912,17 +8080,17 @@ element pb
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Content model</span></td>
                            <td class="wovenodd-col2">
-                              <pre id="index.xml-eg-d31e26628" class="pre_eg cdata">
+                              <pre id="index.xml-eg-d31e27421" class="pre_eg cdata">
 &lt;content&gt;
  &lt;macroRef key="macro.phraseSeq"/&gt;
 &lt;/content&gt;
-    <a href="#index.xml-eg-d31e26628" class="anchorlink">⚓</a></pre>
+    <a href="#index.xml-eg-d31e27421" class="anchorlink">⚓</a></pre>
                            </td>
                         </tr>
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Schema Declaration</span></td>
                            <td class="wovenodd-col2">
-                              <pre id="index.xml-eg-d31e26635" class="pre_eg">
+                              <pre id="index.xml-eg-d31e27428" class="pre_eg">
 element persName
 {
    tei_att.global.attributes,
@@ -7931,14 +8099,14 @@ element persName
    tei_att.personal.attributes,
    tei_att.typed.attributes,
    tei_macro.phraseSeq
-}<a href="#index.xml-eg-d31e26635" class="anchorlink">⚓</a></pre>
+}<a href="#index.xml-eg-d31e27428" class="anchorlink">⚓</a></pre>
                            </td>
                         </tr>
                      </table>
                   </div>
                </div>
                <div class="refdoc" id="TEI.placeName">
-                  <h3><span class="headingNumber">5.1.53. </span><span class="head">&lt;placeName&gt;</span></h3>
+                  <h3><span class="headingNumber">5.1.54. </span><span class="head">&lt;placeName&gt;</span></h3>
                   <div class="table">
                      <table class="wovenodd">
                         <tr>
@@ -7986,7 +8154,7 @@ element persName
                                  <div class="specChild"><span class="specChildModule">linking: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.seg" title="&lt;seg&gt;">seg</a></span></div>
                                  <div class="specChild"><span class="specChildModule">namesdates: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.orgName" title="&lt;orgName&gt;">orgName</a> <a class="link_odd_elementSpec" href="#TEI.persName" title="&lt;persName&gt;">persName</a> <a class="link_odd_elementSpec" href="#TEI.placeName" title="&lt;placeName&gt;">placeName</a></span></div>
                                  <div class="specChild"><span class="specChildModule">textcrit: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.app" title="&lt;app&gt;">app</a></span></div>
-                                 <div class="specChild"><span class="specChildModule">transcr: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.fw" title="&lt;fw&gt;">fw</a></span></div>
+                                 <div class="specChild"><span class="specChildModule">transcr: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.fw" title="&lt;fw&gt;">fw</a> <a class="link_odd_elementSpec" href="#TEI.listTranspose" title="&lt;listTranspose&gt;">listTranspose</a></span></div>
                                  <div class="specChild">character data</div>
                               </div>
                            </td>
@@ -7994,7 +8162,7 @@ element persName
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Example</span></td>
                            <td class="wovenodd-col2">
-                              <div id="index.xml-egXML-d31e27270" class="pre egXML_valid"><span class="element">&lt;placeName&gt;</span>
+                              <div id="index.xml-egXML-d31e28067" class="pre egXML_valid"><span class="element">&lt;placeName&gt;</span>
                                   <span class="element">&lt;settlement&gt;</span>Rochester<span class="element">&lt;/settlement&gt;</span>
                                   <span class="element">&lt;region&gt;</span>New York<span class="element">&lt;/region&gt;</span>
                                  <span class="element">&lt;/placeName&gt;</span></div>
@@ -8003,7 +8171,7 @@ element persName
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Example</span></td>
                            <td class="wovenodd-col2">
-                              <div id="index.xml-egXML-d31e27279" class="pre egXML_valid"><span class="element">&lt;placeName&gt;</span>
+                              <div id="index.xml-egXML-d31e28076" class="pre egXML_valid"><span class="element">&lt;placeName&gt;</span>
                                   <span class="element">&lt;geogName&gt;</span>Arrochar Alps<span class="element">&lt;/geogName&gt;</span>
                                   <span class="element">&lt;region&gt;</span>Argylshire<span class="element">&lt;/region&gt;</span>
                                  <span class="element">&lt;/placeName&gt;</span></div>
@@ -8012,7 +8180,7 @@ element persName
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Example</span></td>
                            <td class="wovenodd-col2">
-                              <div id="index.xml-egXML-d31e27288" class="pre egXML_valid"><span class="element">&lt;placeName&gt;</span>
+                              <div id="index.xml-egXML-d31e28085" class="pre egXML_valid"><span class="element">&lt;placeName&gt;</span>
                                   <span class="element">&lt;measure&gt;</span>10 miles<span class="element">&lt;/measure&gt;</span>
                                   <span class="element">&lt;offset&gt;</span>Northeast of<span class="element">&lt;/offset&gt;</span>
                                   <span class="element">&lt;settlement&gt;</span>Attica<span class="element">&lt;/settlement&gt;</span>
@@ -8022,17 +8190,17 @@ element persName
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Content model</span></td>
                            <td class="wovenodd-col2">
-                              <pre id="index.xml-eg-d31e27298" class="pre_eg cdata">
+                              <pre id="index.xml-eg-d31e28095" class="pre_eg cdata">
 &lt;content&gt;
  &lt;macroRef key="macro.phraseSeq"/&gt;
 &lt;/content&gt;
-    <a href="#index.xml-eg-d31e27298" class="anchorlink">⚓</a></pre>
+    <a href="#index.xml-eg-d31e28095" class="anchorlink">⚓</a></pre>
                            </td>
                         </tr>
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Schema Declaration</span></td>
                            <td class="wovenodd-col2">
-                              <pre id="index.xml-eg-d31e27305" class="pre_eg">
+                              <pre id="index.xml-eg-d31e28102" class="pre_eg">
 element placeName
 {
    tei_att.datable.attributes,
@@ -8041,14 +8209,14 @@ element placeName
    tei_att.personal.attributes,
    tei_att.typed.attributes,
    tei_macro.phraseSeq
-}<a href="#index.xml-eg-d31e27305" class="anchorlink">⚓</a></pre>
+}<a href="#index.xml-eg-d31e28102" class="anchorlink">⚓</a></pre>
                            </td>
                         </tr>
                      </table>
                   </div>
                </div>
                <div class="refdoc" id="TEI.principal">
-                  <h3><span class="headingNumber">5.1.54. </span><span class="head">&lt;principal&gt;</span></h3>
+                  <h3><span class="headingNumber">5.1.55. </span><span class="head">&lt;principal&gt;</span></h3>
                   <div class="table">
                      <table class="wovenodd">
                         <tr>
@@ -8088,7 +8256,7 @@ element placeName
                                  <div class="specChild"><span class="specChildModule">figures: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.figure" title="&lt;figure&gt;">figure</a></span></div>
                                  <div class="specChild"><span class="specChildModule">namesdates: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.orgName" title="&lt;orgName&gt;">orgName</a> <a class="link_odd_elementSpec" href="#TEI.persName" title="&lt;persName&gt;">persName</a> <a class="link_odd_elementSpec" href="#TEI.placeName" title="&lt;placeName&gt;">placeName</a></span></div>
                                  <div class="specChild"><span class="specChildModule">textcrit: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.app" title="&lt;app&gt;">app</a></span></div>
-                                 <div class="specChild"><span class="specChildModule">transcr: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.fw" title="&lt;fw&gt;">fw</a></span></div>
+                                 <div class="specChild"><span class="specChildModule">transcr: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.fw" title="&lt;fw&gt;">fw</a> <a class="link_odd_elementSpec" href="#TEI.listTranspose" title="&lt;listTranspose&gt;">listTranspose</a></span></div>
                                  <div class="specChild">character data</div>
                               </div>
                            </td>
@@ -8096,37 +8264,37 @@ element placeName
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Example</span></td>
                            <td class="wovenodd-col2">
-                              <div id="index.xml-egXML-d31e27686" class="pre egXML_valid"><span class="element">&lt;principal <span class="attribute">ref</span>="<span class="attributevalue">http://viaf.org/viaf/105517912</span>"&gt;</span>Gary Taylor<span class="element">&lt;/principal&gt;</span></div>
+                              <div id="index.xml-egXML-d31e28488" class="pre egXML_valid"><span class="element">&lt;principal <span class="attribute">ref</span>="<span class="attributevalue">http://viaf.org/viaf/105517912</span>"&gt;</span>Gary Taylor<span class="element">&lt;/principal&gt;</span></div>
                            </td>
                         </tr>
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Content model</span></td>
                            <td class="wovenodd-col2">
-                              <pre id="index.xml-eg-d31e27694" class="pre_eg cdata">
+                              <pre id="index.xml-eg-d31e28496" class="pre_eg cdata">
 &lt;content&gt;
  &lt;macroRef key="macro.phraseSeq.limited"/&gt;
 &lt;/content&gt;
-    <a href="#index.xml-eg-d31e27694" class="anchorlink">⚓</a></pre>
+    <a href="#index.xml-eg-d31e28496" class="anchorlink">⚓</a></pre>
                            </td>
                         </tr>
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Schema Declaration</span></td>
                            <td class="wovenodd-col2">
-                              <pre id="index.xml-eg-d31e27701" class="pre_eg">
+                              <pre id="index.xml-eg-d31e28503" class="pre_eg">
 element principal
 {
    tei_att.global.attributes,
    tei_att.canonical.attributes,
    tei_att.datable.attributes,
    tei_macro.phraseSeq.limited
-}<a href="#index.xml-eg-d31e27701" class="anchorlink">⚓</a></pre>
+}<a href="#index.xml-eg-d31e28503" class="anchorlink">⚓</a></pre>
                            </td>
                         </tr>
                      </table>
                   </div>
                </div>
                <div class="refdoc" id="TEI.ptr">
-                  <h3><span class="headingNumber">5.1.55. </span><span class="head">&lt;ptr&gt;</span></h3>
+                  <h3><span class="headingNumber">5.1.56. </span><span class="head">&lt;ptr&gt;</span></h3>
                   <div class="table">
                      <table class="wovenodd">
                         <tr>
@@ -8168,7 +8336,7 @@ element principal
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Member of</span></td>
                            <td class="wovenodd-col2">
-                              <div class="parent"><a class="link_odd_classSpec" href="#TEI.model.ptrLike" title="model.ptrLike">model.ptrLike</a></div>
+                              <div class="parent"><a class="link_odd_classSpec" href="#TEI.model.ptrLike" title="model.ptrLike">model.ptrLike</a> </div>
                            </td>
                         </tr>
                         <tr>
@@ -8184,7 +8352,7 @@ element principal
                                     <div class="specChild"><span class="specChildModule">namesdates: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.orgName" title="&lt;orgName&gt;">orgName</a> <a class="link_odd_elementSpec" href="#TEI.persName" title="&lt;persName&gt;">persName</a> <a class="link_odd_elementSpec" href="#TEI.placeName" title="&lt;placeName&gt;">placeName</a></span></div>
                                     <div class="specChild"><span class="specChildModule">textcrit: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.lem" title="&lt;lem&gt;">lem</a> <a class="link_odd_elementSpec" href="#TEI.rdg" title="&lt;rdg&gt;">rdg</a> <a class="link_odd_elementSpec" href="#TEI.witness" title="&lt;witness&gt;">witness</a></span></div>
                                     <div class="specChild"><span class="specChildModule">textstructure: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.byline" title="&lt;byline&gt;">byline</a> <a class="link_odd_elementSpec" href="#TEI.docImprint" title="&lt;docImprint&gt;">docImprint</a> <a class="link_odd_elementSpec" href="#TEI.imprimatur" title="&lt;imprimatur&gt;">imprimatur</a> <a class="link_odd_elementSpec" href="#TEI.signed" title="&lt;signed&gt;">signed</a> <a class="link_odd_elementSpec" href="#TEI.titlePart" title="&lt;titlePart&gt;">titlePart</a> <a class="link_odd_elementSpec" href="#TEI.trailer" title="&lt;trailer&gt;">trailer</a></span></div>
-                                    <div class="specChild"><span class="specChildModule">transcr: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.fw" title="&lt;fw&gt;">fw</a></span></div>
+                                    <div class="specChild"><span class="specChildModule">transcr: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.fw" title="&lt;fw&gt;">fw</a> <a class="link_odd_elementSpec" href="#TEI.transpose" title="&lt;transpose&gt;">transpose</a></span></div>
                                  </div>
                               </div>
                            </td>
@@ -8196,7 +8364,7 @@ element principal
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Example</span></td>
                            <td class="wovenodd-col2">
-                              <div id="index.xml-egXML-d31e28175" class="pre egXML_valid"><span class="element">&lt;ptr <span class="attribute">target</span>="<span class="attributevalue">#p143 #p144</span>"/&gt;</span>
+                              <div id="index.xml-egXML-d31e28982" class="pre egXML_valid"><span class="element">&lt;ptr <span class="attribute">target</span>="<span class="attributevalue">#p143 #p144</span>"/&gt;</span>
                                  <span class="element">&lt;ptr <span class="attribute">target</span>="<span class="attributevalue">http://www.tei-c.org</span>"/&gt;</span>
                                  <span class="element">&lt;ptr <span class="attribute">cRef</span>="<span class="attributevalue">1.3.4</span>"/&gt;</span></div>
                            </td>
@@ -8212,17 +8380,17 @@ element principal
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Content model</span></td>
                            <td class="wovenodd-col2">
-                              <pre id="index.xml-eg-d31e28191" class="pre_eg cdata">
+                              <pre id="index.xml-eg-d31e28998" class="pre_eg cdata">
 &lt;content&gt;
  &lt;empty/&gt;
 &lt;/content&gt;
-    <a href="#index.xml-eg-d31e28191" class="anchorlink">⚓</a></pre>
+    <a href="#index.xml-eg-d31e28998" class="anchorlink">⚓</a></pre>
                            </td>
                         </tr>
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Schema Declaration</span></td>
                            <td class="wovenodd-col2">
-                              <pre id="index.xml-eg-d31e28198" class="pre_eg">
+                              <pre id="index.xml-eg-d31e29005" class="pre_eg">
 element ptr
 {
    tei_att.cReferencing.attributes,
@@ -8234,14 +8402,14 @@ element ptr
    tei_att.typed.attributes,
    attribute target { list { + } },
    empty
-}<a href="#index.xml-eg-d31e28198" class="anchorlink">⚓</a></pre>
+}<a href="#index.xml-eg-d31e29005" class="anchorlink">⚓</a></pre>
                            </td>
                         </tr>
                      </table>
                   </div>
                </div>
                <div class="refdoc" id="TEI.pubPlace">
-                  <h3><span class="headingNumber">5.1.56. </span><span class="head">&lt;pubPlace&gt;</span></h3>
+                  <h3><span class="headingNumber">5.1.57. </span><span class="head">&lt;pubPlace&gt;</span></h3>
                   <div class="table">
                      <table class="wovenodd">
                         <tr>
@@ -8283,7 +8451,7 @@ element ptr
                                  <div class="specChild"><span class="specChildModule">linking: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.seg" title="&lt;seg&gt;">seg</a></span></div>
                                  <div class="specChild"><span class="specChildModule">namesdates: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.orgName" title="&lt;orgName&gt;">orgName</a> <a class="link_odd_elementSpec" href="#TEI.persName" title="&lt;persName&gt;">persName</a> <a class="link_odd_elementSpec" href="#TEI.placeName" title="&lt;placeName&gt;">placeName</a></span></div>
                                  <div class="specChild"><span class="specChildModule">textcrit: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.app" title="&lt;app&gt;">app</a></span></div>
-                                 <div class="specChild"><span class="specChildModule">transcr: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.fw" title="&lt;fw&gt;">fw</a></span></div>
+                                 <div class="specChild"><span class="specChildModule">transcr: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.fw" title="&lt;fw&gt;">fw</a> <a class="link_odd_elementSpec" href="#TEI.listTranspose" title="&lt;listTranspose&gt;">listTranspose</a></span></div>
                                  <div class="specChild">character data</div>
                               </div>
                            </td>
@@ -8291,7 +8459,7 @@ element ptr
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Example</span></td>
                            <td class="wovenodd-col2">
-                              <div id="index.xml-egXML-d31e28556" class="pre egXML_valid"><span class="element">&lt;publicationStmt&gt;</span>
+                              <div id="index.xml-egXML-d31e29367" class="pre egXML_valid"><span class="element">&lt;publicationStmt&gt;</span>
                                   <span class="element">&lt;publisher&gt;</span>Oxford University Press<span class="element">&lt;/publisher&gt;</span>
                                   <span class="element">&lt;pubPlace&gt;</span>Oxford<span class="element">&lt;/pubPlace&gt;</span>
                                   <span class="element">&lt;date&gt;</span>1989<span class="element">&lt;/date&gt;</span>
@@ -8301,30 +8469,30 @@ element ptr
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Content model</span></td>
                            <td class="wovenodd-col2">
-                              <pre id="index.xml-eg-d31e28566" class="pre_eg cdata">
+                              <pre id="index.xml-eg-d31e29377" class="pre_eg cdata">
 &lt;content&gt;
  &lt;macroRef key="macro.phraseSeq"/&gt;
 &lt;/content&gt;
-    <a href="#index.xml-eg-d31e28566" class="anchorlink">⚓</a></pre>
+    <a href="#index.xml-eg-d31e29377" class="anchorlink">⚓</a></pre>
                            </td>
                         </tr>
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Schema Declaration</span></td>
                            <td class="wovenodd-col2">
-                              <pre id="index.xml-eg-d31e28573" class="pre_eg">
+                              <pre id="index.xml-eg-d31e29384" class="pre_eg">
 element pubPlace
 {
    tei_att.global.attributes,
    tei_att.naming.attributes,
    tei_macro.phraseSeq
-}<a href="#index.xml-eg-d31e28573" class="anchorlink">⚓</a></pre>
+}<a href="#index.xml-eg-d31e29384" class="anchorlink">⚓</a></pre>
                            </td>
                         </tr>
                      </table>
                   </div>
                </div>
                <div class="refdoc" id="TEI.publicationStmt">
-                  <h3><span class="headingNumber">5.1.57. </span><span class="head">&lt;publicationStmt&gt;</span></h3>
+                  <h3><span class="headingNumber">5.1.58. </span><span class="head">&lt;publicationStmt&gt;</span></h3>
                   <div class="table">
                      <table class="wovenodd">
                         <tr>
@@ -8371,7 +8539,7 @@ element pubPlace
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Example</span></td>
                            <td class="wovenodd-col2">
-                              <div id="index.xml-egXML-d31e28790" class="pre egXML_valid"><span class="element">&lt;publicationStmt&gt;</span>
+                              <div id="index.xml-egXML-d31e29601" class="pre egXML_valid"><span class="element">&lt;publicationStmt&gt;</span>
                                   <span class="element">&lt;publisher&gt;</span>C. Muquardt <span class="element">&lt;/publisher&gt;</span>
                                   <span class="element">&lt;pubPlace&gt;</span>Bruxelles &amp;amp; Leipzig<span class="element">&lt;/pubPlace&gt;</span>
                                   <span class="element">&lt;date <span class="attribute">when</span>="<span class="attributevalue">1846</span>"/&gt;</span>
@@ -8381,7 +8549,7 @@ element pubPlace
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Example</span></td>
                            <td class="wovenodd-col2">
-                              <div id="index.xml-egXML-d31e28800" class="pre egXML_valid"><span class="element">&lt;publicationStmt&gt;</span>
+                              <div id="index.xml-egXML-d31e29611" class="pre egXML_valid"><span class="element">&lt;publicationStmt&gt;</span>
                                   <span class="element">&lt;publisher&gt;</span>Chadwyck Healey<span class="element">&lt;/publisher&gt;</span>
                                   <span class="element">&lt;pubPlace&gt;</span>Cambridge<span class="element">&lt;/pubPlace&gt;</span>
                                   <span class="element">&lt;availability&gt;</span>
@@ -8394,7 +8562,7 @@ element pubPlace
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Example</span></td>
                            <td class="wovenodd-col2">
-                              <div id="index.xml-egXML-d31e28813" class="pre egXML_valid"><span class="element">&lt;publicationStmt&gt;</span>
+                              <div id="index.xml-egXML-d31e29624" class="pre egXML_valid"><span class="element">&lt;publicationStmt&gt;</span>
                                   <span class="element">&lt;publisher&gt;</span>Zea Books<span class="element">&lt;/publisher&gt;</span>
                                   <span class="element">&lt;pubPlace&gt;</span>Lincoln, NE<span class="element">&lt;/pubPlace&gt;</span>
                                   <span class="element">&lt;date&gt;</span>2017<span class="element">&lt;/date&gt;</span>
@@ -8409,7 +8577,7 @@ element pubPlace
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Content model</span></td>
                            <td class="wovenodd-col2">
-                              <pre id="index.xml-eg-d31e28826" class="pre_eg cdata">
+                              <pre id="index.xml-eg-d31e29637" class="pre_eg cdata">
 &lt;content&gt;
  &lt;alternate minOccurs="1" maxOccurs="1"&gt;
   &lt;sequence minOccurs="1"
@@ -8421,13 +8589,13 @@ element pubPlace
   &lt;classRef key="model.pLike"/&gt;
  &lt;/alternate&gt;
 &lt;/content&gt;
-    <a href="#index.xml-eg-d31e28826" class="anchorlink">⚓</a></pre>
+    <a href="#index.xml-eg-d31e29637" class="anchorlink">⚓</a></pre>
                            </td>
                         </tr>
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Schema Declaration</span></td>
                            <td class="wovenodd-col2">
-                              <pre id="index.xml-eg-d31e28833" class="pre_eg">
+                              <pre id="index.xml-eg-d31e29644" class="pre_eg">
 element publicationStmt
 {
    tei_att.global.attributes,
@@ -8439,14 +8607,14 @@ element publicationStmt
       )+
     | tei_model.pLike
    )
-}<a href="#index.xml-eg-d31e28833" class="anchorlink">⚓</a></pre>
+}<a href="#index.xml-eg-d31e29644" class="anchorlink">⚓</a></pre>
                            </td>
                         </tr>
                      </table>
                   </div>
                </div>
                <div class="refdoc" id="TEI.publisher">
-                  <h3><span class="headingNumber">5.1.58. </span><span class="head">&lt;publisher&gt;</span></h3>
+                  <h3><span class="headingNumber">5.1.59. </span><span class="head">&lt;publisher&gt;</span></h3>
                   <div class="table">
                      <table class="wovenodd">
                         <tr>
@@ -8489,7 +8657,7 @@ element publicationStmt
                                  <div class="specChild"><span class="specChildModule">linking: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.seg" title="&lt;seg&gt;">seg</a></span></div>
                                  <div class="specChild"><span class="specChildModule">namesdates: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.orgName" title="&lt;orgName&gt;">orgName</a> <a class="link_odd_elementSpec" href="#TEI.persName" title="&lt;persName&gt;">persName</a> <a class="link_odd_elementSpec" href="#TEI.placeName" title="&lt;placeName&gt;">placeName</a></span></div>
                                  <div class="specChild"><span class="specChildModule">textcrit: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.app" title="&lt;app&gt;">app</a></span></div>
-                                 <div class="specChild"><span class="specChildModule">transcr: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.fw" title="&lt;fw&gt;">fw</a></span></div>
+                                 <div class="specChild"><span class="specChildModule">transcr: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.fw" title="&lt;fw&gt;">fw</a> <a class="link_odd_elementSpec" href="#TEI.listTranspose" title="&lt;listTranspose&gt;">listTranspose</a></span></div>
                                  <div class="specChild">character data</div>
                               </div>
                            </td>
@@ -8504,7 +8672,7 @@ element publicationStmt
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Example</span></td>
                            <td class="wovenodd-col2">
-                              <div id="index.xml-egXML-d31e29184" class="pre egXML_valid"><span class="element">&lt;imprint&gt;</span>
+                              <div id="index.xml-egXML-d31e29999" class="pre egXML_valid"><span class="element">&lt;imprint&gt;</span>
                                   <span class="element">&lt;pubPlace&gt;</span>Oxford<span class="element">&lt;/pubPlace&gt;</span>
                                   <span class="element">&lt;publisher&gt;</span>Clarendon Press<span class="element">&lt;/publisher&gt;</span>
                                   <span class="element">&lt;date&gt;</span>1987<span class="element">&lt;/date&gt;</span>
@@ -8514,30 +8682,30 @@ element publicationStmt
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Content model</span></td>
                            <td class="wovenodd-col2">
-                              <pre id="index.xml-eg-d31e29194" class="pre_eg cdata">
+                              <pre id="index.xml-eg-d31e30009" class="pre_eg cdata">
 &lt;content&gt;
  &lt;macroRef key="macro.phraseSeq"/&gt;
 &lt;/content&gt;
-    <a href="#index.xml-eg-d31e29194" class="anchorlink">⚓</a></pre>
+    <a href="#index.xml-eg-d31e30009" class="anchorlink">⚓</a></pre>
                            </td>
                         </tr>
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Schema Declaration</span></td>
                            <td class="wovenodd-col2">
-                              <pre id="index.xml-eg-d31e29201" class="pre_eg">
+                              <pre id="index.xml-eg-d31e30016" class="pre_eg">
 element publisher
 {
    tei_att.global.attributes,
    tei_att.canonical.attributes,
    tei_macro.phraseSeq
-}<a href="#index.xml-eg-d31e29201" class="anchorlink">⚓</a></pre>
+}<a href="#index.xml-eg-d31e30016" class="anchorlink">⚓</a></pre>
                            </td>
                         </tr>
                      </table>
                   </div>
                </div>
                <div class="refdoc" id="TEI.q">
-                  <h3><span class="headingNumber">5.1.59. </span><span class="head">&lt;q&gt;</span></h3>
+                  <h3><span class="headingNumber">5.1.60. </span><span class="head">&lt;q&gt;</span></h3>
                   <div class="table">
                      <table class="wovenodd">
                         <tr>
@@ -8635,7 +8803,7 @@ element publisher
                                  <div class="specChild"><span class="specChildModule">linking: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.seg" title="&lt;seg&gt;">seg</a></span></div>
                                  <div class="specChild"><span class="specChildModule">namesdates: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.orgName" title="&lt;orgName&gt;">orgName</a> <a class="link_odd_elementSpec" href="#TEI.persName" title="&lt;persName&gt;">persName</a> <a class="link_odd_elementSpec" href="#TEI.placeName" title="&lt;placeName&gt;">placeName</a></span></div>
                                  <div class="specChild"><span class="specChildModule">textcrit: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.app" title="&lt;app&gt;">app</a> <a class="link_odd_elementSpec" href="#TEI.listWit" title="&lt;listWit&gt;">listWit</a></span></div>
-                                 <div class="specChild"><span class="specChildModule">transcr: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.fw" title="&lt;fw&gt;">fw</a></span></div>
+                                 <div class="specChild"><span class="specChildModule">transcr: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.fw" title="&lt;fw&gt;">fw</a> <a class="link_odd_elementSpec" href="#TEI.listTranspose" title="&lt;listTranspose&gt;">listTranspose</a></span></div>
                                  <div class="specChild">character data</div>
                               </div>
                            </td>
@@ -8650,7 +8818,7 @@ element publisher
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Example</span></td>
                            <td class="wovenodd-col2">
-                              <div id="index.xml-egXML-d31e29904" class="pre egXML_valid">It is spelled <span class="element">&lt;q&gt;</span>Tübingen<span class="element">&lt;/q&gt;</span> — to enter the
+                              <div id="index.xml-egXML-d31e30723" class="pre egXML_valid">It is spelled <span class="element">&lt;q&gt;</span>Tübingen<span class="element">&lt;/q&gt;</span> — to enter the
                                   letter <span class="element">&lt;q&gt;</span>u<span class="element">&lt;/q&gt;</span> with an umlaut hold down the <span class="element">&lt;q&gt;</span>option<span class="element">&lt;/q&gt;</span> key and press 
                                  <span class="element">&lt;q&gt;</span>0 0 f c<span class="element">&lt;/q&gt;</span></div>
                            </td>
@@ -8658,17 +8826,17 @@ element publisher
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Content model</span></td>
                            <td class="wovenodd-col2">
-                              <pre id="index.xml-eg-d31e29918" class="pre_eg cdata">
+                              <pre id="index.xml-eg-d31e30737" class="pre_eg cdata">
 &lt;content&gt;
  &lt;macroRef key="macro.specialPara"/&gt;
 &lt;/content&gt;
-    <a href="#index.xml-eg-d31e29918" class="anchorlink">⚓</a></pre>
+    <a href="#index.xml-eg-d31e30737" class="anchorlink">⚓</a></pre>
                            </td>
                         </tr>
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Schema Declaration</span></td>
                            <td class="wovenodd-col2">
-                              <pre id="index.xml-eg-d31e29925" class="pre_eg">
+                              <pre id="index.xml-eg-d31e30744" class="pre_eg">
 element q
 {
    tei_att.global.attributes,
@@ -8686,14 +8854,14 @@ element q
     | "mentioned"
    }?,
    tei_macro.specialPara
-}<a href="#index.xml-eg-d31e29925" class="anchorlink">⚓</a></pre>
+}<a href="#index.xml-eg-d31e30744" class="anchorlink">⚓</a></pre>
                            </td>
                         </tr>
                      </table>
                   </div>
                </div>
                <div class="refdoc" id="TEI.quote">
-                  <h3><span class="headingNumber">5.1.60. </span><span class="head">&lt;quote&gt;</span></h3>
+                  <h3><span class="headingNumber">5.1.61. </span><span class="head">&lt;quote&gt;</span></h3>
                   <div class="table">
                      <table class="wovenodd">
                         <tr>
@@ -8742,7 +8910,7 @@ element q
                                  <div class="specChild"><span class="specChildModule">linking: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.seg" title="&lt;seg&gt;">seg</a></span></div>
                                  <div class="specChild"><span class="specChildModule">namesdates: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.orgName" title="&lt;orgName&gt;">orgName</a> <a class="link_odd_elementSpec" href="#TEI.persName" title="&lt;persName&gt;">persName</a> <a class="link_odd_elementSpec" href="#TEI.placeName" title="&lt;placeName&gt;">placeName</a></span></div>
                                  <div class="specChild"><span class="specChildModule">textcrit: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.app" title="&lt;app&gt;">app</a> <a class="link_odd_elementSpec" href="#TEI.listWit" title="&lt;listWit&gt;">listWit</a></span></div>
-                                 <div class="specChild"><span class="specChildModule">transcr: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.fw" title="&lt;fw&gt;">fw</a></span></div>
+                                 <div class="specChild"><span class="specChildModule">transcr: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.fw" title="&lt;fw&gt;">fw</a> <a class="link_odd_elementSpec" href="#TEI.listTranspose" title="&lt;listTranspose&gt;">listTranspose</a></span></div>
                                  <div class="specChild">character data</div>
                               </div>
                            </td>
@@ -8757,7 +8925,7 @@ element q
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Example</span></td>
                            <td class="wovenodd-col2">
-                              <div id="index.xml-egXML-d31e30475" class="pre egXML_valid">Lexicography has shown little sign of being affected by the
+                              <div id="index.xml-egXML-d31e31298" class="pre egXML_valid">Lexicography has shown little sign of being affected by the
                                   work of followers of J.R. Firth, probably best summarized in his
                                   slogan, <span class="element">&lt;quote&gt;</span>You shall know a word by the company it
                                   keeps<span class="element">&lt;/quote&gt;</span>
@@ -8775,31 +8943,31 @@ element q
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Content model</span></td>
                            <td class="wovenodd-col2">
-                              <pre id="index.xml-eg-d31e30491" class="pre_eg cdata">
+                              <pre id="index.xml-eg-d31e31314" class="pre_eg cdata">
 &lt;content&gt;
  &lt;macroRef key="macro.specialPara"/&gt;
 &lt;/content&gt;
-    <a href="#index.xml-eg-d31e30491" class="anchorlink">⚓</a></pre>
+    <a href="#index.xml-eg-d31e31314" class="anchorlink">⚓</a></pre>
                            </td>
                         </tr>
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Schema Declaration</span></td>
                            <td class="wovenodd-col2">
-                              <pre id="index.xml-eg-d31e30498" class="pre_eg">
+                              <pre id="index.xml-eg-d31e31321" class="pre_eg">
 element quote
 {
    tei_att.global.attributes,
    tei_att.typed.attributes,
    tei_att.notated.attributes,
    tei_macro.specialPara
-}<a href="#index.xml-eg-d31e30498" class="anchorlink">⚓</a></pre>
+}<a href="#index.xml-eg-d31e31321" class="anchorlink">⚓</a></pre>
                            </td>
                         </tr>
                      </table>
                   </div>
                </div>
                <div class="refdoc" id="TEI.rdg">
-                  <h3><span class="headingNumber">5.1.61. </span><span class="head">&lt;rdg&gt;</span></h3>
+                  <h3><span class="headingNumber">5.1.62. </span><span class="head">&lt;rdg&gt;</span></h3>
                   <div class="table">
                      <table class="wovenodd">
                         <tr>
@@ -8866,7 +9034,7 @@ element quote
                                  <div class="specChild"><span class="specChildModule">namesdates: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.orgName" title="&lt;orgName&gt;">orgName</a> <a class="link_odd_elementSpec" href="#TEI.persName" title="&lt;persName&gt;">persName</a> <a class="link_odd_elementSpec" href="#TEI.placeName" title="&lt;placeName&gt;">placeName</a></span></div>
                                  <div class="specChild"><span class="specChildModule">textcrit: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.app" title="&lt;app&gt;">app</a> <a class="link_odd_elementSpec" href="#TEI.listWit" title="&lt;listWit&gt;">listWit</a></span></div>
                                  <div class="specChild"><span class="specChildModule">textstructure: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.byline" title="&lt;byline&gt;">byline</a> <a class="link_odd_elementSpec" href="#TEI.div" title="&lt;div&gt;">div</a> <a class="link_odd_elementSpec" href="#TEI.docImprint" title="&lt;docImprint&gt;">docImprint</a> <a class="link_odd_elementSpec" href="#TEI.docTitle" title="&lt;docTitle&gt;">docTitle</a> <a class="link_odd_elementSpec" href="#TEI.epigraph" title="&lt;epigraph&gt;">epigraph</a> <a class="link_odd_elementSpec" href="#TEI.imprimatur" title="&lt;imprimatur&gt;">imprimatur</a> <a class="link_odd_elementSpec" href="#TEI.titlePage" title="&lt;titlePage&gt;">titlePage</a> <a class="link_odd_elementSpec" href="#TEI.titlePart" title="&lt;titlePart&gt;">titlePart</a></span></div>
-                                 <div class="specChild"><span class="specChildModule">transcr: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.fw" title="&lt;fw&gt;">fw</a></span></div>
+                                 <div class="specChild"><span class="specChildModule">transcr: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.fw" title="&lt;fw&gt;">fw</a> <a class="link_odd_elementSpec" href="#TEI.listTranspose" title="&lt;listTranspose&gt;">listTranspose</a></span></div>
                                  <div class="specChild">character data</div>
                               </div>
                            </td>
@@ -8874,13 +9042,13 @@ element quote
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Example</span></td>
                            <td class="wovenodd-col2">
-                              <div id="index.xml-egXML-d31e30943" class="pre egXML_valid"><span class="element">&lt;rdg <span class="attribute">wit</span>="<span class="attributevalue">#Ra2</span>"&gt;</span>Eryment<span class="element">&lt;/rdg&gt;</span></div>
+                              <div id="index.xml-egXML-d31e31770" class="pre egXML_valid"><span class="element">&lt;rdg <span class="attribute">wit</span>="<span class="attributevalue">#Ra2</span>"&gt;</span>Eryment<span class="element">&lt;/rdg&gt;</span></div>
                            </td>
                         </tr>
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Content model</span></td>
                            <td class="wovenodd-col2">
-                              <pre id="index.xml-eg-d31e30951" class="pre_eg cdata">
+                              <pre id="index.xml-eg-d31e31778" class="pre_eg cdata">
 &lt;content&gt;
  &lt;alternate minOccurs="0"
   maxOccurs="unbounded"&gt;
@@ -8909,13 +9077,13 @@ element quote
   &lt;classRef key="model.rdgPart"/&gt;
  &lt;/alternate&gt;
 &lt;/content&gt;
-    <a href="#index.xml-eg-d31e30951" class="anchorlink">⚓</a></pre>
+    <a href="#index.xml-eg-d31e31778" class="anchorlink">⚓</a></pre>
                            </td>
                         </tr>
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Schema Declaration</span></td>
                            <td class="wovenodd-col2">
-                              <pre id="index.xml-eg-d31e30958" class="pre_eg">
+                              <pre id="index.xml-eg-d31e31785" class="pre_eg">
 element rdg
 {
    tei_att.global.attributes,
@@ -8946,14 +9114,14 @@ element rdg
     | tei_model.global
     | tei_model.rdgPart
    )*
-}<a href="#index.xml-eg-d31e30958" class="anchorlink">⚓</a></pre>
+}<a href="#index.xml-eg-d31e31785" class="anchorlink">⚓</a></pre>
                            </td>
                         </tr>
                      </table>
                   </div>
                </div>
                <div class="refdoc" id="TEI.ref">
-                  <h3><span class="headingNumber">5.1.62. </span><span class="head">&lt;ref&gt;</span></h3>
+                  <h3><span class="headingNumber">5.1.63. </span><span class="head">&lt;ref&gt;</span></h3>
                   <div class="table">
                      <table class="wovenodd">
                         <tr>
@@ -9026,7 +9194,7 @@ element rdg
                                  <div class="specChild"><span class="specChildModule">linking: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.seg" title="&lt;seg&gt;">seg</a></span></div>
                                  <div class="specChild"><span class="specChildModule">namesdates: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.orgName" title="&lt;orgName&gt;">orgName</a> <a class="link_odd_elementSpec" href="#TEI.persName" title="&lt;persName&gt;">persName</a> <a class="link_odd_elementSpec" href="#TEI.placeName" title="&lt;placeName&gt;">placeName</a></span></div>
                                  <div class="specChild"><span class="specChildModule">textcrit: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.app" title="&lt;app&gt;">app</a> <a class="link_odd_elementSpec" href="#TEI.listWit" title="&lt;listWit&gt;">listWit</a></span></div>
-                                 <div class="specChild"><span class="specChildModule">transcr: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.fw" title="&lt;fw&gt;">fw</a></span></div>
+                                 <div class="specChild"><span class="specChildModule">transcr: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.fw" title="&lt;fw&gt;">fw</a> <a class="link_odd_elementSpec" href="#TEI.listTranspose" title="&lt;listTranspose&gt;">listTranspose</a></span></div>
                                  <div class="specChild">character data</div>
                               </div>
                            </td>
@@ -9040,14 +9208,14 @@ element rdg
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Example</span></td>
                            <td class="wovenodd-col2">
-                              <div id="index.xml-egXML-d31e31668" class="pre egXML_valid">See especially <span class="element">&lt;ref <span class="attribute">target</span>="<span class="attributevalue">http://www.natcorp.ox.ac.uk/Texts/A02.xml#s2</span>"&gt;</span>the second
+                              <div id="index.xml-egXML-d31e32499" class="pre egXML_valid">See especially <span class="element">&lt;ref <span class="attribute">target</span>="<span class="attributevalue">http://www.natcorp.ox.ac.uk/Texts/A02.xml#s2</span>"&gt;</span>the second
                                   sentence<span class="element">&lt;/ref&gt;</span></div>
                            </td>
                         </tr>
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Example</span></td>
                            <td class="wovenodd-col2">
-                              <div id="index.xml-egXML-d31e31677" class="pre egXML_valid">See also <span class="element">&lt;ref <span class="attribute">target</span>="<span class="attributevalue">#locution</span>"&gt;</span>s.v. <span class="element">&lt;term&gt;</span>locution<span class="element">&lt;/term&gt;</span>
+                              <div id="index.xml-egXML-d31e32508" class="pre egXML_valid">See also <span class="element">&lt;ref <span class="attribute">target</span>="<span class="attributevalue">#locution</span>"&gt;</span>s.v. <span class="element">&lt;term&gt;</span>locution<span class="element">&lt;/term&gt;</span>
                                  <span class="element">&lt;/ref&gt;</span>.</div>
                            </td>
                         </tr>
@@ -9071,17 +9239,17 @@ element rdg
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Content model</span></td>
                            <td class="wovenodd-col2">
-                              <pre id="index.xml-eg-d31e31703" class="pre_eg cdata">
+                              <pre id="index.xml-eg-d31e32534" class="pre_eg cdata">
 &lt;content&gt;
  &lt;macroRef key="macro.paraContent"/&gt;
 &lt;/content&gt;
-    <a href="#index.xml-eg-d31e31703" class="anchorlink">⚓</a></pre>
+    <a href="#index.xml-eg-d31e32534" class="anchorlink">⚓</a></pre>
                            </td>
                         </tr>
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Schema Declaration</span></td>
                            <td class="wovenodd-col2">
-                              <pre id="index.xml-eg-d31e31710" class="pre_eg">
+                              <pre id="index.xml-eg-d31e32541" class="pre_eg">
 element ref
 {
    tei_att.cReferencing.attributes,
@@ -9093,14 +9261,14 @@ element ref
    tei_att.typed.attributes,
    attribute target { list { + } },
    tei_macro.paraContent
-}<a href="#index.xml-eg-d31e31710" class="anchorlink">⚓</a></pre>
+}<a href="#index.xml-eg-d31e32541" class="anchorlink">⚓</a></pre>
                            </td>
                         </tr>
                      </table>
                   </div>
                </div>
                <div class="refdoc" id="TEI.resp">
-                  <h3><span class="headingNumber">5.1.63. </span><span class="head">&lt;resp&gt;</span></h3>
+                  <h3><span class="headingNumber">5.1.64. </span><span class="head">&lt;resp&gt;</span></h3>
                   <div class="table">
                      <table class="wovenodd">
                         <tr>
@@ -9133,7 +9301,7 @@ element ref
                                  <div class="specChild"><span class="specChildModule">figures: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.figure" title="&lt;figure&gt;">figure</a></span></div>
                                  <div class="specChild"><span class="specChildModule">namesdates: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.orgName" title="&lt;orgName&gt;">orgName</a> <a class="link_odd_elementSpec" href="#TEI.persName" title="&lt;persName&gt;">persName</a> <a class="link_odd_elementSpec" href="#TEI.placeName" title="&lt;placeName&gt;">placeName</a></span></div>
                                  <div class="specChild"><span class="specChildModule">textcrit: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.app" title="&lt;app&gt;">app</a></span></div>
-                                 <div class="specChild"><span class="specChildModule">transcr: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.fw" title="&lt;fw&gt;">fw</a></span></div>
+                                 <div class="specChild"><span class="specChildModule">transcr: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.fw" title="&lt;fw&gt;">fw</a> <a class="link_odd_elementSpec" href="#TEI.listTranspose" title="&lt;listTranspose&gt;">listTranspose</a></span></div>
                                  <div class="specChild">character data</div>
                               </div>
                            </td>
@@ -9149,7 +9317,7 @@ element ref
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Example</span></td>
                            <td class="wovenodd-col2">
-                              <div id="index.xml-egXML-d31e32105" class="pre egXML_valid"><span class="element">&lt;respStmt&gt;</span>
+                              <div id="index.xml-egXML-d31e32940" class="pre egXML_valid"><span class="element">&lt;respStmt&gt;</span>
                                   <span class="element">&lt;resp <span class="attribute">ref</span>="<span class="attributevalue">http://id.loc.gov/vocabulary/relators/com.html</span>"&gt;</span>compiler<span class="element">&lt;/resp&gt;</span>
                                   <span class="element">&lt;name&gt;</span>Edward Child<span class="element">&lt;/name&gt;</span>
                                  <span class="element">&lt;/respStmt&gt;</span></div>
@@ -9158,31 +9326,31 @@ element ref
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Content model</span></td>
                            <td class="wovenodd-col2">
-                              <pre id="index.xml-eg-d31e32115" class="pre_eg cdata">
+                              <pre id="index.xml-eg-d31e32950" class="pre_eg cdata">
 &lt;content&gt;
  &lt;macroRef key="macro.phraseSeq.limited"/&gt;
 &lt;/content&gt;
-    <a href="#index.xml-eg-d31e32115" class="anchorlink">⚓</a></pre>
+    <a href="#index.xml-eg-d31e32950" class="anchorlink">⚓</a></pre>
                            </td>
                         </tr>
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Schema Declaration</span></td>
                            <td class="wovenodd-col2">
-                              <pre id="index.xml-eg-d31e32122" class="pre_eg">
+                              <pre id="index.xml-eg-d31e32957" class="pre_eg">
 element resp
 {
    tei_att.global.attributes,
    tei_att.canonical.attributes,
    tei_att.datable.attributes,
    tei_macro.phraseSeq.limited
-}<a href="#index.xml-eg-d31e32122" class="anchorlink">⚓</a></pre>
+}<a href="#index.xml-eg-d31e32957" class="anchorlink">⚓</a></pre>
                            </td>
                         </tr>
                      </table>
                   </div>
                </div>
                <div class="refdoc" id="TEI.respStmt">
-                  <h3><span class="headingNumber">5.1.64. </span><span class="head">&lt;respStmt&gt;</span></h3>
+                  <h3><span class="headingNumber">5.1.65. </span><span class="head">&lt;respStmt&gt;</span></h3>
                   <div class="table">
                      <table class="wovenodd">
                         <tr>
@@ -9229,7 +9397,7 @@ element resp
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Example</span></td>
                            <td class="wovenodd-col2">
-                              <div id="index.xml-egXML-d31e32362" class="pre egXML_valid"><span class="element">&lt;respStmt&gt;</span>
+                              <div id="index.xml-egXML-d31e33197" class="pre egXML_valid"><span class="element">&lt;respStmt&gt;</span>
                                   <span class="element">&lt;resp&gt;</span>transcribed from original ms<span class="element">&lt;/resp&gt;</span>
                                   <span class="element">&lt;persName&gt;</span>Claus Huitfeldt<span class="element">&lt;/persName&gt;</span>
                                  <span class="element">&lt;/respStmt&gt;</span></div>
@@ -9238,7 +9406,7 @@ element resp
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Example</span></td>
                            <td class="wovenodd-col2">
-                              <div id="index.xml-egXML-d31e32371" class="pre egXML_valid"><span class="element">&lt;respStmt&gt;</span>
+                              <div id="index.xml-egXML-d31e33206" class="pre egXML_valid"><span class="element">&lt;respStmt&gt;</span>
                                   <span class="element">&lt;resp&gt;</span>converted to XML encoding<span class="element">&lt;/resp&gt;</span>
                                   <span class="element">&lt;name&gt;</span>Alan Morrison<span class="element">&lt;/name&gt;</span>
                                  <span class="element">&lt;/respStmt&gt;</span></div>
@@ -9247,7 +9415,7 @@ element resp
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Content model</span></td>
                            <td class="wovenodd-col2">
-                              <pre id="index.xml-eg-d31e32380" class="pre_eg cdata">
+                              <pre id="index.xml-eg-d31e33215" class="pre_eg cdata">
 &lt;content&gt;
  &lt;sequence&gt;
   &lt;alternate&gt;
@@ -9268,13 +9436,13 @@ element resp
    maxOccurs="unbounded"/&gt;
  &lt;/sequence&gt;
 &lt;/content&gt;
-    <a href="#index.xml-eg-d31e32380" class="anchorlink">⚓</a></pre>
+    <a href="#index.xml-eg-d31e33215" class="anchorlink">⚓</a></pre>
                            </td>
                         </tr>
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Schema Declaration</span></td>
                            <td class="wovenodd-col2">
-                              <pre id="index.xml-eg-d31e32387" class="pre_eg">
+                              <pre id="index.xml-eg-d31e33222" class="pre_eg">
 element respStmt
 {
    tei_att.global.attributes,
@@ -9286,14 +9454,14 @@ element respStmt
       ),
       tei_note*
    )
-}<a href="#index.xml-eg-d31e32387" class="anchorlink">⚓</a></pre>
+}<a href="#index.xml-eg-d31e33222" class="anchorlink">⚓</a></pre>
                            </td>
                         </tr>
                      </table>
                   </div>
                </div>
                <div class="refdoc" id="TEI.revisionDesc">
-                  <h3><span class="headingNumber">5.1.65. </span><span class="head">&lt;revisionDesc&gt;</span></h3>
+                  <h3><span class="headingNumber">5.1.66. </span><span class="head">&lt;revisionDesc&gt;</span></h3>
                   <div class="table">
                      <table class="wovenodd">
                         <tr>
@@ -9337,7 +9505,7 @@ element respStmt
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Example</span></td>
                            <td class="wovenodd-col2">
-                              <div id="index.xml-egXML-d31e32608" class="pre egXML_valid"><span class="element">&lt;revisionDesc <span class="attribute">status</span>="<span class="attributevalue">embargoed</span>"&gt;</span>
+                              <div id="index.xml-egXML-d31e33444" class="pre egXML_valid"><span class="element">&lt;revisionDesc <span class="attribute">status</span>="<span class="attributevalue">embargoed</span>"&gt;</span>
                                   <span class="element">&lt;change <span class="attribute">when</span>="<span class="attributevalue">1991-11-11</span>" <span class="attribute">who</span>="<span class="attributevalue">#LB</span>"&gt;</span> deleted chapter 10 <span class="element">&lt;/change&gt;</span>
                                  <span class="element">&lt;/revisionDesc&gt;</span></div>
                            </td>
@@ -9345,7 +9513,7 @@ element respStmt
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Content model</span></td>
                            <td class="wovenodd-col2">
-                              <pre id="index.xml-eg-d31e32617" class="pre_eg cdata">
+                              <pre id="index.xml-eg-d31e33453" class="pre_eg cdata">
 &lt;content&gt;
  &lt;alternate&gt;
   &lt;elementRef key="list"/&gt;
@@ -9354,26 +9522,26 @@ element respStmt
    maxOccurs="unbounded"/&gt;
  &lt;/alternate&gt;
 &lt;/content&gt;
-    <a href="#index.xml-eg-d31e32617" class="anchorlink">⚓</a></pre>
+    <a href="#index.xml-eg-d31e33453" class="anchorlink">⚓</a></pre>
                            </td>
                         </tr>
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Schema Declaration</span></td>
                            <td class="wovenodd-col2">
-                              <pre id="index.xml-eg-d31e32624" class="pre_eg">
+                              <pre id="index.xml-eg-d31e33460" class="pre_eg">
 element revisionDesc
 {
    tei_att.global.attributes,
    tei_att.docStatus.attributes,
    ( tei_list | tei_listChange | tei_change+ )
-}<a href="#index.xml-eg-d31e32624" class="anchorlink">⚓</a></pre>
+}<a href="#index.xml-eg-d31e33460" class="anchorlink">⚓</a></pre>
                            </td>
                         </tr>
                      </table>
                   </div>
                </div>
                <div class="refdoc" id="TEI.s">
-                  <h3><span class="headingNumber">5.1.66. </span><span class="head">&lt;s&gt;</span></h3>
+                  <h3><span class="headingNumber">5.1.67. </span><span class="head">&lt;s&gt;</span></h3>
                   <div class="table">
                      <table class="wovenodd">
                         <tr>
@@ -9464,7 +9632,7 @@ element revisionDesc
                                  <div class="specChild"><span class="specChildModule">linking: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.seg" title="&lt;seg&gt;">seg</a></span></div>
                                  <div class="specChild"><span class="specChildModule">namesdates: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.orgName" title="&lt;orgName&gt;">orgName</a> <a class="link_odd_elementSpec" href="#TEI.persName" title="&lt;persName&gt;">persName</a> <a class="link_odd_elementSpec" href="#TEI.placeName" title="&lt;placeName&gt;">placeName</a></span></div>
                                  <div class="specChild"><span class="specChildModule">textcrit: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.app" title="&lt;app&gt;">app</a></span></div>
-                                 <div class="specChild"><span class="specChildModule">transcr: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.fw" title="&lt;fw&gt;">fw</a></span></div>
+                                 <div class="specChild"><span class="specChildModule">transcr: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.fw" title="&lt;fw&gt;">fw</a> <a class="link_odd_elementSpec" href="#TEI.listTranspose" title="&lt;listTranspose&gt;">listTranspose</a></span></div>
                                  <div class="specChild">character data</div>
                               </div>
                            </td>
@@ -9482,7 +9650,7 @@ element revisionDesc
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Example</span></td>
                            <td class="wovenodd-col2">
-                              <div id="index.xml-egXML-d31e33162" class="pre egXML_valid"><span class="element">&lt;head&gt;</span>
+                              <div id="index.xml-egXML-d31e34001" class="pre egXML_valid"><span class="element">&lt;head&gt;</span>
                                   <span class="element">&lt;s&gt;</span>A short affair<span class="element">&lt;/s&gt;</span>
                                  <span class="element">&lt;/head&gt;</span>
                                  <span class="element">&lt;s&gt;</span>When are you leaving?<span class="element">&lt;/s&gt;</span>
@@ -9500,17 +9668,17 @@ element revisionDesc
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Content model</span></td>
                            <td class="wovenodd-col2">
-                              <pre id="index.xml-eg-d31e33179" class="pre_eg cdata">
+                              <pre id="index.xml-eg-d31e34018" class="pre_eg cdata">
 &lt;content&gt;
  &lt;macroRef key="macro.phraseSeq"/&gt;
 &lt;/content&gt;
-    <a href="#index.xml-eg-d31e33179" class="anchorlink">⚓</a></pre>
+    <a href="#index.xml-eg-d31e34018" class="anchorlink">⚓</a></pre>
                            </td>
                         </tr>
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Schema Declaration</span></td>
                            <td class="wovenodd-col2">
-                              <pre id="index.xml-eg-d31e33186" class="pre_eg">
+                              <pre id="index.xml-eg-d31e34025" class="pre_eg">
 element s
 {
    tei_att.global.attribute.xmlid,
@@ -9542,14 +9710,14 @@ element s
       list { ( "bees" | "voice" | "sound" | "music" | "emotion" )+ }
    }?,
    tei_macro.phraseSeq
-}<a href="#index.xml-eg-d31e33186" class="anchorlink">⚓</a></pre>
+}<a href="#index.xml-eg-d31e34025" class="anchorlink">⚓</a></pre>
                            </td>
                         </tr>
                      </table>
                   </div>
                </div>
                <div class="refdoc" id="TEI.seg">
-                  <h3><span class="headingNumber">5.1.67. </span><span class="head">&lt;seg&gt;</span></h3>
+                  <h3><span class="headingNumber">5.1.68. </span><span class="head">&lt;seg&gt;</span></h3>
                   <div class="table">
                      <table class="wovenodd">
                         <tr>
@@ -9601,7 +9769,7 @@ element s
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Member of</span></td>
                            <td class="wovenodd-col2">
-                              <div class="parent"><a class="link_odd_classSpec" href="#TEI.model.segLike" title="model.segLike">model.segLike</a> </div>
+                              <div class="parent"><a class="link_odd_classSpec" href="#TEI.model.segLike" title="model.segLike">model.segLike</a> <a class="link_odd_classSpec" href="#TEI.model.standOffPart" title="model.standOffPart">model.standOffPart</a> </div>
                            </td>
                         </tr>
                         <tr>
@@ -9612,7 +9780,7 @@ element s
                                     <div class="specChild"><span class="specChildModule">analysis: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.s" title="&lt;s&gt;">s</a> <a class="link_odd_elementSpec" href="#TEI.w" title="&lt;w&gt;">w</a></span></div>
                                     <div class="specChild"><span class="specChildModule">core: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.abbr" title="&lt;abbr&gt;">abbr</a> <a class="link_odd_elementSpec" href="#TEI.author" title="&lt;author&gt;">author</a> <a class="link_odd_elementSpec" href="#TEI.bibl" title="&lt;bibl&gt;">bibl</a> <a class="link_odd_elementSpec" href="#TEI.date" title="&lt;date&gt;">date</a> <a class="link_odd_elementSpec" href="#TEI.emph" title="&lt;emph&gt;">emph</a> <a class="link_odd_elementSpec" href="#TEI.foreign" title="&lt;foreign&gt;">foreign</a> <a class="link_odd_elementSpec" href="#TEI.gloss" title="&lt;gloss&gt;">gloss</a> <a class="link_odd_elementSpec" href="#TEI.head" title="&lt;head&gt;">head</a> <a class="link_odd_elementSpec" href="#TEI.hi" title="&lt;hi&gt;">hi</a> <a class="link_odd_elementSpec" href="#TEI.item" title="&lt;item&gt;">item</a> <a class="link_odd_elementSpec" href="#TEI.l" title="&lt;l&gt;">l</a> <a class="link_odd_elementSpec" href="#TEI.name" title="&lt;name&gt;">name</a> <a class="link_odd_elementSpec" href="#TEI.note" title="&lt;note&gt;">note</a> <a class="link_odd_elementSpec" href="#TEI.p" title="&lt;p&gt;">p</a> <a class="link_odd_elementSpec" href="#TEI.pubPlace" title="&lt;pubPlace&gt;">pubPlace</a> <a class="link_odd_elementSpec" href="#TEI.publisher" title="&lt;publisher&gt;">publisher</a> <a class="link_odd_elementSpec" href="#TEI.q" title="&lt;q&gt;">q</a> <a class="link_odd_elementSpec" href="#TEI.quote" title="&lt;quote&gt;">quote</a> <a class="link_odd_elementSpec" href="#TEI.ref" title="&lt;ref&gt;">ref</a> <a class="link_odd_elementSpec" href="#TEI.term" title="&lt;term&gt;">term</a> <a class="link_odd_elementSpec" href="#TEI.title" title="&lt;title&gt;">title</a></span></div>
                                     <div class="specChild"><span class="specChildModule">header: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.change" title="&lt;change&gt;">change</a> <a class="link_odd_elementSpec" href="#TEI.edition" title="&lt;edition&gt;">edition</a> <a class="link_odd_elementSpec" href="#TEI.licence" title="&lt;licence&gt;">licence</a></span></div>
-                                    <div class="specChild"><span class="specChildModule">linking: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.seg" title="&lt;seg&gt;">seg</a></span></div>
+                                    <div class="specChild"><span class="specChildModule">linking: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.seg" title="&lt;seg&gt;">seg</a> <a class="link_odd_elementSpec" href="#TEI.standOff" title="&lt;standOff&gt;">standOff</a></span></div>
                                     <div class="specChild"><span class="specChildModule">namesdates: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.orgName" title="&lt;orgName&gt;">orgName</a> <a class="link_odd_elementSpec" href="#TEI.persName" title="&lt;persName&gt;">persName</a> <a class="link_odd_elementSpec" href="#TEI.placeName" title="&lt;placeName&gt;">placeName</a></span></div>
                                     <div class="specChild"><span class="specChildModule">textcrit: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.lem" title="&lt;lem&gt;">lem</a> <a class="link_odd_elementSpec" href="#TEI.rdg" title="&lt;rdg&gt;">rdg</a></span></div>
                                     <div class="specChild"><span class="specChildModule">textstructure: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.byline" title="&lt;byline&gt;">byline</a> <a class="link_odd_elementSpec" href="#TEI.docImprint" title="&lt;docImprint&gt;">docImprint</a> <a class="link_odd_elementSpec" href="#TEI.imprimatur" title="&lt;imprimatur&gt;">imprimatur</a> <a class="link_odd_elementSpec" href="#TEI.signed" title="&lt;signed&gt;">signed</a> <a class="link_odd_elementSpec" href="#TEI.titlePart" title="&lt;titlePart&gt;">titlePart</a> <a class="link_odd_elementSpec" href="#TEI.trailer" title="&lt;trailer&gt;">trailer</a></span></div>
@@ -9631,7 +9799,7 @@ element s
                                  <div class="specChild"><span class="specChildModule">linking: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.seg" title="&lt;seg&gt;">seg</a></span></div>
                                  <div class="specChild"><span class="specChildModule">namesdates: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.orgName" title="&lt;orgName&gt;">orgName</a> <a class="link_odd_elementSpec" href="#TEI.persName" title="&lt;persName&gt;">persName</a> <a class="link_odd_elementSpec" href="#TEI.placeName" title="&lt;placeName&gt;">placeName</a></span></div>
                                  <div class="specChild"><span class="specChildModule">textcrit: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.app" title="&lt;app&gt;">app</a> <a class="link_odd_elementSpec" href="#TEI.listWit" title="&lt;listWit&gt;">listWit</a></span></div>
-                                 <div class="specChild"><span class="specChildModule">transcr: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.fw" title="&lt;fw&gt;">fw</a></span></div>
+                                 <div class="specChild"><span class="specChildModule">transcr: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.fw" title="&lt;fw&gt;">fw</a> <a class="link_odd_elementSpec" href="#TEI.listTranspose" title="&lt;listTranspose&gt;">listTranspose</a></span></div>
                                  <div class="specChild">character data</div>
                               </div>
                            </td>
@@ -9649,14 +9817,14 @@ element s
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Example</span></td>
                            <td class="wovenodd-col2">
-                              <div id="index.xml-egXML-d31e33877" class="pre egXML_valid"><span class="element">&lt;seg&gt;</span>When are you leaving?<span class="element">&lt;/seg&gt;</span>
+                              <div id="index.xml-egXML-d31e34728" class="pre egXML_valid"><span class="element">&lt;seg&gt;</span>When are you leaving?<span class="element">&lt;/seg&gt;</span>
                                  <span class="element">&lt;seg&gt;</span>Tomorrow.<span class="element">&lt;/seg&gt;</span></div>
                            </td>
                         </tr>
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Example</span></td>
                            <td class="wovenodd-col2">
-                              <div id="index.xml-egXML-d31e33885" class="pre egXML_valid"><span class="element">&lt;s&gt;</span>
+                              <div id="index.xml-egXML-d31e34736" class="pre egXML_valid"><span class="element">&lt;s&gt;</span>
                                   <span class="element">&lt;seg <span class="attribute">rend</span>="<span class="attributevalue">caps</span>" <span class="attribute">type</span>="<span class="attributevalue">initial-cap</span>"&gt;</span>So father's only<span class="element">&lt;/seg&gt;</span> glory was the ballfield. 
                                  <span class="element">&lt;/s&gt;</span></div>
                            </td>
@@ -9664,7 +9832,7 @@ element s
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Example</span></td>
                            <td class="wovenodd-col2">
-                              <div id="index.xml-egXML-d31e33895" class="pre egXML_valid"><span class="element">&lt;seg <span class="attribute">type</span>="<span class="attributevalue">preamble</span>"&gt;</span>
+                              <div id="index.xml-egXML-d31e34746" class="pre egXML_valid"><span class="element">&lt;seg <span class="attribute">type</span>="<span class="attributevalue">preamble</span>"&gt;</span>
                                   <span class="element">&lt;seg&gt;</span>Sigmund, <span class="element">&lt;seg <span class="attribute">type</span>="<span class="attributevalue">patronym</span>"&gt;</span>the son of Volsung<span class="element">&lt;/seg&gt;</span>, was a king in Frankish country.<span class="element">&lt;/seg&gt;</span>
                                   <span class="element">&lt;seg&gt;</span>Sinfiotli was the eldest of his sons ...<span class="element">&lt;/seg&gt;</span>
                                   <span class="element">&lt;seg&gt;</span>Borghild, Sigmund's wife, had a brother ... <span class="element">&lt;/seg&gt;</span>
@@ -9674,17 +9842,17 @@ element s
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Content model</span></td>
                            <td class="wovenodd-col2">
-                              <pre id="index.xml-eg-d31e33909" class="pre_eg cdata">
+                              <pre id="index.xml-eg-d31e34760" class="pre_eg cdata">
 &lt;content&gt;
  &lt;macroRef key="macro.paraContent"/&gt;
 &lt;/content&gt;
-    <a href="#index.xml-eg-d31e33909" class="anchorlink">⚓</a></pre>
+    <a href="#index.xml-eg-d31e34760" class="anchorlink">⚓</a></pre>
                            </td>
                         </tr>
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Schema Declaration</span></td>
                            <td class="wovenodd-col2">
-                              <pre id="index.xml-eg-d31e33917" class="pre_eg">
+                              <pre id="index.xml-eg-d31e34768" class="pre_eg">
 element seg
 {
    tei_att.global.attributes,
@@ -9694,14 +9862,14 @@ element seg
    tei_att.notated.attributes,
    attribute type { "interjection" }?,
    tei_macro.paraContent
-}<a href="#index.xml-eg-d31e33917" class="anchorlink">⚓</a></pre>
+}<a href="#index.xml-eg-d31e34768" class="anchorlink">⚓</a></pre>
                            </td>
                         </tr>
                      </table>
                   </div>
                </div>
                <div class="refdoc" id="TEI.signed">
-                  <h3><span class="headingNumber">5.1.68. </span><span class="head">&lt;signed&gt;</span></h3>
+                  <h3><span class="headingNumber">5.1.69. </span><span class="head">&lt;signed&gt;</span></h3>
                   <div class="table">
                      <table class="wovenodd">
                         <tr>
@@ -9744,7 +9912,7 @@ element seg
                                  <div class="specChild"><span class="specChildModule">linking: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.seg" title="&lt;seg&gt;">seg</a></span></div>
                                  <div class="specChild"><span class="specChildModule">namesdates: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.orgName" title="&lt;orgName&gt;">orgName</a> <a class="link_odd_elementSpec" href="#TEI.persName" title="&lt;persName&gt;">persName</a> <a class="link_odd_elementSpec" href="#TEI.placeName" title="&lt;placeName&gt;">placeName</a></span></div>
                                  <div class="specChild"><span class="specChildModule">textcrit: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.app" title="&lt;app&gt;">app</a> <a class="link_odd_elementSpec" href="#TEI.listWit" title="&lt;listWit&gt;">listWit</a></span></div>
-                                 <div class="specChild"><span class="specChildModule">transcr: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.fw" title="&lt;fw&gt;">fw</a></span></div>
+                                 <div class="specChild"><span class="specChildModule">transcr: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.fw" title="&lt;fw&gt;">fw</a> <a class="link_odd_elementSpec" href="#TEI.listTranspose" title="&lt;listTranspose&gt;">listTranspose</a></span></div>
                                  <div class="specChild">character data</div>
                               </div>
                            </td>
@@ -9752,14 +9920,14 @@ element seg
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Example</span></td>
                            <td class="wovenodd-col2">
-                              <div id="index.xml-egXML-d31e34299" class="pre egXML_valid"><span class="element">&lt;signed&gt;</span>Thine to command <span class="element">&lt;name&gt;</span>Humph. Moseley<span class="element">&lt;/name&gt;</span>
+                              <div id="index.xml-egXML-d31e35154" class="pre egXML_valid"><span class="element">&lt;signed&gt;</span>Thine to command <span class="element">&lt;name&gt;</span>Humph. Moseley<span class="element">&lt;/name&gt;</span>
                                  <span class="element">&lt;/signed&gt;</span></div>
                            </td>
                         </tr>
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Example</span></td>
                            <td class="wovenodd-col2">
-                              <div id="index.xml-egXML-d31e34308" class="pre egXML_valid"><span class="element">&lt;closer&gt;</span>
+                              <div id="index.xml-egXML-d31e35163" class="pre egXML_valid"><span class="element">&lt;closer&gt;</span>
                                   <span class="element">&lt;signed&gt;</span>Sign'd and Seal'd,
                                   <span class="element">&lt;list&gt;</span>
                                     <span class="element">&lt;item&gt;</span>John Bull,<span class="element">&lt;/item&gt;</span>
@@ -9772,30 +9940,30 @@ element seg
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Content model</span></td>
                            <td class="wovenodd-col2">
-                              <pre id="index.xml-eg-d31e34320" class="pre_eg cdata">
+                              <pre id="index.xml-eg-d31e35175" class="pre_eg cdata">
 &lt;content&gt;
  &lt;macroRef key="macro.paraContent"/&gt;
 &lt;/content&gt;
-    <a href="#index.xml-eg-d31e34320" class="anchorlink">⚓</a></pre>
+    <a href="#index.xml-eg-d31e35175" class="anchorlink">⚓</a></pre>
                            </td>
                         </tr>
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Schema Declaration</span></td>
                            <td class="wovenodd-col2">
-                              <pre id="index.xml-eg-d31e34327" class="pre_eg">
+                              <pre id="index.xml-eg-d31e35182" class="pre_eg">
 element signed
 {
    tei_att.global.attributes,
    tei_att.written.attributes,
    tei_macro.paraContent
-}<a href="#index.xml-eg-d31e34327" class="anchorlink">⚓</a></pre>
+}<a href="#index.xml-eg-d31e35182" class="anchorlink">⚓</a></pre>
                            </td>
                         </tr>
                      </table>
                   </div>
                </div>
                <div class="refdoc" id="TEI.sourceDesc">
-                  <h3><span class="headingNumber">5.1.69. </span><span class="head">&lt;sourceDesc&gt;</span></h3>
+                  <h3><span class="headingNumber">5.1.70. </span><span class="head">&lt;sourceDesc&gt;</span></h3>
                   <div class="table">
                      <table class="wovenodd">
                         <tr>
@@ -9833,7 +10001,7 @@ element signed
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Example</span></td>
                            <td class="wovenodd-col2">
-                              <div id="index.xml-egXML-d31e34527" class="pre egXML_valid"><span class="element">&lt;sourceDesc&gt;</span>
+                              <div id="index.xml-egXML-d31e35382" class="pre egXML_valid"><span class="element">&lt;sourceDesc&gt;</span>
                                   <span class="element">&lt;bibl&gt;</span>
                                    <span class="element">&lt;title <span class="attribute">level</span>="<span class="attributevalue">a</span>"&gt;</span>The Interesting story of the Children in the Wood<span class="element">&lt;/title&gt;</span>. In
                                   <span class="element">&lt;author&gt;</span>Victor E Neuberg<span class="element">&lt;/author&gt;</span>, <span class="element">&lt;title&gt;</span>The Penny Histories<span class="element">&lt;/title&gt;</span>.
@@ -9845,7 +10013,7 @@ element signed
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Example</span></td>
                            <td class="wovenodd-col2">
-                              <div id="index.xml-egXML-d31e34545" class="pre egXML_valid"><span class="element">&lt;sourceDesc&gt;</span>
+                              <div id="index.xml-egXML-d31e35400" class="pre egXML_valid"><span class="element">&lt;sourceDesc&gt;</span>
                                   <span class="element">&lt;p&gt;</span>Born digital: no previous source exists.<span class="element">&lt;/p&gt;</span>
                                  <span class="element">&lt;/sourceDesc&gt;</span></div>
                            </td>
@@ -9853,7 +10021,7 @@ element signed
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Content model</span></td>
                            <td class="wovenodd-col2">
-                              <pre id="index.xml-eg-d31e34553" class="pre_eg cdata">
+                              <pre id="index.xml-eg-d31e35408" class="pre_eg cdata">
 &lt;content&gt;
  &lt;alternate&gt;
   &lt;classRef key="model.pLike" minOccurs="1"
@@ -9866,13 +10034,13 @@ element signed
   &lt;/alternate&gt;
  &lt;/alternate&gt;
 &lt;/content&gt;
-    <a href="#index.xml-eg-d31e34553" class="anchorlink">⚓</a></pre>
+    <a href="#index.xml-eg-d31e35408" class="anchorlink">⚓</a></pre>
                            </td>
                         </tr>
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Schema Declaration</span></td>
                            <td class="wovenodd-col2">
-                              <pre id="index.xml-eg-d31e34560" class="pre_eg">
+                              <pre id="index.xml-eg-d31e35415" class="pre_eg">
 element sourceDesc
 {
    tei_att.global.attributes,
@@ -9881,14 +10049,233 @@ element sourceDesc
       tei_model.pLike+
     | ( tei_model.biblLike | tei_model.sourceDescPart | tei_model.listLike )+
    )
-}<a href="#index.xml-eg-d31e34560" class="anchorlink">⚓</a></pre>
+}<a href="#index.xml-eg-d31e35415" class="anchorlink">⚓</a></pre>
+                           </td>
+                        </tr>
+                     </table>
+                  </div>
+               </div>
+               <div class="refdoc" id="TEI.standOff">
+                  <h3><span class="headingNumber">5.1.71. </span><span class="head">&lt;standOff&gt;</span></h3>
+                  <div class="table">
+                     <table class="wovenodd">
+                        <tr>
+                           <td colspan="2" class="wovenodd-col2"><span class="label">&lt;standOff&gt; </span><span xml:lang="en" lang="en">Functions as a container element for linked data, contextual information, and stand-off
+                                 annotations embedded in a TEI document.</span> [<a class="link_ref" href="https://www.tei-c.org/release/doc/tei-p5-doc/en/html/SA.html#SASOstdf">16.10. The standOff Container</a>]</td>
+                        </tr>
+                        <tr>
+                           <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Module</span></td>
+                           <td class="wovenodd-col2">linking</td>
+                        </tr>
+                        <tr>
+                           <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Attributes</span></td>
+                           <td class="wovenodd-col2"><a class="link_ref" href="#TEI.att.global" title="att.global">att.global</a> (<span class="attribute">@xml:id</span>, <span class="attribute">@n</span>, <span class="attribute">@xml:lang</span>, <span class="attribute">@xml:base</span>, <span class="attribute">@xml:space</span>)  (<a class="link_ref" href="#TEI.att.global.rendition" title="att.global.rendition">att.global.rendition</a> (<span class="attribute">@rend</span>, <span class="attribute">@style</span>, <span class="attribute">@rendition</span>)) (<a class="link_ref" href="#TEI.att.global.linking" title="att.global.linking">att.global.linking</a> (<span class="attribute">@corresp</span>, <span class="attribute">@synch</span>, <span class="attribute">@sameAs</span>, <span class="attribute">@copyOf</span>, <span class="attribute">@next</span>, <span class="attribute">@prev</span>, <span class="attribute">@exclude</span>, <span class="attribute">@select</span>)) (<a class="link_ref" href="#TEI.att.global.analytic" title="att.global.analytic">att.global.analytic</a> (<span class="attribute">@ana</span>)) (<a class="link_ref" href="#TEI.att.global.facs" title="att.global.facs">att.global.facs</a> (<span class="attribute">@facs</span>)) (<a class="link_ref" href="#TEI.att.global.change" title="att.global.change">att.global.change</a> (<span class="attribute">@change</span>)) (<a class="link_ref" href="#TEI.att.global.responsibility" title="att.global.responsibility">att.global.responsibility</a> (<span class="attribute">@cert</span>, <span class="attribute">@resp</span>)) (<a class="link_ref" href="#TEI.att.global.source" title="att.global.source">att.global.source</a> (<span class="attribute">@source</span>)) <a class="link_ref" href="#TEI.att.typed" title="att.typed">att.typed</a> (<span class="attribute">@type</span>, <span class="attribute">@subtype</span>) <a class="link_ref" href="#TEI.att.declaring" title="att.declaring">att.declaring</a> (<span class="attribute">@decls</span>) </td>
+                        </tr>
+                        <tr>
+                           <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Member of</span></td>
+                           <td class="wovenodd-col2">
+                              <div class="parent"><a class="link_odd_classSpec" href="#TEI.model.resource" title="model.resource">model.resource</a></div>
+                           </td>
+                        </tr>
+                        <tr>
+                           <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Contained by</span></td>
+                           <td class="wovenodd-col2">
+                              <div class="parent">
+                                 <div class="specChildren">
+                                    <div class="specChild"><span class="specChildModule">textstructure: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.TEI" title="&lt;TEI&gt;">TEI</a></span></div>
+                                 </div>
+                              </div>
+                           </td>
+                        </tr>
+                        <tr>
+                           <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">May contain</span></td>
+                           <td class="wovenodd-col2">
+                              <div class="specChildren">
+                                 <div class="specChild"><span class="specChildModule">core: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.bibl" title="&lt;bibl&gt;">bibl</a> <a class="link_odd_elementSpec" href="#TEI.biblStruct" title="&lt;biblStruct&gt;">biblStruct</a> <a class="link_odd_elementSpec" href="#TEI.list" title="&lt;list&gt;">list</a> <a class="link_odd_elementSpec" href="#TEI.listBibl" title="&lt;listBibl&gt;">listBibl</a> <a class="link_odd_elementSpec" href="#TEI.note" title="&lt;note&gt;">note</a></span></div>
+                                 <div class="specChild"><span class="specChildModule">header: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.listChange" title="&lt;listChange&gt;">listChange</a></span></div>
+                                 <div class="specChild"><span class="specChildModule">linking: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.seg" title="&lt;seg&gt;">seg</a></span></div>
+                                 <div class="specChild"><span class="specChildModule">textcrit: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.listWit" title="&lt;listWit&gt;">listWit</a></span></div>
+                                 <div class="specChild"><span class="specChildModule">transcr: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.listTranspose" title="&lt;listTranspose&gt;">listTranspose</a></span></div>
+                              </div>
+                           </td>
+                        </tr>
+                        <tr>
+                           <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Example</span></td>
+                           <td class="wovenodd-col2">This example shows an encoding of morphosyntactic features similar to the encoding
+                              system used by ISO 24611 (MAF).
+                              <div id="index.xml-egXML-d31e35663" class="pre egXML_feasible"><span class="element">&lt;TEI xmlns="http://www.tei-c.org/ns/1.0"&gt;</span>
+                                  <span class="element">&lt;teiHeader&gt;</span>
+                                 <span class="comment">&lt;!-- ... --&gt;</span>
+                                  <span class="element">&lt;/teiHeader&gt;</span>
+                                  <span class="element">&lt;text&gt;</span>
+                                   <span class="element">&lt;body&gt;</span>
+                                 <span class="comment">&lt;!-- ... --&gt;</span>
+                                    <span class="element">&lt;p&gt;</span>
+                                     <span class="element">&lt;w <span class="attribute">xml:id</span>="<span class="attributevalue">w51</span>"&gt;</span>I<span class="element">&lt;/w&gt;</span>
+                                     <span class="element">&lt;w <span class="attribute">xml:id</span>="<span class="attributevalue">w52</span>"&gt;</span>wanna<span class="element">&lt;/w&gt;</span>
+                                     <span class="element">&lt;w <span class="attribute">xml:id</span>="<span class="attributevalue">w53</span>"&gt;</span>put<span class="element">&lt;/w&gt;</span>
+                                     <span class="element">&lt;w <span class="attribute">xml:id</span>="<span class="attributevalue">w54</span>"&gt;</span>up<span class="element">&lt;/w&gt;</span>
+                                     <span class="element">&lt;w <span class="attribute">xml:id</span>="<span class="attributevalue">w55</span>"&gt;</span>new<span class="element">&lt;/w&gt;</span>
+                                     <span class="element">&lt;w <span class="attribute">xml:id</span>="<span class="attributevalue">w56</span>"&gt;</span>wallpaper<span class="element">&lt;/w&gt;</span>
+                                     <span class="element">&lt;pc&gt;</span>.<span class="element">&lt;/pc&gt;</span>
+                                    <span class="element">&lt;/p&gt;</span>
+                                 <span class="comment">&lt;!-- ... --&gt;</span>
+                                   <span class="element">&lt;/body&gt;</span>
+                                  <span class="element">&lt;/text&gt;</span>
+                                  <span class="element">&lt;standOff <span class="attribute">type</span>="<span class="attributevalue">morphosyntax</span>"&gt;</span>
+                                   <span class="element">&lt;spanGrp <span class="attribute">type</span>="<span class="attributevalue">wordForm</span>"&gt;</span>
+                                    <span class="element">&lt;span <span class="attribute">target</span>="<span class="attributevalue">#w51</span>" <span class="attribute">ana</span>="<span class="attributevalue">#fs01</span>"/&gt;</span>
+                                    <span class="element">&lt;span <span class="attribute">target</span>="<span class="attributevalue">#w52</span>" <span class="attribute">ana</span>="<span class="attributevalue">#fs02</span>"/&gt;</span>
+                                    <span class="element">&lt;span <span class="attribute">target</span>="<span class="attributevalue">#w52</span>" <span class="attribute">ana</span>="<span class="attributevalue">#fs03</span>"/&gt;</span>
+                                    <span class="element">&lt;span <span class="attribute">target</span>="<span class="attributevalue">#w53 #w54</span>" <span class="attribute">ana</span>="<span class="attributevalue">#fs04</span>"/&gt;</span>
+                                    <span class="element">&lt;span <span class="attribute">target</span>="<span class="attributevalue">#w55</span>" <span class="attribute">ana</span>="<span class="attributevalue">#fs05</span>"/&gt;</span>
+                                    <span class="element">&lt;span <span class="attribute">target</span>="<span class="attributevalue">#w56</span>" <span class="attribute">ana</span>="<span class="attributevalue">#fs06</span>"/&gt;</span>
+                                   <span class="element">&lt;/spanGrp&gt;</span>
+                                   <span class="element">&lt;fs <span class="attribute">xml:id</span>="<span class="attributevalue">fs01</span>"&gt;</span>
+                                    <span class="element">&lt;f <span class="attribute">name</span>="<span class="attributevalue">lemma</span>"&gt;</span>
+                                     <span class="element">&lt;string&gt;</span>I<span class="element">&lt;/string&gt;</span>
+                                    <span class="element">&lt;/f&gt;</span>
+                                    <span class="element">&lt;f <span class="attribute">name</span>="<span class="attributevalue">pos</span>"&gt;</span>
+                                     <span class="element">&lt;symbol <span class="attribute">value</span>="<span class="attributevalue">PP</span>"/&gt;</span>
+                                    <span class="element">&lt;/f&gt;</span>
+                                   <span class="element">&lt;/fs&gt;</span>
+                                   <span class="element">&lt;fs <span class="attribute">xml:id</span>="<span class="attributevalue">fs02</span>"&gt;</span>
+                                    <span class="element">&lt;f <span class="attribute">name</span>="<span class="attributevalue">lemma</span>"&gt;</span>
+                                     <span class="element">&lt;string&gt;</span>want<span class="element">&lt;/string&gt;</span>
+                                    <span class="element">&lt;/f&gt;</span>
+                                    <span class="element">&lt;f <span class="attribute">name</span>="<span class="attributevalue">pos</span>"&gt;</span>
+                                     <span class="element">&lt;symbol <span class="attribute">value</span>="<span class="attributevalue">VBP</span>"/&gt;</span>
+                                    <span class="element">&lt;/f&gt;</span>
+                                   <span class="element">&lt;/fs&gt;</span>
+                                   <span class="element">&lt;fs <span class="attribute">xml:id</span>="<span class="attributevalue">fs03</span>"&gt;</span>
+                                    <span class="element">&lt;f <span class="attribute">name</span>="<span class="attributevalue">lemma</span>"&gt;</span>
+                                     <span class="element">&lt;string&gt;</span>to<span class="element">&lt;/string&gt;</span>
+                                    <span class="element">&lt;/f&gt;</span>
+                                    <span class="element">&lt;f <span class="attribute">name</span>="<span class="attributevalue">pos</span>"&gt;</span>
+                                     <span class="element">&lt;symbol <span class="attribute">value</span>="<span class="attributevalue">TO</span>"/&gt;</span>
+                                    <span class="element">&lt;/f&gt;</span>
+                                   <span class="element">&lt;/fs&gt;</span>
+                                   <span class="element">&lt;fs <span class="attribute">xml:id</span>="<span class="attributevalue">fs04</span>"&gt;</span>
+                                    <span class="element">&lt;f <span class="attribute">name</span>="<span class="attributevalue">lemma</span>"&gt;</span>
+                                     <span class="element">&lt;string&gt;</span>put up<span class="element">&lt;/string&gt;</span>
+                                    <span class="element">&lt;/f&gt;</span>
+                                    <span class="element">&lt;f <span class="attribute">name</span>="<span class="attributevalue">pos</span>"&gt;</span>
+                                     <span class="element">&lt;symbol <span class="attribute">value</span>="<span class="attributevalue">VB</span>"/&gt;</span>
+                                    <span class="element">&lt;/f&gt;</span>
+                                   <span class="element">&lt;/fs&gt;</span>
+                                   <span class="element">&lt;fs <span class="attribute">xml:id</span>="<span class="attributevalue">fs05</span>"&gt;</span>
+                                    <span class="element">&lt;f <span class="attribute">name</span>="<span class="attributevalue">lemma</span>"&gt;</span>
+                                     <span class="element">&lt;string&gt;</span>new<span class="element">&lt;/string&gt;</span>
+                                    <span class="element">&lt;/f&gt;</span>
+                                    <span class="element">&lt;f <span class="attribute">name</span>="<span class="attributevalue">pos</span>"&gt;</span>
+                                     <span class="element">&lt;symbol <span class="attribute">value</span>="<span class="attributevalue">JJ</span>"/&gt;</span>
+                                    <span class="element">&lt;/f&gt;</span>
+                                   <span class="element">&lt;/fs&gt;</span>
+                                   <span class="element">&lt;fs <span class="attribute">xml:id</span>="<span class="attributevalue">fs06</span>"&gt;</span>
+                                    <span class="element">&lt;f <span class="attribute">name</span>="<span class="attributevalue">lemma</span>"&gt;</span>
+                                     <span class="element">&lt;string&gt;</span>wallpaper<span class="element">&lt;/string&gt;</span>
+                                    <span class="element">&lt;/f&gt;</span>
+                                    <span class="element">&lt;f <span class="attribute">name</span>="<span class="attributevalue">pos</span>"&gt;</span>
+                                     <span class="element">&lt;symbol <span class="attribute">value</span>="<span class="attributevalue">NN</span>"/&gt;</span>
+                                    <span class="element">&lt;/f&gt;</span>
+                                   <span class="element">&lt;/fs&gt;</span>
+                                  <span class="element">&lt;/standOff&gt;</span>
+                                 <span class="element">&lt;/TEI&gt;</span></div>
+                           </td>
+                        </tr>
+                        <tr>
+                           <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Example</span></td>
+                           <td class="wovenodd-col2">This example shows an encoding of contextual information which is referred to from
+                              the main text.
+                              <div id="index.xml-egXML-d31e35729" class="pre egXML_feasible"><span class="element">&lt;TEI xmlns="http://www.tei-c.org/ns/1.0"&gt;</span>
+                                  <span class="element">&lt;teiHeader&gt;</span>
+                                 <span class="comment">&lt;!-- ... --&gt;</span>
+                                  <span class="element">&lt;/teiHeader&gt;</span>
+                                  <span class="element">&lt;standOff&gt;</span>
+                                   <span class="element">&lt;listPlace&gt;</span>
+                                    <span class="element">&lt;place <span class="attribute">xml:id</span>="<span class="attributevalue">LATL</span>"&gt;</span>
+                                     <span class="element">&lt;placeName&gt;</span>Atlanta<span class="element">&lt;/placeName&gt;</span>
+                                     <span class="element">&lt;location&gt;</span>
+                                      <span class="element">&lt;region <span class="attribute">key</span>="<span class="attributevalue">US-GA</span>"&gt;</span>Georgia<span class="element">&lt;/region&gt;</span>
+                                      <span class="element">&lt;country <span class="attribute">key</span>="<span class="attributevalue">USA</span>"&gt;</span>United States of America<span class="element">&lt;/country&gt;</span>
+                                      <span class="element">&lt;geo&gt;</span>33.755 -84.39<span class="element">&lt;/geo&gt;</span>
+                                     <span class="element">&lt;/location&gt;</span>
+                                     <span class="element">&lt;population <span class="attribute">when</span>="<span class="attributevalue">1963</span>"
+                                         <span class="attribute">type</span>="<span class="attributevalue">interpolatedCensus</span>" <span class="attribute">quantity</span>="<span class="attributevalue">489359</span>"
+                                         <span class="attribute">source</span>="<span class="attributevalue">https://www.biggestuscities.com/city/atlanta-georgia</span>"/&gt;</span>
+                                    <span class="element">&lt;/place&gt;</span>
+                                    <span class="element">&lt;place <span class="attribute">xml:id</span>="<span class="attributevalue">LBHM</span>"&gt;</span>
+                                     <span class="element">&lt;placeName&gt;</span>Birmingham<span class="element">&lt;/placeName&gt;</span>
+                                     <span class="element">&lt;location&gt;</span>
+                                      <span class="element">&lt;region <span class="attribute">key</span>="<span class="attributevalue">US-AL</span>"&gt;</span>Alabama<span class="element">&lt;/region&gt;</span>
+                                      <span class="element">&lt;country <span class="attribute">key</span>="<span class="attributevalue">USA</span>"&gt;</span>United States of America<span class="element">&lt;/country&gt;</span>
+                                      <span class="element">&lt;geo&gt;</span>33.653333 -86.808889<span class="element">&lt;/geo&gt;</span>
+                                     <span class="element">&lt;/location&gt;</span>
+                                     <span class="element">&lt;population <span class="attribute">when</span>="<span class="attributevalue">1963</span>"
+                                         <span class="attribute">type</span>="<span class="attributevalue">interpolatedCensus</span>" <span class="attribute">quantity</span>="<span class="attributevalue">332891</span>"
+                                         <span class="attribute">source</span>="<span class="attributevalue">https://www.biggestuscities.com/city/birmingham-alabama</span>"/&gt;</span>
+                                    <span class="element">&lt;/place&gt;</span>
+                                   <span class="element">&lt;/listPlace&gt;</span>
+                                  <span class="element">&lt;/standOff&gt;</span>
+                                  <span class="element">&lt;text&gt;</span>
+                                   <span class="element">&lt;body&gt;</span>
+                                 <span class="comment">&lt;!-- ... --&gt;</span>
+                                    <span class="element">&lt;p&gt;</span>Moreover, I am <span class="element">&lt;choice&gt;</span>
+                                      <span class="element">&lt;sic&gt;</span>congnizant<span class="element">&lt;/sic&gt;</span>
+                                      <span class="element">&lt;corr&gt;</span>cognizant<span class="element">&lt;/corr&gt;</span>
+                                     <span class="element">&lt;/choice&gt;</span> of the interrelatedness of all communities and
+                                    <span class="element">&lt;lb/&gt;</span>states. I cannot sit idly by in <span class="element">&lt;placeName <span class="attribute">ref</span>="<span class="attributevalue">#LATL</span>"&gt;</span>Atlanta<span class="element">&lt;/placeName&gt;</span> and not be concerned about what happens
+                                    <span class="element">&lt;lb/&gt;</span>in <span class="element">&lt;placeName <span class="attribute">ref</span>="<span class="attributevalue">#LBHM</span>"&gt;</span>Birmingham<span class="element">&lt;/placeName&gt;</span>. <span class="element">&lt;seg <span class="attribute">xml:id</span>="<span class="attributevalue">FQ17</span>"&gt;</span>Injustice anywhere is a threat to justice everywhere.<span class="element">&lt;/seg&gt;</span> We
+                                    <span class="element">&lt;lb/&gt;</span>are caught in an inescapable network of mutuality, tied in a single garment
+                                    <span class="element">&lt;lb/&gt;</span>of destiny. Whatever affects one directly affects all indirectly. Never
+                                    <span class="element">&lt;lb/&gt;</span>again can we afford to live with the narrow, provincial <span class="element">&lt;soCalled <span class="attribute">rendition</span>="<span class="attributevalue">#Rqms</span>"&gt;</span>outside agitator<span class="element">&lt;/soCalled&gt;</span>
+                                     <span class="element">&lt;lb/&gt;</span>idea. Anyone who lives inside the United States can never be considered
+                                    <span class="element">&lt;lb/&gt;</span>an outsider anywhere in this country.<span class="element">&lt;/p&gt;</span>
+                                 <span class="comment">&lt;!-- ... --&gt;</span>
+                                   <span class="element">&lt;/body&gt;</span>
+                                  <span class="element">&lt;/text&gt;</span>
+                                 <span class="element">&lt;/TEI&gt;</span></div>
+                           </td>
+                        </tr>
+                        <tr>
+                           <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Schematron</span></td>
+                           <td class="wovenodd-col2">
+                              <div class="pre">
+                                 &lt;sch:assert test="@type or not(ancestor::tei:standOff)"&gt;This
+                                 &lt;sch:name/&gt; element must have a @type attribute, since it is
+                                 nested inside a &lt;sch:name/&gt;
+                                 &lt;/sch:assert&gt;</div>
+                           </td>
+                        </tr>
+                        <tr>
+                           <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Content model</span></td>
+                           <td class="wovenodd-col2">
+                              <pre id="index.xml-eg-d31e35802" class="pre_eg cdata">
+&lt;content&gt;
+ &lt;classRef key="model.standOffPart"
+  minOccurs="1" maxOccurs="unbounded"/&gt;
+&lt;/content&gt;
+    <a href="#index.xml-eg-d31e35802" class="anchorlink">⚓</a></pre>
+                           </td>
+                        </tr>
+                        <tr>
+                           <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Schema Declaration</span></td>
+                           <td class="wovenodd-col2">
+                              <pre id="index.xml-eg-d31e35809" class="pre_eg">
+element standOff
+{
+   tei_att.global.attributes,
+   tei_att.typed.attributes,
+   tei_att.declaring.attributes,
+   tei_model.standOffPart+
+}<a href="#index.xml-eg-d31e35809" class="anchorlink">⚓</a></pre>
                            </td>
                         </tr>
                      </table>
                   </div>
                </div>
                <div class="refdoc" id="TEI.teiHeader">
-                  <h3><span class="headingNumber">5.1.70. </span><span class="head">&lt;teiHeader&gt;</span></h3>
+                  <h3><span class="headingNumber">5.1.72. </span><span class="head">&lt;teiHeader&gt;</span></h3>
                   <div class="table">
                      <table class="wovenodd">
                         <tr>
@@ -9930,7 +10317,7 @@ element sourceDesc
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Example</span></td>
                            <td class="wovenodd-col2">
-                              <div id="index.xml-egXML-d31e34759" class="pre egXML_valid"><span class="element">&lt;teiHeader&gt;</span>
+                              <div id="index.xml-egXML-d31e36001" class="pre egXML_valid"><span class="element">&lt;teiHeader&gt;</span>
                                   <span class="element">&lt;fileDesc&gt;</span>
                                    <span class="element">&lt;titleStmt&gt;</span>
                                     <span class="element">&lt;title&gt;</span>Shakespeare: the first folio (1623) in electronic form<span class="element">&lt;/title&gt;</span>
@@ -10008,7 +10395,7 @@ element sourceDesc
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Content model</span></td>
                            <td class="wovenodd-col2">
-                              <pre id="index.xml-eg-d31e34828" class="pre_eg cdata">
+                              <pre id="index.xml-eg-d31e36070" class="pre_eg cdata">
 &lt;content&gt;
  &lt;sequence&gt;
   &lt;elementRef key="fileDesc"/&gt;
@@ -10018,25 +10405,25 @@ element sourceDesc
    minOccurs="0"/&gt;
  &lt;/sequence&gt;
 &lt;/content&gt;
-    <a href="#index.xml-eg-d31e34828" class="anchorlink">⚓</a></pre>
+    <a href="#index.xml-eg-d31e36070" class="anchorlink">⚓</a></pre>
                            </td>
                         </tr>
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Schema Declaration</span></td>
                            <td class="wovenodd-col2">
-                              <pre id="index.xml-eg-d31e34835" class="pre_eg">
+                              <pre id="index.xml-eg-d31e36077" class="pre_eg">
 element teiHeader
 {
    tei_att.global.attributes,
    ( tei_fileDesc, tei_model.teiHeaderPart*, tei_revisionDesc? )
-}<a href="#index.xml-eg-d31e34835" class="anchorlink">⚓</a></pre>
+}<a href="#index.xml-eg-d31e36077" class="anchorlink">⚓</a></pre>
                            </td>
                         </tr>
                      </table>
                   </div>
                </div>
                <div class="refdoc" id="TEI.term">
-                  <h3><span class="headingNumber">5.1.71. </span><span class="head">&lt;term&gt;</span></h3>
+                  <h3><span class="headingNumber">5.1.73. </span><span class="head">&lt;term&gt;</span></h3>
                   <div class="table">
                      <table class="wovenodd">
                         <tr>
@@ -10085,7 +10472,7 @@ element teiHeader
                                  <div class="specChild"><span class="specChildModule">linking: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.seg" title="&lt;seg&gt;">seg</a></span></div>
                                  <div class="specChild"><span class="specChildModule">namesdates: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.orgName" title="&lt;orgName&gt;">orgName</a> <a class="link_odd_elementSpec" href="#TEI.persName" title="&lt;persName&gt;">persName</a> <a class="link_odd_elementSpec" href="#TEI.placeName" title="&lt;placeName&gt;">placeName</a></span></div>
                                  <div class="specChild"><span class="specChildModule">textcrit: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.app" title="&lt;app&gt;">app</a></span></div>
-                                 <div class="specChild"><span class="specChildModule">transcr: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.fw" title="&lt;fw&gt;">fw</a></span></div>
+                                 <div class="specChild"><span class="specChildModule">transcr: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.fw" title="&lt;fw&gt;">fw</a> <a class="link_odd_elementSpec" href="#TEI.listTranspose" title="&lt;listTranspose&gt;">listTranspose</a></span></div>
                                  <div class="specChild">character data</div>
                               </div>
                            </td>
@@ -10108,7 +10495,7 @@ element teiHeader
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Example</span></td>
                            <td class="wovenodd-col2">
-                              <div id="index.xml-egXML-d31e35450" class="pre egXML_valid">A computational device that infers structure
+                              <div id="index.xml-egXML-d31e36696" class="pre egXML_valid">A computational device that infers structure
                                   from grammatical strings of words is known as a <span class="element">&lt;term&gt;</span>parser<span class="element">&lt;/term&gt;</span>, and much of the history
                                   of NLP over the last 20 years has been occupied with the design of parsers.</div>
                            </td>
@@ -10116,7 +10503,7 @@ element teiHeader
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Example</span></td>
                            <td class="wovenodd-col2">
-                              <div id="index.xml-egXML-d31e35459" class="pre egXML_valid">We may define <span class="element">&lt;term <span class="attribute">xml:id</span>="<span class="attributevalue">TDPV1</span>" <span class="attribute">rend</span>="<span class="attributevalue">sc</span>"&gt;</span>discoursal point of view<span class="element">&lt;/term&gt;</span> as 
+                              <div id="index.xml-egXML-d31e36705" class="pre egXML_valid">We may define <span class="element">&lt;term <span class="attribute">xml:id</span>="<span class="attributevalue">TDPV1</span>" <span class="attribute">rend</span>="<span class="attributevalue">sc</span>"&gt;</span>discoursal point of view<span class="element">&lt;/term&gt;</span> as 
                                  <span class="element">&lt;gloss <span class="attribute">target</span>="<span class="attributevalue">#TDPV1</span>"&gt;</span>the relationship, expressed
                                   through discourse structure, between the implied author or some other addresser, and
                                  the
@@ -10126,7 +10513,7 @@ element teiHeader
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Example</span></td>
                            <td class="wovenodd-col2">
-                              <div id="index.xml-egXML-d31e35471" class="pre egXML_valid">We may define <span class="element">&lt;term <span class="attribute">ref</span>="<span class="attributevalue">#TDPV2</span>" <span class="attribute">rend</span>="<span class="attributevalue">sc</span>"&gt;</span>discoursal point of view<span class="element">&lt;/term&gt;</span> as 
+                              <div id="index.xml-egXML-d31e36717" class="pre egXML_valid">We may define <span class="element">&lt;term <span class="attribute">ref</span>="<span class="attributevalue">#TDPV2</span>" <span class="attribute">rend</span>="<span class="attributevalue">sc</span>"&gt;</span>discoursal point of view<span class="element">&lt;/term&gt;</span> as 
                                  <span class="element">&lt;gloss <span class="attribute">xml:id</span>="<span class="attributevalue">TDPV2</span>"&gt;</span>the relationship, expressed
                                   through discourse structure, between the implied author or some other addresser, and
                                  the
@@ -10136,23 +10523,23 @@ element teiHeader
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Example</span></td>
                            <td class="wovenodd-col2">
-                              <div id="index.xml-egXML-d31e35483" class="pre egXML_valid">We discuss Leech's concept of <span class="element">&lt;term <span class="attribute">ref</span>="<span class="attributevalue">myGlossary.xml#TDPV2</span>" <span class="attribute">rend</span>="<span class="attributevalue">sc</span>"&gt;</span>discoursal point of view<span class="element">&lt;/term&gt;</span> below. </div>
+                              <div id="index.xml-egXML-d31e36729" class="pre egXML_valid">We discuss Leech's concept of <span class="element">&lt;term <span class="attribute">ref</span>="<span class="attributevalue">myGlossary.xml#TDPV2</span>" <span class="attribute">rend</span>="<span class="attributevalue">sc</span>"&gt;</span>discoursal point of view<span class="element">&lt;/term&gt;</span> below. </div>
                            </td>
                         </tr>
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Content model</span></td>
                            <td class="wovenodd-col2">
-                              <pre id="index.xml-eg-d31e35494" class="pre_eg cdata">
+                              <pre id="index.xml-eg-d31e36740" class="pre_eg cdata">
 &lt;content&gt;
  &lt;macroRef key="macro.phraseSeq"/&gt;
 &lt;/content&gt;
-    <a href="#index.xml-eg-d31e35494" class="anchorlink">⚓</a></pre>
+    <a href="#index.xml-eg-d31e36740" class="anchorlink">⚓</a></pre>
                            </td>
                         </tr>
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Schema Declaration</span></td>
                            <td class="wovenodd-col2">
-                              <pre id="index.xml-eg-d31e35501" class="pre_eg">
+                              <pre id="index.xml-eg-d31e36747" class="pre_eg">
 element term
 {
    tei_att.global.attributes,
@@ -10163,14 +10550,14 @@ element term
    tei_att.sortable.attributes,
    tei_att.cReferencing.attributes,
    tei_macro.phraseSeq
-}<a href="#index.xml-eg-d31e35501" class="anchorlink">⚓</a></pre>
+}<a href="#index.xml-eg-d31e36747" class="anchorlink">⚓</a></pre>
                            </td>
                         </tr>
                      </table>
                   </div>
                </div>
                <div class="refdoc" id="TEI.text">
-                  <h3><span class="headingNumber">5.1.72. </span><span class="head">&lt;text&gt;</span></h3>
+                  <h3><span class="headingNumber">5.1.74. </span><span class="head">&lt;text&gt;</span></h3>
                   <div class="table">
                      <table class="wovenodd">
                         <tr>
@@ -10209,7 +10596,7 @@ element term
                                  <div class="specChild"><span class="specChildModule">figures: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.figure" title="&lt;figure&gt;">figure</a></span></div>
                                  <div class="specChild"><span class="specChildModule">textcrit: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.app" title="&lt;app&gt;">app</a></span></div>
                                  <div class="specChild"><span class="specChildModule">textstructure: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.back" title="&lt;back&gt;">back</a> <a class="link_odd_elementSpec" href="#TEI.body" title="&lt;body&gt;">body</a> <a class="link_odd_elementSpec" href="#TEI.front" title="&lt;front&gt;">front</a></span></div>
-                                 <div class="specChild"><span class="specChildModule">transcr: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.fw" title="&lt;fw&gt;">fw</a></span></div>
+                                 <div class="specChild"><span class="specChildModule">transcr: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.fw" title="&lt;fw&gt;">fw</a> <a class="link_odd_elementSpec" href="#TEI.listTranspose" title="&lt;listTranspose&gt;">listTranspose</a></span></div>
                               </div>
                            </td>
                         </tr>
@@ -10224,7 +10611,7 @@ element term
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Example</span></td>
                            <td class="wovenodd-col2">
-                              <div id="index.xml-egXML-d31e35780" class="pre egXML_valid"><span class="element">&lt;text&gt;</span>
+                              <div id="index.xml-egXML-d31e37030" class="pre egXML_valid"><span class="element">&lt;text&gt;</span>
                                   <span class="element">&lt;front&gt;</span>
                                    <span class="element">&lt;docTitle&gt;</span>
                                     <span class="element">&lt;titlePart&gt;</span>Autumn Haze<span class="element">&lt;/titlePart&gt;</span>
@@ -10241,7 +10628,7 @@ element term
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Example</span></td>
                            <td class="wovenodd-col2">The body of a text may be replaced by a group of nested texts, as in the following
                               schematic:
-                              <div id="index.xml-egXML-d31e35794" class="pre egXML_feasible"><span class="element">&lt;text&gt;</span>
+                              <div id="index.xml-egXML-d31e37044" class="pre egXML_feasible"><span class="element">&lt;text&gt;</span>
                                   <span class="element">&lt;front&gt;</span>
                                  <span class="comment">&lt;!-- front matter for the whole group --&gt;</span>
                                   <span class="element">&lt;/front&gt;</span>
@@ -10259,7 +10646,7 @@ element term
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Content model</span></td>
                            <td class="wovenodd-col2">
-                              <pre id="index.xml-eg-d31e35808" class="pre_eg cdata">
+                              <pre id="index.xml-eg-d31e37058" class="pre_eg cdata">
 &lt;content&gt;
  &lt;sequence&gt;
   &lt;classRef key="model.global"
@@ -10282,13 +10669,13 @@ element term
   &lt;/sequence&gt;
  &lt;/sequence&gt;
 &lt;/content&gt;
-    <a href="#index.xml-eg-d31e35808" class="anchorlink">⚓</a></pre>
+    <a href="#index.xml-eg-d31e37058" class="anchorlink">⚓</a></pre>
                            </td>
                         </tr>
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Schema Declaration</span></td>
                            <td class="wovenodd-col2">
-                              <pre id="index.xml-eg-d31e35815" class="pre_eg">
+                              <pre id="index.xml-eg-d31e37065" class="pre_eg">
 element text
 {
    tei_att.global.attributes,
@@ -10302,14 +10689,14 @@ element text
       tei_model.global*,
       ( tei_back, tei_model.global* )?
    )
-}<a href="#index.xml-eg-d31e35815" class="anchorlink">⚓</a></pre>
+}<a href="#index.xml-eg-d31e37065" class="anchorlink">⚓</a></pre>
                            </td>
                         </tr>
                      </table>
                   </div>
                </div>
                <div class="refdoc" id="TEI.title">
-                  <h3><span class="headingNumber">5.1.73. </span><span class="head">&lt;title&gt;</span></h3>
+                  <h3><span class="headingNumber">5.1.75. </span><span class="head">&lt;title&gt;</span></h3>
                   <div class="table">
                      <table class="wovenodd">
                         <tr>
@@ -10455,7 +10842,7 @@ element text
                                  <div class="specChild"><span class="specChildModule">linking: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.seg" title="&lt;seg&gt;">seg</a></span></div>
                                  <div class="specChild"><span class="specChildModule">namesdates: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.orgName" title="&lt;orgName&gt;">orgName</a> <a class="link_odd_elementSpec" href="#TEI.persName" title="&lt;persName&gt;">persName</a> <a class="link_odd_elementSpec" href="#TEI.placeName" title="&lt;placeName&gt;">placeName</a></span></div>
                                  <div class="specChild"><span class="specChildModule">textcrit: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.app" title="&lt;app&gt;">app</a> <a class="link_odd_elementSpec" href="#TEI.listWit" title="&lt;listWit&gt;">listWit</a></span></div>
-                                 <div class="specChild"><span class="specChildModule">transcr: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.fw" title="&lt;fw&gt;">fw</a></span></div>
+                                 <div class="specChild"><span class="specChildModule">transcr: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.fw" title="&lt;fw&gt;">fw</a> <a class="link_odd_elementSpec" href="#TEI.listTranspose" title="&lt;listTranspose&gt;">listTranspose</a></span></div>
                                  <div class="specChild">character data</div>
                               </div>
                            </td>
@@ -10471,7 +10858,7 @@ element text
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Example</span></td>
                            <td class="wovenodd-col2">
-                              <div id="index.xml-egXML-d31e36683" class="pre egXML_valid"><span class="element">&lt;title&gt;</span>Information Technology and the Research Process: Proceedings of
+                              <div id="index.xml-egXML-d31e37937" class="pre egXML_valid"><span class="element">&lt;title&gt;</span>Information Technology and the Research Process: Proceedings of
                                   a conference held at Cranfield Institute of Technology, UK,
                                   18–21 July 1989<span class="element">&lt;/title&gt;</span></div>
                            </td>
@@ -10479,14 +10866,14 @@ element text
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Example</span></td>
                            <td class="wovenodd-col2">
-                              <div id="index.xml-egXML-d31e36690" class="pre egXML_valid"><span class="element">&lt;title&gt;</span>Hardy's Tess of the D'Urbervilles: a machine readable
+                              <div id="index.xml-egXML-d31e37944" class="pre egXML_valid"><span class="element">&lt;title&gt;</span>Hardy's Tess of the D'Urbervilles: a machine readable
                                   edition<span class="element">&lt;/title&gt;</span></div>
                            </td>
                         </tr>
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Example</span></td>
                            <td class="wovenodd-col2">
-                              <div id="index.xml-egXML-d31e36697" class="pre egXML_valid"><span class="element">&lt;title <span class="attribute">type</span>="<span class="attributevalue">full</span>"&gt;</span>
+                              <div id="index.xml-egXML-d31e37951" class="pre egXML_valid"><span class="element">&lt;title <span class="attribute">type</span>="<span class="attributevalue">full</span>"&gt;</span>
                                   <span class="element">&lt;title <span class="attribute">type</span>="<span class="attributevalue">main</span>"&gt;</span>Synthèse<span class="element">&lt;/title&gt;</span>
                                   <span class="element">&lt;title <span class="attribute">type</span>="<span class="attributevalue">sub</span>"&gt;</span>an international journal for
                                     epistemology, methodology and history of
@@ -10497,17 +10884,17 @@ element text
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Content model</span></td>
                            <td class="wovenodd-col2">
-                              <pre id="index.xml-eg-d31e36708" class="pre_eg cdata">
+                              <pre id="index.xml-eg-d31e37962" class="pre_eg cdata">
 &lt;content&gt;
  &lt;macroRef key="macro.paraContent"/&gt;
 &lt;/content&gt;
-    <a href="#index.xml-eg-d31e36708" class="anchorlink">⚓</a></pre>
+    <a href="#index.xml-eg-d31e37962" class="anchorlink">⚓</a></pre>
                            </td>
                         </tr>
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Schema Declaration</span></td>
                            <td class="wovenodd-col2">
-                              <pre id="index.xml-eg-d31e36716" class="pre_eg">
+                              <pre id="index.xml-eg-d31e37970" class="pre_eg">
 element title
 {
    tei_att.global.attributes,
@@ -10517,14 +10904,14 @@ element title
    attribute type { text }?,
    attribute level { "a" | "m" | "j" | "s" | "u" }?,
    tei_macro.paraContent
-}<a href="#index.xml-eg-d31e36716" class="anchorlink">⚓</a></pre>
+}<a href="#index.xml-eg-d31e37970" class="anchorlink">⚓</a></pre>
                            </td>
                         </tr>
                      </table>
                   </div>
                </div>
                <div class="refdoc" id="TEI.titlePage">
-                  <h3><span class="headingNumber">5.1.74. </span><span class="head">&lt;titlePage&gt;</span></h3>
+                  <h3><span class="headingNumber">5.1.76. </span><span class="head">&lt;titlePage&gt;</span></h3>
                   <div class="table">
                      <table class="wovenodd">
                         <tr>
@@ -10595,14 +10982,14 @@ element title
                                  <div class="specChild"><span class="specChildModule">figures: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.figure" title="&lt;figure&gt;">figure</a></span></div>
                                  <div class="specChild"><span class="specChildModule">textcrit: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.app" title="&lt;app&gt;">app</a></span></div>
                                  <div class="specChild"><span class="specChildModule">textstructure: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.byline" title="&lt;byline&gt;">byline</a> <a class="link_odd_elementSpec" href="#TEI.docImprint" title="&lt;docImprint&gt;">docImprint</a> <a class="link_odd_elementSpec" href="#TEI.docTitle" title="&lt;docTitle&gt;">docTitle</a> <a class="link_odd_elementSpec" href="#TEI.epigraph" title="&lt;epigraph&gt;">epigraph</a> <a class="link_odd_elementSpec" href="#TEI.imprimatur" title="&lt;imprimatur&gt;">imprimatur</a> <a class="link_odd_elementSpec" href="#TEI.titlePart" title="&lt;titlePart&gt;">titlePart</a></span></div>
-                                 <div class="specChild"><span class="specChildModule">transcr: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.fw" title="&lt;fw&gt;">fw</a></span></div>
+                                 <div class="specChild"><span class="specChildModule">transcr: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.fw" title="&lt;fw&gt;">fw</a> <a class="link_odd_elementSpec" href="#TEI.listTranspose" title="&lt;listTranspose&gt;">listTranspose</a></span></div>
                               </div>
                            </td>
                         </tr>
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Example</span></td>
                            <td class="wovenodd-col2">
-                              <div id="index.xml-egXML-d31e37026" class="pre egXML_valid"><span class="element">&lt;titlePage&gt;</span>
+                              <div id="index.xml-egXML-d31e38284" class="pre egXML_valid"><span class="element">&lt;titlePage&gt;</span>
                                   <span class="element">&lt;docTitle&gt;</span>
                                    <span class="element">&lt;titlePart <span class="attribute">type</span>="<span class="attributevalue">main</span>"&gt;</span>THOMAS OF Reading.<span class="element">&lt;/titlePart&gt;</span>
                                    <span class="element">&lt;titlePart <span class="attribute">type</span>="<span class="attributevalue">alt</span>"&gt;</span>OR, The sixe worthy yeomen of the West.<span class="element">&lt;/titlePart&gt;</span>
@@ -10623,7 +11010,7 @@ element title
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Content model</span></td>
                            <td class="wovenodd-col2">
-                              <pre id="index.xml-eg-d31e37051" class="pre_eg cdata">
+                              <pre id="index.xml-eg-d31e38309" class="pre_eg cdata">
 &lt;content&gt;
  &lt;sequence&gt;
   &lt;classRef key="model.global"
@@ -10636,13 +11023,13 @@ element title
   &lt;/alternate&gt;
  &lt;/sequence&gt;
 &lt;/content&gt;
-    <a href="#index.xml-eg-d31e37051" class="anchorlink">⚓</a></pre>
+    <a href="#index.xml-eg-d31e38309" class="anchorlink">⚓</a></pre>
                            </td>
                         </tr>
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Schema Declaration</span></td>
                            <td class="wovenodd-col2">
-                              <pre id="index.xml-eg-d31e37058" class="pre_eg">
+                              <pre id="index.xml-eg-d31e38316" class="pre_eg">
 element titlePage
 {
    tei_att.global.attributes,
@@ -10653,14 +11040,14 @@ element titlePage
       tei_model.titlepagePart,
       ( tei_model.titlepagePart | tei_model.global )*
    )
-}<a href="#index.xml-eg-d31e37058" class="anchorlink">⚓</a></pre>
+}<a href="#index.xml-eg-d31e38316" class="anchorlink">⚓</a></pre>
                            </td>
                         </tr>
                      </table>
                   </div>
                </div>
                <div class="refdoc" id="TEI.titlePart">
-                  <h3><span class="headingNumber">5.1.75. </span><span class="head">&lt;titlePart&gt;</span></h3>
+                  <h3><span class="headingNumber">5.1.77. </span><span class="head">&lt;titlePart&gt;</span></h3>
                   <div class="table">
                      <table class="wovenodd">
                         <tr>
@@ -10744,7 +11131,7 @@ element titlePage
                                  <div class="specChild"><span class="specChildModule">linking: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.seg" title="&lt;seg&gt;">seg</a></span></div>
                                  <div class="specChild"><span class="specChildModule">namesdates: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.orgName" title="&lt;orgName&gt;">orgName</a> <a class="link_odd_elementSpec" href="#TEI.persName" title="&lt;persName&gt;">persName</a> <a class="link_odd_elementSpec" href="#TEI.placeName" title="&lt;placeName&gt;">placeName</a></span></div>
                                  <div class="specChild"><span class="specChildModule">textcrit: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.app" title="&lt;app&gt;">app</a> <a class="link_odd_elementSpec" href="#TEI.listWit" title="&lt;listWit&gt;">listWit</a></span></div>
-                                 <div class="specChild"><span class="specChildModule">transcr: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.fw" title="&lt;fw&gt;">fw</a></span></div>
+                                 <div class="specChild"><span class="specChildModule">transcr: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.fw" title="&lt;fw&gt;">fw</a> <a class="link_odd_elementSpec" href="#TEI.listTranspose" title="&lt;listTranspose&gt;">listTranspose</a></span></div>
                                  <div class="specChild">character data</div>
                               </div>
                            </td>
@@ -10752,7 +11139,7 @@ element titlePage
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Example</span></td>
                            <td class="wovenodd-col2">
-                              <div id="index.xml-egXML-d31e37525" class="pre egXML_valid"><span class="element">&lt;docTitle&gt;</span>
+                              <div id="index.xml-egXML-d31e38788" class="pre egXML_valid"><span class="element">&lt;docTitle&gt;</span>
                                   <span class="element">&lt;titlePart <span class="attribute">type</span>="<span class="attributevalue">main</span>"&gt;</span>THE FORTUNES
                                     AND MISFORTUNES Of the FAMOUS
                                     Moll Flanders, &amp;amp;c.
@@ -10771,31 +11158,31 @@ element titlePage
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Content model</span></td>
                            <td class="wovenodd-col2">
-                              <pre id="index.xml-eg-d31e37553" class="pre_eg cdata">
+                              <pre id="index.xml-eg-d31e38816" class="pre_eg cdata">
 &lt;content&gt;
  &lt;macroRef key="macro.paraContent"/&gt;
 &lt;/content&gt;
-    <a href="#index.xml-eg-d31e37553" class="anchorlink">⚓</a></pre>
+    <a href="#index.xml-eg-d31e38816" class="anchorlink">⚓</a></pre>
                            </td>
                         </tr>
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Schema Declaration</span></td>
                            <td class="wovenodd-col2">
-                              <pre id="index.xml-eg-d31e37560" class="pre_eg">
+                              <pre id="index.xml-eg-d31e38823" class="pre_eg">
 element titlePart
 {
    tei_att.global.attributes,
    tei_att.typed.attribute.subtype,
    attribute type { "main" | "sub" | "alt" | "short" | "desc" }?,
    tei_macro.paraContent
-}<a href="#index.xml-eg-d31e37560" class="anchorlink">⚓</a></pre>
+}<a href="#index.xml-eg-d31e38823" class="anchorlink">⚓</a></pre>
                            </td>
                         </tr>
                      </table>
                   </div>
                </div>
                <div class="refdoc" id="TEI.titleStmt">
-                  <h3><span class="headingNumber">5.1.76. </span><span class="head">&lt;titleStmt&gt;</span></h3>
+                  <h3><span class="headingNumber">5.1.78. </span><span class="head">&lt;titleStmt&gt;</span></h3>
                   <div class="table">
                      <table class="wovenodd">
                         <tr>
@@ -10831,7 +11218,7 @@ element titlePart
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Example</span></td>
                            <td class="wovenodd-col2">
-                              <div id="index.xml-egXML-d31e37751" class="pre egXML_valid"><span class="element">&lt;titleStmt&gt;</span>
+                              <div id="index.xml-egXML-d31e39014" class="pre egXML_valid"><span class="element">&lt;titleStmt&gt;</span>
                                   <span class="element">&lt;title&gt;</span>Capgrave's Life of St. John Norbert: a machine-readable transcription<span class="element">&lt;/title&gt;</span>
                                   <span class="element">&lt;respStmt&gt;</span>
                                    <span class="element">&lt;resp&gt;</span>compiled by<span class="element">&lt;/resp&gt;</span>
@@ -10843,7 +11230,7 @@ element titlePart
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Content model</span></td>
                            <td class="wovenodd-col2">
-                              <pre id="index.xml-eg-d31e37762" class="pre_eg cdata">
+                              <pre id="index.xml-eg-d31e39025" class="pre_eg cdata">
 &lt;content&gt;
  &lt;sequence&gt;
   &lt;elementRef key="title" minOccurs="1"
@@ -10852,25 +11239,25 @@ element titlePart
    minOccurs="0" maxOccurs="unbounded"/&gt;
  &lt;/sequence&gt;
 &lt;/content&gt;
-    <a href="#index.xml-eg-d31e37762" class="anchorlink">⚓</a></pre>
+    <a href="#index.xml-eg-d31e39025" class="anchorlink">⚓</a></pre>
                            </td>
                         </tr>
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Schema Declaration</span></td>
                            <td class="wovenodd-col2">
-                              <pre id="index.xml-eg-d31e37769" class="pre_eg">
+                              <pre id="index.xml-eg-d31e39032" class="pre_eg">
 element titleStmt
 {
    tei_att.global.attributes,
    ( tei_title+, tei_model.respLike* )
-}<a href="#index.xml-eg-d31e37769" class="anchorlink">⚓</a></pre>
+}<a href="#index.xml-eg-d31e39032" class="anchorlink">⚓</a></pre>
                            </td>
                         </tr>
                      </table>
                   </div>
                </div>
                <div class="refdoc" id="TEI.trailer">
-                  <h3><span class="headingNumber">5.1.77. </span><span class="head">&lt;trailer&gt;</span></h3>
+                  <h3><span class="headingNumber">5.1.79. </span><span class="head">&lt;trailer&gt;</span></h3>
                   <div class="table">
                      <table class="wovenodd">
                         <tr>
@@ -10912,7 +11299,7 @@ element titleStmt
                                  <div class="specChild"><span class="specChildModule">linking: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.seg" title="&lt;seg&gt;">seg</a></span></div>
                                  <div class="specChild"><span class="specChildModule">namesdates: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.orgName" title="&lt;orgName&gt;">orgName</a> <a class="link_odd_elementSpec" href="#TEI.persName" title="&lt;persName&gt;">persName</a> <a class="link_odd_elementSpec" href="#TEI.placeName" title="&lt;placeName&gt;">placeName</a></span></div>
                                  <div class="specChild"><span class="specChildModule">textcrit: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.app" title="&lt;app&gt;">app</a> <a class="link_odd_elementSpec" href="#TEI.listWit" title="&lt;listWit&gt;">listWit</a></span></div>
-                                 <div class="specChild"><span class="specChildModule">transcr: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.fw" title="&lt;fw&gt;">fw</a></span></div>
+                                 <div class="specChild"><span class="specChildModule">transcr: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.fw" title="&lt;fw&gt;">fw</a> <a class="link_odd_elementSpec" href="#TEI.listTranspose" title="&lt;listTranspose&gt;">listTranspose</a></span></div>
                                  <div class="specChild">character data</div>
                               </div>
                            </td>
@@ -10920,13 +11307,13 @@ element titleStmt
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Example</span></td>
                            <td class="wovenodd-col2">
-                              <div id="index.xml-egXML-d31e38157" class="pre egXML_valid"><span class="element">&lt;trailer&gt;</span>Explicit pars tertia<span class="element">&lt;/trailer&gt;</span></div>
+                              <div id="index.xml-egXML-d31e39423" class="pre egXML_valid"><span class="element">&lt;trailer&gt;</span>Explicit pars tertia<span class="element">&lt;/trailer&gt;</span></div>
                            </td>
                         </tr>
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Example</span></td>
                            <td class="wovenodd-col2">
-                              <div id="index.xml-egXML-d31e38164" class="pre egXML_valid"><span class="element">&lt;trailer&gt;</span>
+                              <div id="index.xml-egXML-d31e39430" class="pre egXML_valid"><span class="element">&lt;trailer&gt;</span>
                                   <span class="element">&lt;l&gt;</span>In stead of FINIS this advice <span class="element">&lt;hi&gt;</span>I<span class="element">&lt;/hi&gt;</span> send,<span class="element">&lt;/l&gt;</span>
                                   <span class="element">&lt;l&gt;</span>Let Rogues and Thieves beware of <span class="element">&lt;lb/&gt;</span>
                                    <span class="element">&lt;hi&gt;</span>Hamans<span class="element">&lt;/hi&gt;</span> END.<span class="element">&lt;/l&gt;</span>
@@ -10935,7 +11322,7 @@ element titleStmt
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Content model</span></td>
                            <td class="wovenodd-col2">
-                              <pre id="index.xml-eg-d31e38181" class="pre_eg cdata">
+                              <pre id="index.xml-eg-d31e39447" class="pre_eg cdata">
 &lt;content&gt;
  &lt;alternate minOccurs="0"
   maxOccurs="unbounded"&gt;
@@ -10948,13 +11335,13 @@ element titleStmt
   &lt;classRef key="model.global"/&gt;
  &lt;/alternate&gt;
 &lt;/content&gt;
-    <a href="#index.xml-eg-d31e38181" class="anchorlink">⚓</a></pre>
+    <a href="#index.xml-eg-d31e39447" class="anchorlink">⚓</a></pre>
                            </td>
                         </tr>
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Schema Declaration</span></td>
                            <td class="wovenodd-col2">
-                              <pre id="index.xml-eg-d31e38188" class="pre_eg">
+                              <pre id="index.xml-eg-d31e39454" class="pre_eg">
 element trailer
 {
    tei_att.global.attributes,
@@ -10970,14 +11357,85 @@ element trailer
     | tei_model.lLike
     | tei_model.global
    )*
-}<a href="#index.xml-eg-d31e38188" class="anchorlink">⚓</a></pre>
+}<a href="#index.xml-eg-d31e39454" class="anchorlink">⚓</a></pre>
+                           </td>
+                        </tr>
+                     </table>
+                  </div>
+               </div>
+               <div class="refdoc" id="TEI.transpose">
+                  <h3><span class="headingNumber">5.1.80. </span><span class="head">&lt;transpose&gt;</span></h3>
+                  <div class="table">
+                     <table class="wovenodd">
+                        <tr>
+                           <td colspan="2" class="wovenodd-col2"><span class="label">&lt;transpose&gt; </span><span xml:lang="en" lang="en">describes a single textual transposition as an ordered list of at least two pointers
+                                 specifying the order in which the elements indicated should be re-combined.</span> [<a class="link_ref" href="https://www.tei-c.org/release/doc/tei-p5-doc/en/html/PH.html#transpo">11.3.4.5. Transpositions</a>]</td>
+                        </tr>
+                        <tr>
+                           <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Module</span></td>
+                           <td class="wovenodd-col2">transcr</td>
+                        </tr>
+                        <tr>
+                           <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Attributes</span></td>
+                           <td class="wovenodd-col2"><a class="link_ref" href="#TEI.att.global" title="att.global">att.global</a> (<span class="attribute">@xml:id</span>, <span class="attribute">@n</span>, <span class="attribute">@xml:lang</span>, <span class="attribute">@xml:base</span>, <span class="attribute">@xml:space</span>)  (<a class="link_ref" href="#TEI.att.global.rendition" title="att.global.rendition">att.global.rendition</a> (<span class="attribute">@rend</span>, <span class="attribute">@style</span>, <span class="attribute">@rendition</span>)) (<a class="link_ref" href="#TEI.att.global.linking" title="att.global.linking">att.global.linking</a> (<span class="attribute">@corresp</span>, <span class="attribute">@synch</span>, <span class="attribute">@sameAs</span>, <span class="attribute">@copyOf</span>, <span class="attribute">@next</span>, <span class="attribute">@prev</span>, <span class="attribute">@exclude</span>, <span class="attribute">@select</span>)) (<a class="link_ref" href="#TEI.att.global.analytic" title="att.global.analytic">att.global.analytic</a> (<span class="attribute">@ana</span>)) (<a class="link_ref" href="#TEI.att.global.facs" title="att.global.facs">att.global.facs</a> (<span class="attribute">@facs</span>)) (<a class="link_ref" href="#TEI.att.global.change" title="att.global.change">att.global.change</a> (<span class="attribute">@change</span>)) (<a class="link_ref" href="#TEI.att.global.responsibility" title="att.global.responsibility">att.global.responsibility</a> (<span class="attribute">@cert</span>, <span class="attribute">@resp</span>)) (<a class="link_ref" href="#TEI.att.global.source" title="att.global.source">att.global.source</a> (<span class="attribute">@source</span>))</td>
+                        </tr>
+                        <tr>
+                           <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Contained by</span></td>
+                           <td class="wovenodd-col2">
+                              <div class="parent">
+                                 <div class="specChildren">
+                                    <div class="specChild"><span class="specChildModule">transcr: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.listTranspose" title="&lt;listTranspose&gt;">listTranspose</a></span></div>
+                                 </div>
+                              </div>
+                           </td>
+                        </tr>
+                        <tr>
+                           <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">May contain</span></td>
+                           <td class="wovenodd-col2">
+                              <div class="specChildren">
+                                 <div class="specChild"><span class="specChildModule">core: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.ptr" title="&lt;ptr&gt;">ptr</a></span></div>
+                              </div>
+                           </td>
+                        </tr>
+                        <tr>
+                           <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Note</span></td>
+                           <td class="wovenodd-col2">
+                              <p>Transposition is usually indicated in a document by a metamark such as a wavy line
+                                 or numbering. </p>
+                              <p>The order in which <a class="link_ref" href="#TEI.ptr" title="&lt;ptr&gt;">&lt;ptr&gt;</a> elements appear within a <a class="link_ref" href="#TEI.transpose" title="&lt;transpose&gt;">&lt;transpose&gt;</a> element should correspond with the desired order, as indicated by the metamark.</p>
+                           </td>
+                        </tr>
+                        <tr>
+                           <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Example</span></td>
+                           <td class="wovenodd-col2">
+                              <div id="index.xml-egXML-d31e39658" class="pre egXML_valid"><span class="element">&lt;transpose&gt;</span>
+                                  <span class="element">&lt;ptr <span class="attribute">target</span>="<span class="attributevalue">#ib02</span>"/&gt;</span>
+                                  <span class="element">&lt;ptr <span class="attribute">target</span>="<span class="attributevalue">#ib01</span>"/&gt;</span>
+                                 <span class="element">&lt;/transpose&gt;</span></div>The transposition recorded here indicates that the content of the element with identifier <code>ib02</code> should appear before the content of the element with identifier <code>ib01</code>.</td>
+                        </tr>
+                        <tr>
+                           <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Content model</span></td>
+                           <td class="wovenodd-col2">
+                              <pre id="index.xml-eg-d31e39674" class="pre_eg cdata">
+&lt;content&gt;
+ &lt;elementRef key="ptr" minOccurs="2"
+  maxOccurs="unbounded"/&gt;
+&lt;/content&gt;
+    <a href="#index.xml-eg-d31e39674" class="anchorlink">⚓</a></pre>
+                           </td>
+                        </tr>
+                        <tr>
+                           <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Schema Declaration</span></td>
+                           <td class="wovenodd-col2">
+                              <pre id="index.xml-eg-d31e39681" class="pre_eg">
+element transpose { tei_att.global.attributes, ( tei_ptr, tei_ptr, tei_ptr* ) }<a href="#index.xml-eg-d31e39681" class="anchorlink">⚓</a></pre>
                            </td>
                         </tr>
                      </table>
                   </div>
                </div>
                <div class="refdoc" id="TEI.variantEncoding">
-                  <h3><span class="headingNumber">5.1.78. </span><span class="head">&lt;variantEncoding&gt;</span></h3>
+                  <h3><span class="headingNumber">5.1.81. </span><span class="head">&lt;variantEncoding&gt;</span></h3>
                   <div class="table">
                      <table class="wovenodd">
                         <tr>
@@ -11101,24 +11559,24 @@ element trailer
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Example</span></td>
                            <td class="wovenodd-col2">
-                              <div id="index.xml-egXML-d31e38502" class="pre egXML_valid"><span class="element">&lt;variantEncoding <span class="attribute">method</span>="<span class="attributevalue">location-referenced</span>"
+                              <div id="index.xml-egXML-d31e39976" class="pre egXML_valid"><span class="element">&lt;variantEncoding <span class="attribute">method</span>="<span class="attributevalue">location-referenced</span>"
                                      <span class="attribute">location</span>="<span class="attributevalue">external</span>"/&gt;</span></div>
                            </td>
                         </tr>
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Content model</span></td>
                            <td class="wovenodd-col2">
-                              <pre id="index.xml-eg-d31e38509" class="pre_eg cdata">
+                              <pre id="index.xml-eg-d31e39983" class="pre_eg cdata">
 &lt;content&gt;
  &lt;empty/&gt;
 &lt;/content&gt;
-    <a href="#index.xml-eg-d31e38509" class="anchorlink">⚓</a></pre>
+    <a href="#index.xml-eg-d31e39983" class="anchorlink">⚓</a></pre>
                            </td>
                         </tr>
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Schema Declaration</span></td>
                            <td class="wovenodd-col2">
-                              <pre id="index.xml-eg-d31e38516" class="pre_eg">
+                              <pre id="index.xml-eg-d31e39990" class="pre_eg">
 element variantEncoding
 {
    tei_att.global.attributes,
@@ -11128,14 +11586,14 @@ element variantEncoding
    },
    attribute location { "internal" | "external" },
    empty
-}<a href="#index.xml-eg-d31e38516" class="anchorlink">⚓</a></pre>
+}<a href="#index.xml-eg-d31e39990" class="anchorlink">⚓</a></pre>
                            </td>
                         </tr>
                      </table>
                   </div>
                </div>
                <div class="refdoc" id="TEI.w">
-                  <h3><span class="headingNumber">5.1.79. </span><span class="head">&lt;w&gt;</span></h3>
+                  <h3><span class="headingNumber">5.1.82. </span><span class="head">&lt;w&gt;</span></h3>
                   <div class="table">
                      <table class="wovenodd">
                         <tr>
@@ -11226,7 +11684,7 @@ element variantEncoding
                                  <div class="specChild"><span class="specChildModule">figures: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.figure" title="&lt;figure&gt;">figure</a></span></div>
                                  <div class="specChild"><span class="specChildModule">linking: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.seg" title="&lt;seg&gt;">seg</a></span></div>
                                  <div class="specChild"><span class="specChildModule">textcrit: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.app" title="&lt;app&gt;">app</a></span></div>
-                                 <div class="specChild"><span class="specChildModule">transcr: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.fw" title="&lt;fw&gt;">fw</a></span></div>
+                                 <div class="specChild"><span class="specChildModule">transcr: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.fw" title="&lt;fw&gt;">fw</a> <a class="link_odd_elementSpec" href="#TEI.listTranspose" title="&lt;listTranspose&gt;">listTranspose</a></span></div>
                                  <div class="specChild">character data</div>
                               </div>
                            </td>
@@ -11235,7 +11693,7 @@ element variantEncoding
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Example</span></td>
                            <td class="wovenodd-col2">This example is adapted from the Folger Library’s Early Modern English Drama version
                               of <a class="link_ref" href="https://emed.folger.edu/wits">The Wits: a Comedy</a> by William Davenant.
-                              <div id="index.xml-egXML-d31e39006" class="pre egXML_valid"><span class="element">&lt;l&gt;</span>
+                              <div id="index.xml-egXML-d31e40484" class="pre egXML_valid"><span class="element">&lt;l&gt;</span>
                                   <span class="element">&lt;w <span class="attribute">lemma</span>="<span class="attributevalue">it</span>" <span class="attribute">pos</span>="<span class="attributevalue">pn</span>"
                                       <span class="attribute">xml:id</span>="<span class="attributevalue">A19883-003-a-0100</span>"&gt;</span>IT<span class="element">&lt;/w&gt;</span>
                                   <span class="element">&lt;w <span class="attribute">lemma</span>="<span class="attributevalue">have</span>" <span class="attribute">pos</span>="<span class="attributevalue">vvz</span>"
@@ -11302,7 +11760,7 @@ element variantEncoding
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Content model</span></td>
                            <td class="wovenodd-col2">
-                              <pre id="index.xml-eg-d31e39071" class="pre_eg cdata">
+                              <pre id="index.xml-eg-d31e40549" class="pre_eg cdata">
 &lt;content&gt;
  &lt;alternate minOccurs="0"
   maxOccurs="unbounded"&gt;
@@ -11319,13 +11777,13 @@ element variantEncoding
   &lt;classRef key="model.pPart.edit"/&gt;
  &lt;/alternate&gt;
 &lt;/content&gt;
-    <a href="#index.xml-eg-d31e39071" class="anchorlink">⚓</a></pre>
+    <a href="#index.xml-eg-d31e40549" class="anchorlink">⚓</a></pre>
                            </td>
                         </tr>
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Schema Declaration</span></td>
                            <td class="wovenodd-col2">
-                              <pre id="index.xml-eg-d31e39078" class="pre_eg">
+                              <pre id="index.xml-eg-d31e40556" class="pre_eg">
 element w
 {
    tei_att.global.attribute.xmlid,
@@ -11370,14 +11828,14 @@ element w
     | tei_model.hiLike
     | tei_model.pPart.edit
    )*
-}<a href="#index.xml-eg-d31e39078" class="anchorlink">⚓</a></pre>
+}<a href="#index.xml-eg-d31e40556" class="anchorlink">⚓</a></pre>
                            </td>
                         </tr>
                      </table>
                   </div>
                </div>
                <div class="refdoc" id="TEI.witness">
-                  <h3><span class="headingNumber">5.1.80. </span><span class="head">&lt;witness&gt;</span></h3>
+                  <h3><span class="headingNumber">5.1.83. </span><span class="head">&lt;witness&gt;</span></h3>
                   <div class="table">
                      <table class="wovenodd">
                         <tr>
@@ -11448,7 +11906,7 @@ element w
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Example</span></td>
                            <td class="wovenodd-col2">
-                              <div id="index.xml-egXML-d31e39435" class="pre egXML_valid"><span class="element">&lt;listWit&gt;</span>
+                              <div id="index.xml-egXML-d31e40913" class="pre egXML_valid"><span class="element">&lt;listWit&gt;</span>
                                   <span class="element">&lt;witness <span class="attribute">xml:id</span>="<span class="attributevalue">EL</span>"&gt;</span>Ellesmere, Huntingdon Library 26.C.9<span class="element">&lt;/witness&gt;</span>
                                   <span class="element">&lt;witness <span class="attribute">xml:id</span>="<span class="attributevalue">HG</span>"&gt;</span>Hengwrt, National Library of Wales,
                                     Aberystwyth, Peniarth 392D<span class="element">&lt;/witness&gt;</span>
@@ -11460,7 +11918,7 @@ element w
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Content model</span></td>
                            <td class="wovenodd-col2">
-                              <pre id="index.xml-eg-d31e39450" class="pre_eg cdata">
+                              <pre id="index.xml-eg-d31e40928" class="pre_eg cdata">
 &lt;content&gt;
  &lt;alternate minOccurs="0"
   maxOccurs="unbounded"&gt;
@@ -11471,13 +11929,13 @@ element w
   &lt;elementRef key="object"/&gt;
  &lt;/alternate&gt;
 &lt;/content&gt;
-    <a href="#index.xml-eg-d31e39450" class="anchorlink">⚓</a></pre>
+    <a href="#index.xml-eg-d31e40928" class="anchorlink">⚓</a></pre>
                            </td>
                         </tr>
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Schema Declaration</span></td>
                            <td class="wovenodd-col2">
-                              <pre id="index.xml-eg-d31e39457" class="pre_eg">
+                              <pre id="index.xml-eg-d31e40935" class="pre_eg">
 element witness
 {
    tei_att.global.attribute.n,
@@ -11504,7 +11962,7 @@ element witness
    tei_att.sortable.attributes,
    attribute xml:id { text },
    ( text | tei_model.limitedPhrase | tei_model.inter | tei_note | object )*
-}<a href="#index.xml-eg-d31e39457" class="anchorlink">⚓</a></pre>
+}<a href="#index.xml-eg-d31e40935" class="anchorlink">⚓</a></pre>
                            </td>
                         </tr>
                      </table>
@@ -11513,8 +11971,32 @@ element witness
             </div>
             <div class="teidiv1" id="index.xml-body.1_div.5_div.2">
                <h2><span class="headingNumber">5.2. </span><span class="head">Model classes</span></h2>
+               <div class="refdoc" id="TEI.model.annotationLike">
+                  <h3><span class="headingNumber">5.2.1. </span><span class="head">model.annotationLike</span></h3>
+                  <div class="table">
+                     <table class="wovenodd">
+                        <tr>
+                           <td colspan="2" class="wovenodd-col2"><span class="label">model.annotationLike</span> <span xml:lang="en" lang="en">groups elements used to represent annotations.</span> [<a class="link_ref" href="https://www.tei-c.org/release/doc/tei-p5-doc/en/html/SA.html#SASOstdf">16.10. The standOff Container</a>]</td>
+                        </tr>
+                        <tr>
+                           <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Module</span></td>
+                           <td class="wovenodd-col2">tei</td>
+                        </tr>
+                        <tr>
+                           <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Used by</span></td>
+                           <td class="wovenodd-col2">
+                              <div class="parent"><a class="link_odd_classSpec" href="#TEI.model.standOffPart" title="model.standOffPart">model.standOffPart</a></div>
+                           </td>
+                        </tr>
+                        <tr>
+                           <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Members</span></td>
+                           <td class="wovenodd-col2"><span class="showmembers1"><a class="link_odd_elementSpec" href="#TEI.note" title="&lt;note&gt;">note</a></span></td>
+                        </tr>
+                     </table>
+                  </div>
+               </div>
                <div class="refdoc" id="TEI.model.attributable">
-                  <h3><span class="headingNumber">5.2.1. </span><span class="head">model.attributable</span></h3>
+                  <h3><span class="headingNumber">5.2.2. </span><span class="head">model.attributable</span></h3>
                   <div class="table">
                      <table class="wovenodd">
                         <tr>
@@ -11538,7 +12020,7 @@ element witness
                   </div>
                </div>
                <div class="refdoc" id="TEI.model.availabilityPart">
-                  <h3><span class="headingNumber">5.2.2. </span><span class="head">model.availabilityPart</span></h3>
+                  <h3><span class="headingNumber">5.2.3. </span><span class="head">model.availabilityPart</span></h3>
                   <div class="table">
                      <table class="wovenodd">
                         <tr>
@@ -11563,7 +12045,7 @@ element witness
                   </div>
                </div>
                <div class="refdoc" id="TEI.model.biblLike">
-                  <h3><span class="headingNumber">5.2.3. </span><span class="head">model.biblLike</span></h3>
+                  <h3><span class="headingNumber">5.2.4. </span><span class="head">model.biblLike</span></h3>
                   <div class="table">
                      <table class="wovenodd">
                         <tr>
@@ -11576,7 +12058,7 @@ element witness
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Used by</span></td>
                            <td class="wovenodd-col2">
-                              <div class="parent"><a class="link_odd_elementSpec" href="#TEI.cit" title="&lt;cit&gt;">cit</a> <a class="link_odd_elementSpec" href="#TEI.listBibl" title="&lt;listBibl&gt;">listBibl</a> <a class="link_odd_classSpec" href="#TEI.model.inter" title="model.inter">model.inter</a> <a class="link_odd_elementSpec" href="#TEI.sourceDesc" title="&lt;sourceDesc&gt;">sourceDesc</a></div>
+                              <div class="parent"><a class="link_odd_elementSpec" href="#TEI.cit" title="&lt;cit&gt;">cit</a> <a class="link_odd_elementSpec" href="#TEI.listBibl" title="&lt;listBibl&gt;">listBibl</a> <a class="link_odd_classSpec" href="#TEI.model.inter" title="model.inter">model.inter</a> <a class="link_odd_classSpec" href="#TEI.model.standOffPart" title="model.standOffPart">model.standOffPart</a> <a class="link_odd_elementSpec" href="#TEI.sourceDesc" title="&lt;sourceDesc&gt;">sourceDesc</a></div>
                            </td>
                         </tr>
                         <tr>
@@ -11587,7 +12069,7 @@ element witness
                   </div>
                </div>
                <div class="refdoc" id="TEI.model.biblPart">
-                  <h3><span class="headingNumber">5.2.4. </span><span class="head">model.biblPart</span></h3>
+                  <h3><span class="headingNumber">5.2.5. </span><span class="head">model.biblPart</span></h3>
                   <div class="table">
                      <table class="wovenodd">
                         <tr>
@@ -11611,7 +12093,7 @@ element witness
                   </div>
                </div>
                <div class="refdoc" id="TEI.model.common">
-                  <h3><span class="headingNumber">5.2.5. </span><span class="head">model.common</span></h3>
+                  <h3><span class="headingNumber">5.2.6. </span><span class="head">model.common</span></h3>
                   <div class="table">
                      <table class="wovenodd">
                         <tr>
@@ -11642,7 +12124,7 @@ element witness
                   </div>
                </div>
                <div class="refdoc" id="TEI.model.dateLike">
-                  <h3><span class="headingNumber">5.2.6. </span><span class="head">model.dateLike</span></h3>
+                  <h3><span class="headingNumber">5.2.7. </span><span class="head">model.dateLike</span></h3>
                   <div class="table">
                      <table class="wovenodd">
                         <tr>
@@ -11666,7 +12148,7 @@ element witness
                   </div>
                </div>
                <div class="refdoc" id="TEI.model.divBottom">
-                  <h3><span class="headingNumber">5.2.7. </span><span class="head">model.divBottom</span></h3>
+                  <h3><span class="headingNumber">5.2.8. </span><span class="head">model.divBottom</span></h3>
                   <div class="table">
                      <table class="wovenodd">
                         <tr>
@@ -11690,7 +12172,7 @@ element witness
                   </div>
                </div>
                <div class="refdoc" id="TEI.model.divBottomPart">
-                  <h3><span class="headingNumber">5.2.8. </span><span class="head">model.divBottomPart</span></h3>
+                  <h3><span class="headingNumber">5.2.9. </span><span class="head">model.divBottomPart</span></h3>
                   <div class="table">
                      <table class="wovenodd">
                         <tr>
@@ -11714,7 +12196,7 @@ element witness
                   </div>
                </div>
                <div class="refdoc" id="TEI.model.divLike">
-                  <h3><span class="headingNumber">5.2.9. </span><span class="head">model.divLike</span></h3>
+                  <h3><span class="headingNumber">5.2.10. </span><span class="head">model.divLike</span></h3>
                   <div class="table">
                      <table class="wovenodd">
                         <tr>
@@ -11738,7 +12220,7 @@ element witness
                   </div>
                </div>
                <div class="refdoc" id="TEI.model.divPart">
-                  <h3><span class="headingNumber">5.2.10. </span><span class="head">model.divPart</span></h3>
+                  <h3><span class="headingNumber">5.2.11. </span><span class="head">model.divPart</span></h3>
                   <div class="table">
                      <table class="wovenodd">
                         <tr>
@@ -11768,7 +12250,7 @@ element witness
                   </div>
                </div>
                <div class="refdoc" id="TEI.model.divTop">
-                  <h3><span class="headingNumber">5.2.11. </span><span class="head">model.divTop</span></h3>
+                  <h3><span class="headingNumber">5.2.12. </span><span class="head">model.divTop</span></h3>
                   <div class="table">
                      <table class="wovenodd">
                         <tr>
@@ -11792,7 +12274,7 @@ element witness
                   </div>
                </div>
                <div class="refdoc" id="TEI.model.divTopPart">
-                  <h3><span class="headingNumber">5.2.12. </span><span class="head">model.divTopPart</span></h3>
+                  <h3><span class="headingNumber">5.2.13. </span><span class="head">model.divTopPart</span></h3>
                   <div class="table">
                      <table class="wovenodd">
                         <tr>
@@ -11816,7 +12298,7 @@ element witness
                   </div>
                </div>
                <div class="refdoc" id="TEI.model.divWrapper">
-                  <h3><span class="headingNumber">5.2.13. </span><span class="head">model.divWrapper</span></h3>
+                  <h3><span class="headingNumber">5.2.14. </span><span class="head">model.divWrapper</span></h3>
                   <div class="table">
                      <table class="wovenodd">
                         <tr>
@@ -11840,7 +12322,7 @@ element witness
                   </div>
                </div>
                <div class="refdoc" id="TEI.model.emphLike">
-                  <h3><span class="headingNumber">5.2.14. </span><span class="head">model.emphLike</span></h3>
+                  <h3><span class="headingNumber">5.2.15. </span><span class="head">model.emphLike</span></h3>
                   <div class="table">
                      <table class="wovenodd">
                         <tr>
@@ -11865,7 +12347,7 @@ element witness
                   </div>
                </div>
                <div class="refdoc" id="TEI.model.encodingDescPart">
-                  <h3><span class="headingNumber">5.2.15. </span><span class="head">model.encodingDescPart</span></h3>
+                  <h3><span class="headingNumber">5.2.16. </span><span class="head">model.encodingDescPart</span></h3>
                   <div class="table">
                      <table class="wovenodd">
                         <tr>
@@ -11889,7 +12371,7 @@ element witness
                   </div>
                </div>
                <div class="refdoc" id="TEI.model.frontPart">
-                  <h3><span class="headingNumber">5.2.16. </span><span class="head">model.frontPart</span></h3>
+                  <h3><span class="headingNumber">5.2.17. </span><span class="head">model.frontPart</span></h3>
                   <div class="table">
                      <table class="wovenodd">
                         <tr>
@@ -11913,7 +12395,7 @@ element witness
                   </div>
                </div>
                <div class="refdoc" id="TEI.model.global">
-                  <h3><span class="headingNumber">5.2.17. </span><span class="head">model.global</span></h3>
+                  <h3><span class="headingNumber">5.2.18. </span><span class="head">model.global</span></h3>
                   <div class="table">
                      <table class="wovenodd">
                         <tr>
@@ -11931,13 +12413,13 @@ element witness
                         </tr>
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Members</span></td>
-                           <td class="wovenodd-col2"><span class="showmembers1"><a class="link_odd_classSpec" href="#TEI.model.global.edit" title="model.global.edit">model.global.edit</a><span class="showmembers2">[<a class="link_odd_elementSpec" href="#TEI.app" title="&lt;app&gt;">app</a>]</span> model.global.meta <a class="link_odd_classSpec" href="#TEI.model.milestoneLike" title="model.milestoneLike">model.milestoneLike</a><span class="showmembers2">[<a class="link_odd_elementSpec" href="#TEI.cb" title="&lt;cb&gt;">cb</a> <a class="link_odd_elementSpec" href="#TEI.fw" title="&lt;fw&gt;">fw</a> <a class="link_odd_elementSpec" href="#TEI.lb" title="&lt;lb&gt;">lb</a> <a class="link_odd_elementSpec" href="#TEI.pb" title="&lt;pb&gt;">pb</a>]</span> <a class="link_odd_classSpec" href="#TEI.model.noteLike" title="model.noteLike">model.noteLike</a><span class="showmembers2">[<a class="link_odd_elementSpec" href="#TEI.note" title="&lt;note&gt;">note</a>]</span> <a class="link_odd_elementSpec" href="#TEI.figure" title="&lt;figure&gt;">figure</a></span></td>
+                           <td class="wovenodd-col2"><span class="showmembers1"><a class="link_odd_classSpec" href="#TEI.model.global.edit" title="model.global.edit">model.global.edit</a><span class="showmembers2">[<a class="link_odd_elementSpec" href="#TEI.app" title="&lt;app&gt;">app</a>]</span> <a class="link_odd_classSpec" href="#TEI.model.global.meta" title="model.global.meta">model.global.meta</a><span class="showmembers2">[<a class="link_odd_elementSpec" href="#TEI.listTranspose" title="&lt;listTranspose&gt;">listTranspose</a>]</span> <a class="link_odd_classSpec" href="#TEI.model.milestoneLike" title="model.milestoneLike">model.milestoneLike</a><span class="showmembers2">[<a class="link_odd_elementSpec" href="#TEI.cb" title="&lt;cb&gt;">cb</a> <a class="link_odd_elementSpec" href="#TEI.fw" title="&lt;fw&gt;">fw</a> <a class="link_odd_elementSpec" href="#TEI.lb" title="&lt;lb&gt;">lb</a> <a class="link_odd_elementSpec" href="#TEI.pb" title="&lt;pb&gt;">pb</a>]</span> <a class="link_odd_classSpec" href="#TEI.model.noteLike" title="model.noteLike">model.noteLike</a><span class="showmembers2">[<a class="link_odd_elementSpec" href="#TEI.note" title="&lt;note&gt;">note</a>]</span> <a class="link_odd_elementSpec" href="#TEI.figure" title="&lt;figure&gt;">figure</a></span></td>
                         </tr>
                      </table>
                   </div>
                </div>
                <div class="refdoc" id="TEI.model.global.edit">
-                  <h3><span class="headingNumber">5.2.18. </span><span class="head">model.global.edit</span></h3>
+                  <h3><span class="headingNumber">5.2.19. </span><span class="head">model.global.edit</span></h3>
                   <div class="table">
                      <table class="wovenodd">
                         <tr>
@@ -11960,8 +12442,42 @@ element witness
                      </table>
                   </div>
                </div>
+               <div class="refdoc" id="TEI.model.global.meta">
+                  <h3><span class="headingNumber">5.2.20. </span><span class="head">model.global.meta</span></h3>
+                  <div class="table">
+                     <table class="wovenodd">
+                        <tr>
+                           <td colspan="2" class="wovenodd-col2"><span class="label">model.global.meta</span> <span xml:lang="en" lang="en">groups globally available elements which describe the status of other elements.</span> [<a class="link_ref" href="https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ST.html#STEC">1.3. The TEI Class System</a>]</td>
+                        </tr>
+                        <tr>
+                           <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Module</span></td>
+                           <td class="wovenodd-col2">tei</td>
+                        </tr>
+                        <tr>
+                           <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Used by</span></td>
+                           <td class="wovenodd-col2">
+                              <div class="parent"><a class="link_odd_classSpec" href="#TEI.model.global" title="model.global">model.global</a> <a class="link_odd_classSpec" href="#TEI.model.standOffPart" title="model.standOffPart">model.standOffPart</a></div>
+                           </td>
+                        </tr>
+                        <tr>
+                           <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Members</span></td>
+                           <td class="wovenodd-col2"><span class="showmembers1"><a class="link_odd_elementSpec" href="#TEI.listTranspose" title="&lt;listTranspose&gt;">listTranspose</a></span></td>
+                        </tr>
+                        <tr>
+                           <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Note</span></td>
+                           <td class="wovenodd-col2">
+                              <p>Elements in this class are typically used to hold groups of links or of abstract interpretations,
+                                 or by provide indications of certainty etc. It may find be convenient to localize
+                                 all metadata elements, for example to contain them within the same divison as the
+                                 elements that they relate to; or to locate them all to a division of their own. They
+                                 may however appear at any point in a TEI text.</p>
+                           </td>
+                        </tr>
+                     </table>
+                  </div>
+               </div>
                <div class="refdoc" id="TEI.model.graphicLike">
-                  <h3><span class="headingNumber">5.2.19. </span><span class="head">model.graphicLike</span></h3>
+                  <h3><span class="headingNumber">5.2.21. </span><span class="head">model.graphicLike</span></h3>
                   <div class="table">
                      <table class="wovenodd">
                         <tr>
@@ -11985,7 +12501,7 @@ element witness
                   </div>
                </div>
                <div class="refdoc" id="TEI.model.headLike">
-                  <h3><span class="headingNumber">5.2.20. </span><span class="head">model.headLike</span></h3>
+                  <h3><span class="headingNumber">5.2.22. </span><span class="head">model.headLike</span></h3>
                   <div class="table">
                      <table class="wovenodd">
                         <tr>
@@ -12009,7 +12525,7 @@ element witness
                   </div>
                </div>
                <div class="refdoc" id="TEI.model.hiLike">
-                  <h3><span class="headingNumber">5.2.21. </span><span class="head">model.hiLike</span></h3>
+                  <h3><span class="headingNumber">5.2.23. </span><span class="head">model.hiLike</span></h3>
                   <div class="table">
                      <table class="wovenodd">
                         <tr>
@@ -12034,7 +12550,7 @@ element witness
                   </div>
                </div>
                <div class="refdoc" id="TEI.model.highlighted">
-                  <h3><span class="headingNumber">5.2.22. </span><span class="head">model.highlighted</span></h3>
+                  <h3><span class="headingNumber">5.2.24. </span><span class="head">model.highlighted</span></h3>
                   <div class="table">
                      <table class="wovenodd">
                         <tr>
@@ -12058,7 +12574,7 @@ element witness
                   </div>
                </div>
                <div class="refdoc" id="TEI.model.imprintPart">
-                  <h3><span class="headingNumber">5.2.23. </span><span class="head">model.imprintPart</span></h3>
+                  <h3><span class="headingNumber">5.2.25. </span><span class="head">model.imprintPart</span></h3>
                   <div class="table">
                      <table class="wovenodd">
                         <tr>
@@ -12082,7 +12598,7 @@ element witness
                   </div>
                </div>
                <div class="refdoc" id="TEI.model.inter">
-                  <h3><span class="headingNumber">5.2.24. </span><span class="head">model.inter</span></h3>
+                  <h3><span class="headingNumber">5.2.26. </span><span class="head">model.inter</span></h3>
                   <div class="table">
                      <table class="wovenodd">
                         <tr>
@@ -12106,7 +12622,7 @@ element witness
                   </div>
                </div>
                <div class="refdoc" id="TEI.model.lLike">
-                  <h3><span class="headingNumber">5.2.25. </span><span class="head">model.lLike</span></h3>
+                  <h3><span class="headingNumber">5.2.27. </span><span class="head">model.lLike</span></h3>
                   <div class="table">
                      <table class="wovenodd">
                         <tr>
@@ -12130,7 +12646,7 @@ element witness
                   </div>
                </div>
                <div class="refdoc" id="TEI.model.limitedPhrase">
-                  <h3><span class="headingNumber">5.2.26. </span><span class="head">model.limitedPhrase</span></h3>
+                  <h3><span class="headingNumber">5.2.28. </span><span class="head">model.limitedPhrase</span></h3>
                   <div class="table">
                      <table class="wovenodd">
                         <tr>
@@ -12155,7 +12671,7 @@ element witness
                   </div>
                </div>
                <div class="refdoc" id="TEI.model.listLike">
-                  <h3><span class="headingNumber">5.2.27. </span><span class="head">model.listLike</span></h3>
+                  <h3><span class="headingNumber">5.2.29. </span><span class="head">model.listLike</span></h3>
                   <div class="table">
                      <table class="wovenodd">
                         <tr>
@@ -12168,7 +12684,7 @@ element witness
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Used by</span></td>
                            <td class="wovenodd-col2">
-                              <div class="parent"><a class="link_odd_elementSpec" href="#TEI.back" title="&lt;back&gt;">back</a> <a class="link_odd_classSpec" href="#TEI.model.inter" title="model.inter">model.inter</a> <a class="link_odd_elementSpec" href="#TEI.sourceDesc" title="&lt;sourceDesc&gt;">sourceDesc</a></div>
+                              <div class="parent"><a class="link_odd_elementSpec" href="#TEI.back" title="&lt;back&gt;">back</a> <a class="link_odd_classSpec" href="#TEI.model.inter" title="model.inter">model.inter</a> <a class="link_odd_classSpec" href="#TEI.model.standOffPart" title="model.standOffPart">model.standOffPart</a> <a class="link_odd_elementSpec" href="#TEI.sourceDesc" title="&lt;sourceDesc&gt;">sourceDesc</a></div>
                            </td>
                         </tr>
                         <tr>
@@ -12179,7 +12695,7 @@ element witness
                   </div>
                </div>
                <div class="refdoc" id="TEI.model.milestoneLike">
-                  <h3><span class="headingNumber">5.2.28. </span><span class="head">model.milestoneLike</span></h3>
+                  <h3><span class="headingNumber">5.2.30. </span><span class="head">model.milestoneLike</span></h3>
                   <div class="table">
                      <table class="wovenodd">
                         <tr>
@@ -12203,7 +12719,7 @@ element witness
                   </div>
                </div>
                <div class="refdoc" id="TEI.model.nameLike">
-                  <h3><span class="headingNumber">5.2.29. </span><span class="head">model.nameLike</span></h3>
+                  <h3><span class="headingNumber">5.2.31. </span><span class="head">model.nameLike</span></h3>
                   <div class="table">
                      <table class="wovenodd">
                         <tr>
@@ -12234,7 +12750,7 @@ element witness
                   </div>
                </div>
                <div class="refdoc" id="TEI.model.nameLike.agent">
-                  <h3><span class="headingNumber">5.2.30. </span><span class="head">model.nameLike.agent</span></h3>
+                  <h3><span class="headingNumber">5.2.32. </span><span class="head">model.nameLike.agent</span></h3>
                   <div class="table">
                      <table class="wovenodd">
                         <tr>
@@ -12265,7 +12781,7 @@ element witness
                   </div>
                </div>
                <div class="refdoc" id="TEI.model.noteLike">
-                  <h3><span class="headingNumber">5.2.31. </span><span class="head">model.noteLike</span></h3>
+                  <h3><span class="headingNumber">5.2.33. </span><span class="head">model.noteLike</span></h3>
                   <div class="table">
                      <table class="wovenodd">
                         <tr>
@@ -12289,7 +12805,7 @@ element witness
                   </div>
                </div>
                <div class="refdoc" id="TEI.model.pLike">
-                  <h3><span class="headingNumber">5.2.32. </span><span class="head">model.pLike</span></h3>
+                  <h3><span class="headingNumber">5.2.34. </span><span class="head">model.pLike</span></h3>
                   <div class="table">
                      <table class="wovenodd">
                         <tr>
@@ -12313,7 +12829,7 @@ element witness
                   </div>
                </div>
                <div class="refdoc" id="TEI.model.pLike.front">
-                  <h3><span class="headingNumber">5.2.33. </span><span class="head">model.pLike.front</span></h3>
+                  <h3><span class="headingNumber">5.2.35. </span><span class="head">model.pLike.front</span></h3>
                   <div class="table">
                      <table class="wovenodd">
                         <tr>
@@ -12337,7 +12853,7 @@ element witness
                   </div>
                </div>
                <div class="refdoc" id="TEI.model.pPart.data">
-                  <h3><span class="headingNumber">5.2.34. </span><span class="head">model.pPart.data</span></h3>
+                  <h3><span class="headingNumber">5.2.36. </span><span class="head">model.pPart.data</span></h3>
                   <div class="table">
                      <table class="wovenodd">
                         <tr>
@@ -12362,7 +12878,7 @@ element witness
                   </div>
                </div>
                <div class="refdoc" id="TEI.model.pPart.edit">
-                  <h3><span class="headingNumber">5.2.35. </span><span class="head">model.pPart.edit</span></h3>
+                  <h3><span class="headingNumber">5.2.37. </span><span class="head">model.pPart.edit</span></h3>
                   <div class="table">
                      <table class="wovenodd">
                         <tr>
@@ -12386,7 +12902,7 @@ element witness
                   </div>
                </div>
                <div class="refdoc" id="TEI.model.pPart.editorial">
-                  <h3><span class="headingNumber">5.2.36. </span><span class="head">model.pPart.editorial</span></h3>
+                  <h3><span class="headingNumber">5.2.38. </span><span class="head">model.pPart.editorial</span></h3>
                   <div class="table">
                      <table class="wovenodd">
                         <tr>
@@ -12411,7 +12927,7 @@ element witness
                   </div>
                </div>
                <div class="refdoc" id="TEI.model.paraPart">
-                  <h3><span class="headingNumber">5.2.37. </span><span class="head">model.paraPart</span></h3>
+                  <h3><span class="headingNumber">5.2.39. </span><span class="head">model.paraPart</span></h3>
                   <div class="table">
                      <table class="wovenodd">
                         <tr>
@@ -12429,13 +12945,13 @@ element witness
                         </tr>
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Members</span></td>
-                           <td class="wovenodd-col2"><span class="showmembers1">model.gLike <a class="link_odd_classSpec" href="#TEI.model.global" title="model.global">model.global</a><span class="showmembers2">[<a class="link_odd_classSpec" href="#TEI.model.global.edit" title="model.global.edit">model.global.edit</a><span class="showmembers3">[<a class="link_odd_elementSpec" href="#TEI.app" title="&lt;app&gt;">app</a>]</span> model.global.meta <a class="link_odd_classSpec" href="#TEI.model.milestoneLike" title="model.milestoneLike">model.milestoneLike</a><span class="showmembers3">[<a class="link_odd_elementSpec" href="#TEI.cb" title="&lt;cb&gt;">cb</a> <a class="link_odd_elementSpec" href="#TEI.fw" title="&lt;fw&gt;">fw</a> <a class="link_odd_elementSpec" href="#TEI.lb" title="&lt;lb&gt;">lb</a> <a class="link_odd_elementSpec" href="#TEI.pb" title="&lt;pb&gt;">pb</a>]</span> <a class="link_odd_classSpec" href="#TEI.model.noteLike" title="model.noteLike">model.noteLike</a><span class="showmembers3">[<a class="link_odd_elementSpec" href="#TEI.note" title="&lt;note&gt;">note</a>]</span> <a class="link_odd_elementSpec" href="#TEI.figure" title="&lt;figure&gt;">figure</a>]</span> <a class="link_odd_classSpec" href="#TEI.model.inter" title="model.inter">model.inter</a><span class="showmembers2">[<a class="link_odd_classSpec" href="#TEI.model.attributable" title="model.attributable">model.attributable</a><span class="showmembers3">[<a class="link_odd_classSpec" href="#TEI.model.quoteLike" title="model.quoteLike">model.quoteLike</a><span class="showmembers4">[<a class="link_odd_elementSpec" href="#TEI.cit" title="&lt;cit&gt;">cit</a> <a class="link_odd_elementSpec" href="#TEI.quote" title="&lt;quote&gt;">quote</a>]</span>]</span> <a class="link_odd_classSpec" href="#TEI.model.biblLike" title="model.biblLike">model.biblLike</a><span class="showmembers3">[<a class="link_odd_elementSpec" href="#TEI.bibl" title="&lt;bibl&gt;">bibl</a> <a class="link_odd_elementSpec" href="#TEI.biblStruct" title="&lt;biblStruct&gt;">biblStruct</a> <a class="link_odd_elementSpec" href="#TEI.listBibl" title="&lt;listBibl&gt;">listBibl</a>]</span> model.egLike model.labelLike <a class="link_odd_classSpec" href="#TEI.model.listLike" title="model.listLike">model.listLike</a><span class="showmembers3">[<a class="link_odd_elementSpec" href="#TEI.list" title="&lt;list&gt;">list</a> <a class="link_odd_elementSpec" href="#TEI.listWit" title="&lt;listWit&gt;">listWit</a>]</span> model.oddDecl model.stageLike]</span> <a class="link_odd_classSpec" href="#TEI.model.lLike" title="model.lLike">model.lLike</a><span class="showmembers2">[<a class="link_odd_elementSpec" href="#TEI.l" title="&lt;l&gt;">l</a>]</span> <a class="link_odd_classSpec" href="#TEI.model.phrase" title="model.phrase">model.phrase</a><span class="showmembers2">[<a class="link_odd_classSpec" href="#TEI.model.graphicLike" title="model.graphicLike">model.graphicLike</a><span class="showmembers3">[<a class="link_odd_elementSpec" href="#TEI.graphic" title="&lt;graphic&gt;">graphic</a>]</span> <a class="link_odd_classSpec" href="#TEI.model.highlighted" title="model.highlighted">model.highlighted</a><span class="showmembers3">[<a class="link_odd_classSpec" href="#TEI.model.emphLike" title="model.emphLike">model.emphLike</a><span class="showmembers4">[<a class="link_odd_elementSpec" href="#TEI.emph" title="&lt;emph&gt;">emph</a> <a class="link_odd_elementSpec" href="#TEI.foreign" title="&lt;foreign&gt;">foreign</a> <a class="link_odd_elementSpec" href="#TEI.gloss" title="&lt;gloss&gt;">gloss</a> <a class="link_odd_elementSpec" href="#TEI.term" title="&lt;term&gt;">term</a> <a class="link_odd_elementSpec" href="#TEI.title" title="&lt;title&gt;">title</a>]</span> <a class="link_odd_classSpec" href="#TEI.model.hiLike" title="model.hiLike">model.hiLike</a><span class="showmembers4">[<a class="link_odd_elementSpec" href="#TEI.hi" title="&lt;hi&gt;">hi</a> <a class="link_odd_elementSpec" href="#TEI.q" title="&lt;q&gt;">q</a>]</span>]</span> model.lPart <a class="link_odd_classSpec" href="#TEI.model.pPart.data" title="model.pPart.data">model.pPart.data</a><span class="showmembers3">[model.addressLike <a class="link_odd_classSpec" href="#TEI.model.dateLike" title="model.dateLike">model.dateLike</a><span class="showmembers4">[<a class="link_odd_elementSpec" href="#TEI.date" title="&lt;date&gt;">date</a>]</span> model.measureLike <a class="link_odd_classSpec" href="#TEI.model.nameLike" title="model.nameLike">model.nameLike</a><span class="showmembers4">[<a class="link_odd_classSpec" href="#TEI.model.nameLike.agent" title="model.nameLike.agent">model.nameLike.agent</a><span class="showmembers5">[<a class="link_odd_elementSpec" href="#TEI.name" title="&lt;name&gt;">name</a> <a class="link_odd_elementSpec" href="#TEI.orgName" title="&lt;orgName&gt;">orgName</a> <a class="link_odd_elementSpec" href="#TEI.persName" title="&lt;persName&gt;">persName</a>]</span> model.offsetLike model.persNamePart <a class="link_odd_classSpec" href="#TEI.model.placeStateLike" title="model.placeStateLike">model.placeStateLike</a><span class="showmembers5">[<a class="link_odd_classSpec" href="#TEI.model.placeNamePart" title="model.placeNamePart">model.placeNamePart</a><span class="showmembers6">[<a class="link_odd_elementSpec" href="#TEI.placeName" title="&lt;placeName&gt;">placeName</a>]</span>]</span>]</span>]</span> <a class="link_odd_classSpec" href="#TEI.model.pPart.edit" title="model.pPart.edit">model.pPart.edit</a><span class="showmembers3">[<a class="link_odd_classSpec" href="#TEI.model.pPart.editorial" title="model.pPart.editorial">model.pPart.editorial</a><span class="showmembers4">[<a class="link_odd_elementSpec" href="#TEI.abbr" title="&lt;abbr&gt;">abbr</a>]</span> model.pPart.transcriptional]</span> model.pPart.msdesc model.phrase.xml <a class="link_odd_classSpec" href="#TEI.model.ptrLike" title="model.ptrLike">model.ptrLike</a><span class="showmembers3">[<a class="link_odd_elementSpec" href="#TEI.ptr" title="&lt;ptr&gt;">ptr</a> <a class="link_odd_elementSpec" href="#TEI.ref" title="&lt;ref&gt;">ref</a>]</span> <a class="link_odd_classSpec" href="#TEI.model.segLike" title="model.segLike">model.segLike</a><span class="showmembers3">[<a class="link_odd_elementSpec" href="#TEI.s" title="&lt;s&gt;">s</a> <a class="link_odd_elementSpec" href="#TEI.seg" title="&lt;seg&gt;">seg</a> <a class="link_odd_elementSpec" href="#TEI.w" title="&lt;w&gt;">w</a>]</span> model.specDescLike]</span> <a class="link_odd_elementSpec" href="#TEI.lg" title="&lt;lg&gt;">lg</a></span></td>
+                           <td class="wovenodd-col2"><span class="showmembers1">model.gLike <a class="link_odd_classSpec" href="#TEI.model.global" title="model.global">model.global</a><span class="showmembers2">[<a class="link_odd_classSpec" href="#TEI.model.global.edit" title="model.global.edit">model.global.edit</a><span class="showmembers3">[<a class="link_odd_elementSpec" href="#TEI.app" title="&lt;app&gt;">app</a>]</span> <a class="link_odd_classSpec" href="#TEI.model.global.meta" title="model.global.meta">model.global.meta</a><span class="showmembers3">[<a class="link_odd_elementSpec" href="#TEI.listTranspose" title="&lt;listTranspose&gt;">listTranspose</a>]</span> <a class="link_odd_classSpec" href="#TEI.model.milestoneLike" title="model.milestoneLike">model.milestoneLike</a><span class="showmembers3">[<a class="link_odd_elementSpec" href="#TEI.cb" title="&lt;cb&gt;">cb</a> <a class="link_odd_elementSpec" href="#TEI.fw" title="&lt;fw&gt;">fw</a> <a class="link_odd_elementSpec" href="#TEI.lb" title="&lt;lb&gt;">lb</a> <a class="link_odd_elementSpec" href="#TEI.pb" title="&lt;pb&gt;">pb</a>]</span> <a class="link_odd_classSpec" href="#TEI.model.noteLike" title="model.noteLike">model.noteLike</a><span class="showmembers3">[<a class="link_odd_elementSpec" href="#TEI.note" title="&lt;note&gt;">note</a>]</span> <a class="link_odd_elementSpec" href="#TEI.figure" title="&lt;figure&gt;">figure</a>]</span> <a class="link_odd_classSpec" href="#TEI.model.inter" title="model.inter">model.inter</a><span class="showmembers2">[<a class="link_odd_classSpec" href="#TEI.model.attributable" title="model.attributable">model.attributable</a><span class="showmembers3">[<a class="link_odd_classSpec" href="#TEI.model.quoteLike" title="model.quoteLike">model.quoteLike</a><span class="showmembers4">[<a class="link_odd_elementSpec" href="#TEI.cit" title="&lt;cit&gt;">cit</a> <a class="link_odd_elementSpec" href="#TEI.quote" title="&lt;quote&gt;">quote</a>]</span>]</span> <a class="link_odd_classSpec" href="#TEI.model.biblLike" title="model.biblLike">model.biblLike</a><span class="showmembers3">[<a class="link_odd_elementSpec" href="#TEI.bibl" title="&lt;bibl&gt;">bibl</a> <a class="link_odd_elementSpec" href="#TEI.biblStruct" title="&lt;biblStruct&gt;">biblStruct</a> <a class="link_odd_elementSpec" href="#TEI.listBibl" title="&lt;listBibl&gt;">listBibl</a>]</span> model.egLike model.labelLike <a class="link_odd_classSpec" href="#TEI.model.listLike" title="model.listLike">model.listLike</a><span class="showmembers3">[<a class="link_odd_elementSpec" href="#TEI.list" title="&lt;list&gt;">list</a> <a class="link_odd_elementSpec" href="#TEI.listWit" title="&lt;listWit&gt;">listWit</a>]</span> model.oddDecl model.stageLike]</span> <a class="link_odd_classSpec" href="#TEI.model.lLike" title="model.lLike">model.lLike</a><span class="showmembers2">[<a class="link_odd_elementSpec" href="#TEI.l" title="&lt;l&gt;">l</a>]</span> <a class="link_odd_classSpec" href="#TEI.model.phrase" title="model.phrase">model.phrase</a><span class="showmembers2">[<a class="link_odd_classSpec" href="#TEI.model.graphicLike" title="model.graphicLike">model.graphicLike</a><span class="showmembers3">[<a class="link_odd_elementSpec" href="#TEI.graphic" title="&lt;graphic&gt;">graphic</a>]</span> <a class="link_odd_classSpec" href="#TEI.model.highlighted" title="model.highlighted">model.highlighted</a><span class="showmembers3">[<a class="link_odd_classSpec" href="#TEI.model.emphLike" title="model.emphLike">model.emphLike</a><span class="showmembers4">[<a class="link_odd_elementSpec" href="#TEI.emph" title="&lt;emph&gt;">emph</a> <a class="link_odd_elementSpec" href="#TEI.foreign" title="&lt;foreign&gt;">foreign</a> <a class="link_odd_elementSpec" href="#TEI.gloss" title="&lt;gloss&gt;">gloss</a> <a class="link_odd_elementSpec" href="#TEI.term" title="&lt;term&gt;">term</a> <a class="link_odd_elementSpec" href="#TEI.title" title="&lt;title&gt;">title</a>]</span> <a class="link_odd_classSpec" href="#TEI.model.hiLike" title="model.hiLike">model.hiLike</a><span class="showmembers4">[<a class="link_odd_elementSpec" href="#TEI.hi" title="&lt;hi&gt;">hi</a> <a class="link_odd_elementSpec" href="#TEI.q" title="&lt;q&gt;">q</a>]</span>]</span> model.lPart <a class="link_odd_classSpec" href="#TEI.model.pPart.data" title="model.pPart.data">model.pPart.data</a><span class="showmembers3">[model.addressLike <a class="link_odd_classSpec" href="#TEI.model.dateLike" title="model.dateLike">model.dateLike</a><span class="showmembers4">[<a class="link_odd_elementSpec" href="#TEI.date" title="&lt;date&gt;">date</a>]</span> model.measureLike <a class="link_odd_classSpec" href="#TEI.model.nameLike" title="model.nameLike">model.nameLike</a><span class="showmembers4">[<a class="link_odd_classSpec" href="#TEI.model.nameLike.agent" title="model.nameLike.agent">model.nameLike.agent</a><span class="showmembers5">[<a class="link_odd_elementSpec" href="#TEI.name" title="&lt;name&gt;">name</a> <a class="link_odd_elementSpec" href="#TEI.orgName" title="&lt;orgName&gt;">orgName</a> <a class="link_odd_elementSpec" href="#TEI.persName" title="&lt;persName&gt;">persName</a>]</span> model.offsetLike model.persNamePart <a class="link_odd_classSpec" href="#TEI.model.placeStateLike" title="model.placeStateLike">model.placeStateLike</a><span class="showmembers5">[<a class="link_odd_classSpec" href="#TEI.model.placeNamePart" title="model.placeNamePart">model.placeNamePart</a><span class="showmembers6">[<a class="link_odd_elementSpec" href="#TEI.placeName" title="&lt;placeName&gt;">placeName</a>]</span>]</span>]</span>]</span> <a class="link_odd_classSpec" href="#TEI.model.pPart.edit" title="model.pPart.edit">model.pPart.edit</a><span class="showmembers3">[<a class="link_odd_classSpec" href="#TEI.model.pPart.editorial" title="model.pPart.editorial">model.pPart.editorial</a><span class="showmembers4">[<a class="link_odd_elementSpec" href="#TEI.abbr" title="&lt;abbr&gt;">abbr</a>]</span> model.pPart.transcriptional]</span> model.pPart.msdesc model.phrase.xml <a class="link_odd_classSpec" href="#TEI.model.ptrLike" title="model.ptrLike">model.ptrLike</a><span class="showmembers3">[<a class="link_odd_elementSpec" href="#TEI.ptr" title="&lt;ptr&gt;">ptr</a> <a class="link_odd_elementSpec" href="#TEI.ref" title="&lt;ref&gt;">ref</a>]</span> <a class="link_odd_classSpec" href="#TEI.model.segLike" title="model.segLike">model.segLike</a><span class="showmembers3">[<a class="link_odd_elementSpec" href="#TEI.s" title="&lt;s&gt;">s</a> <a class="link_odd_elementSpec" href="#TEI.seg" title="&lt;seg&gt;">seg</a> <a class="link_odd_elementSpec" href="#TEI.w" title="&lt;w&gt;">w</a>]</span> model.specDescLike]</span> <a class="link_odd_elementSpec" href="#TEI.lg" title="&lt;lg&gt;">lg</a></span></td>
                         </tr>
                      </table>
                   </div>
                </div>
                <div class="refdoc" id="TEI.model.phrase">
-                  <h3><span class="headingNumber">5.2.38. </span><span class="head">model.phrase</span></h3>
+                  <h3><span class="headingNumber">5.2.40. </span><span class="head">model.phrase</span></h3>
                   <div class="table">
                      <table class="wovenodd">
                         <tr>
@@ -12465,7 +12981,7 @@ element witness
                   </div>
                </div>
                <div class="refdoc" id="TEI.model.placeNamePart">
-                  <h3><span class="headingNumber">5.2.39. </span><span class="head">model.placeNamePart</span></h3>
+                  <h3><span class="headingNumber">5.2.41. </span><span class="head">model.placeNamePart</span></h3>
                   <div class="table">
                      <table class="wovenodd">
                         <tr>
@@ -12489,7 +13005,7 @@ element witness
                   </div>
                </div>
                <div class="refdoc" id="TEI.model.placeStateLike">
-                  <h3><span class="headingNumber">5.2.40. </span><span class="head">model.placeStateLike</span></h3>
+                  <h3><span class="headingNumber">5.2.42. </span><span class="head">model.placeStateLike</span></h3>
                   <div class="table">
                      <table class="wovenodd">
                         <tr>
@@ -12513,7 +13029,7 @@ element witness
                   </div>
                </div>
                <div class="refdoc" id="TEI.model.ptrLike">
-                  <h3><span class="headingNumber">5.2.41. </span><span class="head">model.ptrLike</span></h3>
+                  <h3><span class="headingNumber">5.2.43. </span><span class="head">model.ptrLike</span></h3>
                   <div class="table">
                      <table class="wovenodd">
                         <tr>
@@ -12537,7 +13053,7 @@ element witness
                   </div>
                </div>
                <div class="refdoc" id="TEI.model.publicationStmtPart.agency">
-                  <h3><span class="headingNumber">5.2.42. </span><span class="head">model.publicationStmtPart.agency</span></h3>
+                  <h3><span class="headingNumber">5.2.44. </span><span class="head">model.publicationStmtPart.agency</span></h3>
                   <div class="table">
                      <table class="wovenodd">
                         <tr>
@@ -12570,7 +13086,7 @@ element witness
                   </div>
                </div>
                <div class="refdoc" id="TEI.model.publicationStmtPart.detail">
-                  <h3><span class="headingNumber">5.2.43. </span><span class="head">model.publicationStmtPart.detail</span></h3>
+                  <h3><span class="headingNumber">5.2.45. </span><span class="head">model.publicationStmtPart.detail</span></h3>
                   <div class="table">
                      <table class="wovenodd">
                         <tr>
@@ -12601,7 +13117,7 @@ element witness
                   </div>
                </div>
                <div class="refdoc" id="TEI.model.quoteLike">
-                  <h3><span class="headingNumber">5.2.44. </span><span class="head">model.quoteLike</span></h3>
+                  <h3><span class="headingNumber">5.2.46. </span><span class="head">model.quoteLike</span></h3>
                   <div class="table">
                      <table class="wovenodd">
                         <tr>
@@ -12625,7 +13141,7 @@ element witness
                   </div>
                </div>
                <div class="refdoc" id="TEI.model.rdgLike">
-                  <h3><span class="headingNumber">5.2.45. </span><span class="head">model.rdgLike</span></h3>
+                  <h3><span class="headingNumber">5.2.47. </span><span class="head">model.rdgLike</span></h3>
                   <div class="table">
                      <table class="wovenodd">
                         <tr>
@@ -12656,7 +13172,7 @@ element witness
                   </div>
                </div>
                <div class="refdoc" id="TEI.model.resource">
-                  <h3><span class="headingNumber">5.2.46. </span><span class="head">model.resource</span></h3>
+                  <h3><span class="headingNumber">5.2.48. </span><span class="head">model.resource</span></h3>
                   <div class="table">
                      <table class="wovenodd">
                         <tr>
@@ -12675,13 +13191,13 @@ element witness
                         </tr>
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Members</span></td>
-                           <td class="wovenodd-col2"><span class="showmembers1"><a class="link_odd_elementSpec" href="#TEI.text" title="&lt;text&gt;">text</a></span></td>
+                           <td class="wovenodd-col2"><span class="showmembers1"><a class="link_odd_elementSpec" href="#TEI.standOff" title="&lt;standOff&gt;">standOff</a> <a class="link_odd_elementSpec" href="#TEI.text" title="&lt;text&gt;">text</a></span></td>
                         </tr>
                      </table>
                   </div>
                </div>
                <div class="refdoc" id="TEI.model.respLike">
-                  <h3><span class="headingNumber">5.2.47. </span><span class="head">model.respLike</span></h3>
+                  <h3><span class="headingNumber">5.2.49. </span><span class="head">model.respLike</span></h3>
                   <div class="table">
                      <table class="wovenodd">
                         <tr>
@@ -12706,7 +13222,7 @@ element witness
                   </div>
                </div>
                <div class="refdoc" id="TEI.model.segLike">
-                  <h3><span class="headingNumber">5.2.48. </span><span class="head">model.segLike</span></h3>
+                  <h3><span class="headingNumber">5.2.50. </span><span class="head">model.segLike</span></h3>
                   <div class="table">
                      <table class="wovenodd">
                         <tr>
@@ -12736,8 +13252,32 @@ element witness
                      </table>
                   </div>
                </div>
+               <div class="refdoc" id="TEI.model.standOffPart">
+                  <h3><span class="headingNumber">5.2.51. </span><span class="head">model.standOffPart</span></h3>
+                  <div class="table">
+                     <table class="wovenodd">
+                        <tr>
+                           <td colspan="2" class="wovenodd-col2"><span class="label">model.standOffPart</span> <span xml:lang="en" lang="en">groups elements which may be used as children of <a class="link_ref" href="#TEI.standOff" title="&lt;standOff&gt;">&lt;standOff&gt;</a>.</span></td>
+                        </tr>
+                        <tr>
+                           <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Module</span></td>
+                           <td class="wovenodd-col2">tei</td>
+                        </tr>
+                        <tr>
+                           <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Used by</span></td>
+                           <td class="wovenodd-col2">
+                              <div class="parent"><a class="link_odd_elementSpec" href="#TEI.standOff" title="&lt;standOff&gt;">standOff</a></div>
+                           </td>
+                        </tr>
+                        <tr>
+                           <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Members</span></td>
+                           <td class="wovenodd-col2"><span class="showmembers1"><a class="link_odd_classSpec" href="#TEI.model.annotationLike" title="model.annotationLike">model.annotationLike</a><span class="showmembers2">[<a class="link_odd_elementSpec" href="#TEI.note" title="&lt;note&gt;">note</a>]</span> <a class="link_odd_classSpec" href="#TEI.model.biblLike" title="model.biblLike">model.biblLike</a><span class="showmembers2">[<a class="link_odd_elementSpec" href="#TEI.bibl" title="&lt;bibl&gt;">bibl</a> <a class="link_odd_elementSpec" href="#TEI.biblStruct" title="&lt;biblStruct&gt;">biblStruct</a> <a class="link_odd_elementSpec" href="#TEI.listBibl" title="&lt;listBibl&gt;">listBibl</a>]</span> <a class="link_odd_classSpec" href="#TEI.model.global.meta" title="model.global.meta">model.global.meta</a><span class="showmembers2">[<a class="link_odd_elementSpec" href="#TEI.listTranspose" title="&lt;listTranspose&gt;">listTranspose</a>]</span> <a class="link_odd_classSpec" href="#TEI.model.listLike" title="model.listLike">model.listLike</a><span class="showmembers2">[<a class="link_odd_elementSpec" href="#TEI.list" title="&lt;list&gt;">list</a> <a class="link_odd_elementSpec" href="#TEI.listWit" title="&lt;listWit&gt;">listWit</a>]</span> <a class="link_odd_elementSpec" href="#TEI.listChange" title="&lt;listChange&gt;">listChange</a> <a class="link_odd_elementSpec" href="#TEI.seg" title="&lt;seg&gt;">seg</a></span></td>
+                        </tr>
+                     </table>
+                  </div>
+               </div>
                <div class="refdoc" id="TEI.model.teiHeaderPart">
-                  <h3><span class="headingNumber">5.2.49. </span><span class="head">model.teiHeaderPart</span></h3>
+                  <h3><span class="headingNumber">5.2.52. </span><span class="head">model.teiHeaderPart</span></h3>
                   <div class="table">
                      <table class="wovenodd">
                         <tr>
@@ -12761,7 +13301,7 @@ element witness
                   </div>
                </div>
                <div class="refdoc" id="TEI.model.titlepagePart">
-                  <h3><span class="headingNumber">5.2.50. </span><span class="head">model.titlepagePart</span></h3>
+                  <h3><span class="headingNumber">5.2.53. </span><span class="head">model.titlepagePart</span></h3>
                   <div class="table">
                      <table class="wovenodd">
                         <tr>
@@ -12872,7 +13412,7 @@ element witness
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Example</span></td>
                            <td class="wovenodd-col2">
-                              <div id="index.xml-egXML-d31e43439" class="pre egXML_valid"><span class="element">&lt;p&gt;</span>(...) tamen reuerendos dominos archiepiscopum et canonicos Leopolienses
+                              <div id="index.xml-egXML-d31e45117" class="pre egXML_valid"><span class="element">&lt;p&gt;</span>(...) tamen reuerendos dominos archiepiscopum et canonicos Leopolienses
                                   necnon episcopum in duplicibus Quatuortemporibus<span class="element">&lt;anchor <span class="attribute">xml:id</span>="<span class="attributevalue">A55234</span>"/&gt;</span> totaliter expediui...<span class="element">&lt;/p&gt;</span>
                                  <span class="comment">&lt;!-- elsewhere in the document --&gt;</span>
                                  <span class="element">&lt;noteGrp <span class="attribute">targetEnd</span>="<span class="attributevalue">#A55234</span>"&gt;</span>
@@ -12921,7 +13461,7 @@ element witness
                                                 </tr>
                                                 <tr>
                                                    <td colspan="2">In the following example from Hamlet, speeches (<span class="gi">&lt;sp&gt;</span>) in the body of the play are linked to <span class="gi">&lt;castItem&gt;</span> elements in the <span class="gi">&lt;castList&gt;</span> using the <span class="att">who</span> attribute.
-                                                      <div id="index.xml-egXML-d31e43543" class="pre egXML_feasible"><span class="element">&lt;castItem <span class="attribute">type</span>="<span class="attributevalue">role</span>"&gt;</span>
+                                                      <div id="index.xml-egXML-d31e45221" class="pre egXML_feasible"><span class="element">&lt;castItem <span class="attribute">type</span>="<span class="attributevalue">role</span>"&gt;</span>
                                                           <span class="element">&lt;role <span class="attribute">xml:id</span>="<span class="attributevalue">Barnardo</span>"&gt;</span>Bernardo<span class="element">&lt;/role&gt;</span>
                                                          <span class="element">&lt;/castItem&gt;</span>
                                                          <span class="element">&lt;castItem <span class="attribute">type</span>="<span class="attributevalue">role</span>"&gt;</span>
@@ -12992,7 +13532,7 @@ element witness
                                                 </tr>
                                                 <tr>
                                                    <td colspan="2">In the following example from Mary Pix's The False Friend, speeches (<span class="gi">&lt;sp&gt;</span>) in the body of the play are linked to <span class="gi">&lt;castItem&gt;</span> elements in the <span class="gi">&lt;castList&gt;</span> using the <span class="att">toWhom</span> attribute, which is used to specify who the speech is directed to. Additionally, the <span class="gi">&lt;stage&gt;</span> includes <span class="att">toWhom</span> to indicate the directionality of the action.
-                                                      <div id="index.xml-egXML-d31e43668" class="pre egXML_feasible"><span class="element">&lt;castItem <span class="attribute">type</span>="<span class="attributevalue">role</span>"&gt;</span>
+                                                      <div id="index.xml-egXML-d31e45346" class="pre egXML_feasible"><span class="element">&lt;castItem <span class="attribute">type</span>="<span class="attributevalue">role</span>"&gt;</span>
                                                           <span class="element">&lt;role <span class="attribute">xml:id</span>="<span class="attributevalue">emil</span>"&gt;</span>Emilius.<span class="element">&lt;/role&gt;</span>
                                                          <span class="element">&lt;/castItem&gt;</span>
                                                          <span class="element">&lt;castItem <span class="attribute">type</span>="<span class="attributevalue">role</span>"&gt;</span>
@@ -13086,7 +13626,7 @@ element witness
                                                 </tr>
                                                 <tr>
                                                    <td colspan="2">In the following lines from the <q class="titlea">Dream of the Rood</q>, linebreaks occur in the middle of the words <span class="mentioned">lāðost</span> and <span class="mentioned">reord-berendum</span>.
-                                                      <div id="index.xml-egXML-d31e43807" class="pre egXML_valid"><span class="element">&lt;ab&gt;</span> ...eƿesa tome iu icƿæs ȝeƿorden ƿita heardoſt .
+                                                      <div id="index.xml-egXML-d31e45485" class="pre egXML_valid"><span class="element">&lt;ab&gt;</span> ...eƿesa tome iu icƿæs ȝeƿorden ƿita heardoſt .
                                                           leodum la<span class="element">&lt;lb <span class="attribute">break</span>="<span class="attributevalue">no</span>"/&gt;</span> ðost ærþan ichim lifes
                                                           ƿeȝ rihtne ȝerymde reord be<span class="element">&lt;lb <span class="attribute">break</span>="<span class="attributevalue">no</span>"/&gt;</span>
                                                           rendum hƿæt me þaȝeƿeorðode ƿuldres ealdor ofer...
@@ -13194,7 +13734,7 @@ element witness
                                                 </tr>
                                                 <tr>
                                                    <td colspan="2">
-                                                      <div id="index.xml-egXML-d31e44057" class="pre egXML_valid"><span class="element">&lt;author&gt;</span>
+                                                      <div id="index.xml-egXML-d31e45735" class="pre egXML_valid"><span class="element">&lt;author&gt;</span>
                                                           <span class="element">&lt;name <span class="attribute">key</span>="<span class="attributevalue">name 427308</span>"
                                                               <span class="attribute">type</span>="<span class="attributevalue">organisation</span>"&gt;</span>[New Zealand Parliament, Legislative Council]<span class="element">&lt;/name&gt;</span>
                                                          <span class="element">&lt;/author&gt;</span></div>
@@ -13202,7 +13742,7 @@ element witness
                                                 </tr>
                                                 <tr>
                                                    <td colspan="2">
-                                                      <div id="index.xml-egXML-d31e44063" class="pre egXML_valid"><span class="element">&lt;author&gt;</span>
+                                                      <div id="index.xml-egXML-d31e45741" class="pre egXML_valid"><span class="element">&lt;author&gt;</span>
                                                           <span class="element">&lt;name <span class="attribute">key</span>="<span class="attributevalue">Hugo, Victor (1802-1885)</span>"
                                                               <span class="attribute">ref</span>="<span class="attributevalue">http://www.idref.fr/026927608</span>"&gt;</span>Victor Hugo<span class="element">&lt;/name&gt;</span>
                                                          <span class="element">&lt;/author&gt;</span></div>
@@ -13239,7 +13779,7 @@ element witness
                                                 </tr>
                                                 <tr>
                                                    <td colspan="2">
-                                                      <div id="index.xml-egXML-d31e44122" class="pre egXML_valid"><span class="element">&lt;name <span class="attribute">ref</span>="<span class="attributevalue">http://viaf.org/viaf/109557338</span>"
+                                                      <div id="index.xml-egXML-d31e45800" class="pre egXML_valid"><span class="element">&lt;name <span class="attribute">ref</span>="<span class="attributevalue">http://viaf.org/viaf/109557338</span>"
                                                              <span class="attribute">type</span>="<span class="attributevalue">person</span>"&gt;</span>Seamus Heaney<span class="element">&lt;/name&gt;</span></div>
                                                    </td>
                                                 </tr>
@@ -13311,7 +13851,7 @@ element witness
                                                 </tr>
                                                 <tr>
                                                    <td colspan="2">
-                                                      <div id="index.xml-egXML-d31e44332" class="pre egXML_valid">He was born on <span class="element">&lt;date <span class="attribute">calendar</span>="<span class="attributevalue">#gregorian</span>"&gt;</span>Feb. 22, 1732<span class="element">&lt;/date&gt;</span> (<span class="element">&lt;date <span class="attribute">calendar</span>="<span class="attributevalue">#julian</span>"
+                                                      <div id="index.xml-egXML-d31e46010" class="pre egXML_valid">He was born on <span class="element">&lt;date <span class="attribute">calendar</span>="<span class="attributevalue">#gregorian</span>"&gt;</span>Feb. 22, 1732<span class="element">&lt;/date&gt;</span> (<span class="element">&lt;date <span class="attribute">calendar</span>="<span class="attributevalue">#julian</span>"
                                                              <span class="attribute">when</span>="<span class="attributevalue">1732-02-22</span>"&gt;</span>Feb. 11, 1731/32,
                                                           O.S.<span class="element">&lt;/date&gt;</span>).
                                                          </div>
@@ -13319,7 +13859,7 @@ element witness
                                                 </tr>
                                                 <tr>
                                                    <td colspan="2">
-                                                      <div id="index.xml-egXML-d31e44342" class="pre egXML_valid"> He was born on <span class="element">&lt;date <span class="attribute">calendar</span>="<span class="attributevalue">#gregorian #julian</span>"
+                                                      <div id="index.xml-egXML-d31e46020" class="pre egXML_valid"> He was born on <span class="element">&lt;date <span class="attribute">calendar</span>="<span class="attributevalue">#gregorian #julian</span>"
                                                              <span class="attribute">when</span>="<span class="attributevalue">1732-02-22</span>"&gt;</span>Feb. 22, 1732
                                                           (Feb. 11, 1731/32, O.S.)<span class="element">&lt;/date&gt;</span>.
                                                          </div>
@@ -13405,7 +13945,7 @@ element witness
                                                 </tr>
                                                 <tr>
                                                    <td colspan="2">The following are examples of custom date or time formats that are <em>not</em> valid ISO or W3C format normalizations, normalized to a different dating system
-                                                      <div id="index.xml-egXML-d31e44563" class="pre egXML_valid"><span class="element">&lt;p&gt;</span>Alhazen died in Cairo on the
+                                                      <div id="index.xml-egXML-d31e46241" class="pre egXML_valid"><span class="element">&lt;p&gt;</span>Alhazen died in Cairo on the
                                                          <span class="element">&lt;date <span class="attribute">when</span>="<span class="attributevalue">1040-03-06</span>"
                                                               <span class="attribute">when-custom</span>="<span class="attributevalue">431-06-12</span>"&gt;</span> 12th day of Jumada t-Tania, 430 AH
                                                           <span class="element">&lt;/date&gt;</span>.<span class="element">&lt;/p&gt;</span>
@@ -13469,7 +14009,7 @@ element witness
                                                 </tr>
                                                 <tr>
                                                    <td colspan="2">
-                                                      <div id="index.xml-egXML-d31e44679" class="pre egXML_valid"><span class="element">&lt;event <span class="attribute">xml:id</span>="<span class="attributevalue">FIRE1</span>"
+                                                      <div id="index.xml-egXML-d31e46357" class="pre egXML_valid"><span class="element">&lt;event <span class="attribute">xml:id</span>="<span class="attributevalue">FIRE1</span>"
                                                              <span class="attribute">datingMethod</span>="<span class="attributevalue">#julian</span>"
                                                              <span class="attribute">from-custom</span>="<span class="attributevalue">1666-09-02</span>"
                                                              <span class="attribute">to-custom</span>="<span class="attributevalue">1666-09-05</span>"&gt;</span>
@@ -13530,7 +14070,7 @@ element witness
                                                 </tr>
                                                 <tr>
                                                    <td colspan="2">
-                                                      <div id="index.xml-egXML-d31e44763" class="pre egXML_valid">Contayning the Originall, Antiquity, Increaſe, Moderne
+                                                      <div id="index.xml-egXML-d31e46441" class="pre egXML_valid">Contayning the Originall, Antiquity, Increaſe, Moderne
                                                           eſtate, and deſcription of that Citie, written in the yeare
                                                          <span class="element">&lt;date <span class="attribute">when-custom</span>="<span class="attributevalue">1598</span>"
                                                              <span class="attribute">calendar</span>="<span class="attributevalue">#julian</span>"
@@ -13539,7 +14079,7 @@ element witness
                                                 </tr>
                                                 <tr>
                                                    <td colspan="2">
-                                                      <div id="index.xml-egXML-d31e44785" class="pre egXML_valid"><span class="element">&lt;date <span class="attribute">when</span>="<span class="attributevalue">1382-06-28</span>"
+                                                      <div id="index.xml-egXML-d31e46463" class="pre egXML_valid"><span class="element">&lt;date <span class="attribute">when</span>="<span class="attributevalue">1382-06-28</span>"
                                                              <span class="attribute">when-custom</span>="<span class="attributevalue">6890-06-20</span>"
                                                              <span class="attribute">datingMethod</span>="<span class="attributevalue">#creationOfWorld</span>"&gt;</span> μηνὶ Ἰουνίου εἰς <span class="element">&lt;num&gt;</span>κ<span class="element">&lt;/num&gt;</span> ἔτους <span class="element">&lt;num&gt;</span>ςωϞ<span class="element">&lt;/num&gt;</span>
                                                          <span class="element">&lt;/date&gt;</span></div>In this example, a date is given in a Mediaeval text measured <span class="q">‘from the creation of the world’</span>, which is normalized (in <span class="att">when</span>) to the Gregorian date, but is also normalized (in <span class="att">when-custom</span>) to a machine-actionable, numeric version of the date from the Creation.</td>
@@ -13597,7 +14137,7 @@ element witness
                                                 </tr>
                                                 <tr>
                                                    <td colspan="2">The following are examples of ISO date, time, and date &amp; time formats that are <em>not</em> valid W3C format normalizations.
-                                                      <div id="index.xml-egXML-d31e44961" class="pre egXML_valid"><span class="element">&lt;date <span class="attribute">when-iso</span>="<span class="attributevalue">1996-09-24T07:25+00</span>"&gt;</span>Sept. 24th, 1996 at 3:25 in the morning<span class="element">&lt;/date&gt;</span>
+                                                      <div id="index.xml-egXML-d31e46639" class="pre egXML_valid"><span class="element">&lt;date <span class="attribute">when-iso</span>="<span class="attributevalue">1996-09-24T07:25+00</span>"&gt;</span>Sept. 24th, 1996 at 3:25 in the morning<span class="element">&lt;/date&gt;</span>
                                                          <span class="element">&lt;date <span class="attribute">when-iso</span>="<span class="attributevalue">1996-09-24T03:25-04</span>"&gt;</span>Sept. 24th, 1996 at 3:25 in the morning<span class="element">&lt;/date&gt;</span>
                                                          <span class="element">&lt;time <span class="attribute">when-iso</span>="<span class="attributevalue">1999-01-04T20:42-05</span>"&gt;</span>4 Jan 1999 at 8:42 pm<span class="element">&lt;/time&gt;</span>
                                                          <span class="element">&lt;time <span class="attribute">when-iso</span>="<span class="attributevalue">1999-W01-1T20,70-05</span>"&gt;</span>4 Jan 1999 at 8:42 pm<span class="element">&lt;/time&gt;</span>
@@ -13608,7 +14148,7 @@ element witness
                                                 </tr>
                                                 <tr>
                                                    <td colspan="2">
-                                                      <div id="index.xml-egXML-d31e44987" class="pre egXML_valid">He likes to be punctual. I said <span class="element">&lt;q&gt;</span>
+                                                      <div id="index.xml-egXML-d31e46665" class="pre egXML_valid">He likes to be punctual. I said <span class="element">&lt;q&gt;</span>
                                                           <span class="element">&lt;time <span class="attribute">when-iso</span>="<span class="attributevalue">12</span>"&gt;</span>around noon<span class="element">&lt;/time&gt;</span>
                                                          <span class="element">&lt;/q&gt;</span>, and he showed up at <span class="element">&lt;time <span class="attribute">when-iso</span>="<span class="attributevalue">12:00:00</span>"&gt;</span>12 O'clock<span class="element">&lt;/time&gt;</span> on the dot.</div>The second occurence of <span class="gi">&lt;time&gt;</span> could have been encoded with the <span class="att">when</span> attribute, as <span class="val">12:00:00</span> is a valid time with respect to the W3C <span class="titlem">XML Schema Part 2: Datatypes Second Edition</span> specification. The first occurence could not.</td>
                                                 </tr>
@@ -13692,8 +14232,8 @@ element witness
                                  8601:2004, using the Gregorian calendar.</p>
                               <div class="p">If both <span class="att">when-iso</span> and <span class="att">dur-iso</span> are specified, the values should be interpreted as indicating a span of time by its
                                  starting time (or date) and duration. That is, 
-                                 <div id="index.xml-egXML-d31e45116" class="pre egXML_valid"><span class="element">&lt;date <span class="attribute">when-iso</span>="<span class="attributevalue">2007-06-01</span>" <span class="attribute">dur-iso</span>="<span class="attributevalue">P8D</span>"/&gt;</span></div> indicates the same time period as 
-                                 <div id="index.xml-egXML-d31e45119" class="pre egXML_valid"><span class="element">&lt;date <span class="attribute">when-iso</span>="<span class="attributevalue">2007-06-01/P8D</span>"/&gt;</span></div>
+                                 <div id="index.xml-egXML-d31e46794" class="pre egXML_valid"><span class="element">&lt;date <span class="attribute">when-iso</span>="<span class="attributevalue">2007-06-01</span>" <span class="attribute">dur-iso</span>="<span class="attributevalue">P8D</span>"/&gt;</span></div> indicates the same time period as 
+                                 <div id="index.xml-egXML-d31e46797" class="pre egXML_valid"><span class="element">&lt;date <span class="attribute">when-iso</span>="<span class="attributevalue">2007-06-01/P8D</span>"/&gt;</span></div>
                               </div>
                               <p>In providing a ‘regularized’ form, no claim is made that the form in the source text
                                  is incorrect; the regularized form is simply that chosen as the main form for purposes
@@ -13738,7 +14278,7 @@ element witness
                                                 </tr>
                                                 <tr>
                                                    <td colspan="2">Examples of W3C date, time, and date &amp; time formats.
-                                                      <div id="index.xml-egXML-d31e45259" class="pre egXML_valid"><span class="element">&lt;p&gt;</span>
+                                                      <div id="index.xml-egXML-d31e46937" class="pre egXML_valid"><span class="element">&lt;p&gt;</span>
                                                           <span class="element">&lt;date <span class="attribute">when</span>="<span class="attributevalue">1945-10-24</span>"&gt;</span>24 Oct 45<span class="element">&lt;/date&gt;</span>
                                                           <span class="element">&lt;date <span class="attribute">when</span>="<span class="attributevalue">1996-09-24T07:25:00Z</span>"&gt;</span>September 24th, 1996 at 3:25 in the morning<span class="element">&lt;/date&gt;</span>
                                                           <span class="element">&lt;time <span class="attribute">when</span>="<span class="attributevalue">1999-01-04T20:42:00-05:00</span>"&gt;</span>Jan 4 1999 at 8 pm<span class="element">&lt;/time&gt;</span>
@@ -13755,7 +14295,7 @@ element witness
                                                 </tr>
                                                 <tr>
                                                    <td colspan="2">
-                                                      <div id="index.xml-egXML-d31e45285" class="pre egXML_valid">This list begins in
+                                                      <div id="index.xml-egXML-d31e46963" class="pre egXML_valid">This list begins in
                                                           the year 1632, more precisely on Trinity Sunday, i.e. the Sunday after
                                                           Pentecost, in that year the
                                                          <span class="element">&lt;date <span class="attribute">calendar</span>="<span class="attributevalue">#julian</span>"
@@ -13764,7 +14304,7 @@ element witness
                                                 </tr>
                                                 <tr>
                                                    <td colspan="2">
-                                                      <div id="index.xml-egXML-d31e45292" class="pre egXML_valid"><span class="element">&lt;opener&gt;</span>
+                                                      <div id="index.xml-egXML-d31e46970" class="pre egXML_valid"><span class="element">&lt;opener&gt;</span>
                                                           <span class="element">&lt;dateline&gt;</span>
                                                            <span class="element">&lt;placeName&gt;</span>Dorchester, Village,<span class="element">&lt;/placeName&gt;</span>
                                                            <span class="element">&lt;date <span class="attribute">when</span>="<span class="attributevalue">1828-03-02</span>"&gt;</span>March 2d. 1828.<span class="element">&lt;/date&gt;</span>
@@ -13880,7 +14420,7 @@ element witness
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Example</span></td>
                            <td class="wovenodd-col2">
-                              <div id="index.xml-egXML-d31e45420" class="pre egXML_valid"><span class="element">&lt;date <span class="attribute">from</span>="<span class="attributevalue">1863-05-28</span>" <span class="attribute">to</span>="<span class="attributevalue">1863-06-01</span>"&gt;</span>28 May through 1 June 1863<span class="element">&lt;/date&gt;</span></div>
+                              <div id="index.xml-egXML-d31e47098" class="pre egXML_valid"><span class="element">&lt;date <span class="attribute">from</span>="<span class="attributevalue">1863-05-28</span>" <span class="attribute">to</span>="<span class="attributevalue">1863-06-01</span>"&gt;</span>28 May through 1 June 1863<span class="element">&lt;/date&gt;</span></div>
                            </td>
                         </tr>
                         <tr>
@@ -13983,7 +14523,7 @@ element witness
                            <td class="wovenodd-col2">The example below presents the TEI encoding of the <a class="link_ref" href="https://en.wikipedia.org/wiki/Name%E2%80%93value_pair">name-value pair</a> <code style="font-weight: normal; font-family: monospace;">&lt;part of speech, common noun&gt;</code>, where the name (key) <span class="q">‘part of speech’</span> is abbreviated as <span class="q">‘POS’</span>, and the value, <span class="q">‘common noun’</span> is symbolized by <span class="q">‘NN’</span>. The entire name-value pair is encoded by means of the element <span class="gi">&lt;f&gt;</span>. In TEI XML, that element acts as the container, labeled with the <span class="att">name</span> attribute. Its contents may be complex or simple. In the case at hand, the content
                               is the symbol <span class="q">‘NN’</span>.The <span class="att">datcat</span> attribute relates the feature <span style="font-style:italic">name</span> (i.e., the key) to the data category <span class="q">‘part of speech’</span>, while the attribute <span class="att">valueDatcat</span> relates the feature <span style="font-style:italic">value</span> to the data category <span class="term">common noun</span>. Both these data categories should be defined in an external and preferably open
                               reference taxonomy or ontology.
-                              <div id="index.xml-egXML-d31e45675" class="pre egXML_valid"><span class="element">&lt;fs&gt;</span>
+                              <div id="index.xml-egXML-d31e47353" class="pre egXML_valid"><span class="element">&lt;fs&gt;</span>
                                   <span class="element">&lt;f <span class="attribute">name</span>="<span class="attributevalue">POS</span>"
                                       <span class="attribute">datcat</span>="<span class="attributevalue">http://hdl.handle.net/11459/CCR_C-396_5a972b93-2294-ab5c-a541-7c344c5f26c3</span>"&gt;</span>
                                    <span class="element">&lt;symbol <span class="attribute">valueDatcat</span>="<span class="attributevalue">http://hdl.handle.net/11459/CCR_C-1256_7ec6083c-23d4-224d-6f94-eecbe6861545</span>"
@@ -14005,7 +14545,7 @@ element witness
                               structure markup. The following example is much more concise than the one above and
                               relies on the concepts of feature structure declaration and feature value library,
                               discussed in chapter [[undefined FS]]. 
-                              <div id="index.xml-egXML-d31e45725" class="pre egXML_valid"><span class="element">&lt;fs&gt;</span>
+                              <div id="index.xml-egXML-d31e47403" class="pre egXML_valid"><span class="element">&lt;fs&gt;</span>
                                   <span class="element">&lt;f <span class="attribute">name</span>="<span class="attributevalue">POS</span>" <span class="attribute">fVal</span>="<span class="attributevalue">#commonNoun</span>"/&gt;</span>
                                  <span class="comment">&lt;!-- ... --&gt;</span>
                                  <span class="element">&lt;/fs&gt;</span></div>The assumption here is that the relevant feature values are collected in a place that
@@ -14014,7 +14554,7 @@ element witness
                               presents an <span class="gi">&lt;fvLib&gt;</span> element that collects the relevant feature values (most of them omitted). At the same
                               time, this example shows one way of encoding a <span class="term">tagset</span>, i.e., an established inventory of values of (in the case at hand) morphosyntactic
                               categories. 
-                              <div id="index.xml-egXML-d31e45746" class="pre egXML_valid"><span class="element">&lt;fvLib <span class="attribute">n</span>="<span class="attributevalue">POS values</span>"&gt;</span>
+                              <div id="index.xml-egXML-d31e47424" class="pre egXML_valid"><span class="element">&lt;fvLib <span class="attribute">n</span>="<span class="attributevalue">POS values</span>"&gt;</span>
                                   <span class="element">&lt;symbol <span class="attribute">xml:id</span>="<span class="attributevalue">commonNoun</span>" <span class="attribute">value</span>="<span class="attributevalue">NN</span>"
                                       <span class="attribute">datcat</span>="<span class="attributevalue">http://hdl.handle.net/11459/CCR_C-396_5a972b93-2294-ab5c-a541-7c344c5f26c3</span>"/&gt;</span>
                                   <span class="element">&lt;symbol <span class="attribute">xml:id</span>="<span class="attributevalue">properNoun</span>" <span class="attribute">value</span>="<span class="attributevalue">NP</span>"
@@ -14031,14 +14571,14 @@ element witness
                            <td class="wovenodd-col2">In the context of dictionaries designed with semantic interoperability in mind, the
                               following example ensures that the <span class="gi">&lt;pos&gt;</span> element is interpreted as the same information container as in the case of the example
                               of <span class="tag">&lt;f name="POS"&gt;</span> above.
-                              <div id="index.xml-egXML-d31e45774" class="pre egXML_valid"><span class="element">&lt;gramGrp&gt;</span>
+                              <div id="index.xml-egXML-d31e47452" class="pre egXML_valid"><span class="element">&lt;gramGrp&gt;</span>
                                   <span class="element">&lt;pos <span class="attribute">datcat</span>="<span class="attributevalue">http://hdl.handle.net/11459/CCR_C-396_5a972b93-2294-ab5c-a541-7c344c5f26c3</span>"
                                       <span class="attribute">valueDatcat</span>="<span class="attributevalue">http://hdl.handle.net/11459/CCR_C-1256_7ec6083c-23d4-224d-6f94-eecbe6861545</span>"&gt;</span>NN<span class="element">&lt;/pos&gt;</span>
                                  <span class="element">&lt;/gramGrp&gt;</span></div>Efficiency of this type of interoperable markup demands that the references to the
                               particular data categories should best be provided in a single place within the dictionary
                               (or a single place within the project), rather than being repeated inside every entry.
                               For the container elements, this can be achieved at the level of <span class="gi">&lt;tagUsage&gt;</span>, although here, the <span class="att">valueDatcat</span> attribute should be used, because it is not the <span class="gi">&lt;tagUsage&gt;</span> element that is associated with the relevant data category, but rather the element <span class="gi">&lt;pos&gt;</span> (or <span class="gi">&lt;case&gt;</span>, etc.) that is described by <span class="gi">&lt;tagUsage&gt;</span>: 
-                              <div id="index.xml-egXML-d31e45793" class="pre egXML_valid"><span class="element">&lt;tagsDecl <span class="attribute">partial</span>="<span class="attributevalue">true</span>"&gt;</span>
+                              <div id="index.xml-egXML-d31e47471" class="pre egXML_valid"><span class="element">&lt;tagsDecl <span class="attribute">partial</span>="<span class="attributevalue">true</span>"&gt;</span>
                                  <span class="comment">&lt;!-- ... --&gt;</span>
                                   <span class="element">&lt;namespace <span class="attribute">name</span>="<span class="attributevalue">http://www.tei-c.org/ns/1.0</span>"&gt;</span>
                                    <span class="element">&lt;tagUsage <span class="attribute">gi</span>="<span class="attributevalue">pos</span>"
@@ -14049,7 +14589,7 @@ element witness
                                  <span class="comment">&lt;!-- ... --&gt;</span>
                                   <span class="element">&lt;/namespace&gt;</span>
                                  <span class="element">&lt;/tagsDecl&gt;</span></div>Another possibility is to shorten the URIs by means of the <span class="gi">&lt;prefixDef&gt;</span> mechanism, as illustrated below: 
-                              <div id="index.xml-egXML-d31e45806" class="pre egXML_feasible"><span class="element">&lt;listPrefixDef&gt;</span>
+                              <div id="index.xml-egXML-d31e47484" class="pre egXML_feasible"><span class="element">&lt;listPrefixDef&gt;</span>
                                   <span class="element">&lt;prefixDef <span class="attribute">ident</span>="<span class="attributevalue">ccr</span>" <span class="attribute">matchPattern</span>="<span class="attributevalue">pos</span>"
                                       <span class="attribute">replacementPattern</span>="<span class="attributevalue">http://hdl.handle.net/11459/CCR_C-396_5a972b93-2294-ab5c-a541-7c344c5f26c3</span>"/&gt;</span>
                                   <span class="element">&lt;prefixDef <span class="attribute">ident</span>="<span class="attributevalue">ccr</span>" <span class="attribute">matchPattern</span>="<span class="attributevalue">adj</span>"
@@ -14079,7 +14619,7 @@ element witness
                            <td class="wovenodd-col2">The <span class="att">targetDatcat</span> attribute is designed to be used in, e.g., feature structure declarations, and is
                               analogous to the <span class="att">targetLang</span> attribute of the <span class="ident">att.pointing</span> class, in that it describes the object that is being referenced, rather than the referencing
                               object.
-                              <div id="index.xml-egXML-d31e45847" class="pre egXML_valid"><span class="element">&lt;fDecl <span class="attribute">name</span>="<span class="attributevalue">POS</span>"
+                              <div id="index.xml-egXML-d31e47525" class="pre egXML_valid"><span class="element">&lt;fDecl <span class="attribute">name</span>="<span class="attributevalue">POS</span>"
                                      <span class="attribute">targetDatcat</span>="<span class="attributevalue">http://hdl.handle.net/11459/CCR_C-396_5a972b93-2294-ab5c-a541-7c344c5f26c3</span>"&gt;</span>
                                   <span class="element">&lt;fDescr&gt;</span>part of speech (morphosyntactic category)<span class="element">&lt;/fDescr&gt;</span>
                                   <span class="element">&lt;vRange&gt;</span>
@@ -14209,7 +14749,7 @@ element witness
                         </tr>
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Members</span></td>
-                           <td class="wovenodd-col2"><span class="showmembers1"><a class="link_odd_elementSpec" href="#TEI.back" title="&lt;back&gt;">back</a> <a class="link_odd_elementSpec" href="#TEI.body" title="&lt;body&gt;">body</a> <a class="link_odd_elementSpec" href="#TEI.div" title="&lt;div&gt;">div</a> <a class="link_odd_elementSpec" href="#TEI.front" title="&lt;front&gt;">front</a> <a class="link_odd_elementSpec" href="#TEI.gloss" title="&lt;gloss&gt;">gloss</a> <a class="link_odd_elementSpec" href="#TEI.graphic" title="&lt;graphic&gt;">graphic</a> <a class="link_odd_elementSpec" href="#TEI.lg" title="&lt;lg&gt;">lg</a> <a class="link_odd_elementSpec" href="#TEI.p" title="&lt;p&gt;">p</a> <a class="link_odd_elementSpec" href="#TEI.ptr" title="&lt;ptr&gt;">ptr</a> <a class="link_odd_elementSpec" href="#TEI.ref" title="&lt;ref&gt;">ref</a> <a class="link_odd_elementSpec" href="#TEI.term" title="&lt;term&gt;">term</a> <a class="link_odd_elementSpec" href="#TEI.text" title="&lt;text&gt;">text</a></span></td>
+                           <td class="wovenodd-col2"><span class="showmembers1"><a class="link_odd_elementSpec" href="#TEI.back" title="&lt;back&gt;">back</a> <a class="link_odd_elementSpec" href="#TEI.body" title="&lt;body&gt;">body</a> <a class="link_odd_elementSpec" href="#TEI.div" title="&lt;div&gt;">div</a> <a class="link_odd_elementSpec" href="#TEI.front" title="&lt;front&gt;">front</a> <a class="link_odd_elementSpec" href="#TEI.gloss" title="&lt;gloss&gt;">gloss</a> <a class="link_odd_elementSpec" href="#TEI.graphic" title="&lt;graphic&gt;">graphic</a> <a class="link_odd_elementSpec" href="#TEI.lg" title="&lt;lg&gt;">lg</a> <a class="link_odd_elementSpec" href="#TEI.p" title="&lt;p&gt;">p</a> <a class="link_odd_elementSpec" href="#TEI.ptr" title="&lt;ptr&gt;">ptr</a> <a class="link_odd_elementSpec" href="#TEI.ref" title="&lt;ref&gt;">ref</a> <a class="link_odd_elementSpec" href="#TEI.standOff" title="&lt;standOff&gt;">standOff</a> <a class="link_odd_elementSpec" href="#TEI.term" title="&lt;term&gt;">term</a> <a class="link_odd_elementSpec" href="#TEI.text" title="&lt;text&gt;">text</a></span></td>
                         </tr>
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Attributes</span></td>
@@ -14331,12 +14871,12 @@ element witness
                                                 </tr>
                                                 <tr>
                                                    <td colspan="2">
-                                                      <div id="index.xml-egXML-d31e46385" class="pre egXML_valid"><span class="element">&lt;gap <span class="attribute">extent</span>="<span class="attributevalue">5 words</span>"/&gt;</span></div>
+                                                      <div id="index.xml-egXML-d31e48067" class="pre egXML_valid"><span class="element">&lt;gap <span class="attribute">extent</span>="<span class="attributevalue">5 words</span>"/&gt;</span></div>
                                                    </td>
                                                 </tr>
                                                 <tr>
                                                    <td colspan="2">
-                                                      <div id="index.xml-egXML-d31e46389" class="pre egXML_valid"><span class="element">&lt;height <span class="attribute">extent</span>="<span class="attributevalue">half the page</span>"/&gt;</span></div>
+                                                      <div id="index.xml-egXML-d31e48071" class="pre egXML_valid"><span class="element">&lt;height <span class="attribute">extent</span>="<span class="attributevalue">half the page</span>"/&gt;</span></div>
                                                    </td>
                                                 </tr>
                                              </table>
@@ -14567,7 +15107,7 @@ element witness
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Example</span></td>
                            <td class="wovenodd-col2">
-                              <div id="index.xml-egXML-d31e46743" class="pre egXML_valid"><span class="element">&lt;revisionDesc <span class="attribute">status</span>="<span class="attributevalue">published</span>"&gt;</span>
+                              <div id="index.xml-egXML-d31e48425" class="pre egXML_valid"><span class="element">&lt;revisionDesc <span class="attribute">status</span>="<span class="attributevalue">published</span>"&gt;</span>
                                   <span class="element">&lt;change <span class="attribute">when</span>="<span class="attributevalue">2010-10-21</span>"
                                       <span class="attribute">status</span>="<span class="attributevalue">published</span>"/&gt;</span>
                                   <span class="element">&lt;change <span class="attribute">when</span>="<span class="attributevalue">2010-10-02</span>" <span class="attribute">status</span>="<span class="attributevalue">cleared</span>"/&gt;</span>
@@ -14735,7 +15275,7 @@ element witness
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Example</span></td>
                            <td class="wovenodd-col2">
-                              <div id="index.xml-egXML-d31e47039" class="pre egXML_valid"><span class="element">&lt;l&gt;</span>Of Mans First Disobedience,<span class="element">&lt;lb <span class="attribute">ed</span>="<span class="attributevalue">1674</span>"/&gt;</span> and<span class="element">&lt;lb <span class="attribute">ed</span>="<span class="attributevalue">1667</span>"/&gt;</span> the Fruit<span class="element">&lt;/l&gt;</span>
+                              <div id="index.xml-egXML-d31e48721" class="pre egXML_valid"><span class="element">&lt;l&gt;</span>Of Mans First Disobedience,<span class="element">&lt;lb <span class="attribute">ed</span>="<span class="attributevalue">1674</span>"/&gt;</span> and<span class="element">&lt;lb <span class="attribute">ed</span>="<span class="attributevalue">1667</span>"/&gt;</span> the Fruit<span class="element">&lt;/l&gt;</span>
                                  <span class="element">&lt;l&gt;</span>Of that Forbidden Tree, whose<span class="element">&lt;lb <span class="attribute">ed</span>="<span class="attributevalue">1667 1674</span>"/&gt;</span> mortal tast<span class="element">&lt;/l&gt;</span>
                                  <span class="element">&lt;l&gt;</span>Brought Death into the World,<span class="element">&lt;lb <span class="attribute">ed</span>="<span class="attributevalue">1667</span>"/&gt;</span> and all<span class="element">&lt;lb <span class="attribute">ed</span>="<span class="attributevalue">1674</span>"/&gt;</span> our woe,<span class="element">&lt;/l&gt;</span></div>
                            </td>
@@ -14743,7 +15283,7 @@ element witness
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Example</span></td>
                            <td class="wovenodd-col2">
-                              <div id="index.xml-egXML-d31e47061" class="pre egXML_valid"><span class="element">&lt;listBibl&gt;</span>
+                              <div id="index.xml-egXML-d31e48743" class="pre egXML_valid"><span class="element">&lt;listBibl&gt;</span>
                                   <span class="element">&lt;bibl <span class="attribute">xml:id</span>="<span class="attributevalue">stapledon1937</span>"&gt;</span>
                                    <span class="element">&lt;author&gt;</span>Olaf Stapledon<span class="element">&lt;/author&gt;</span>,
                                   <span class="element">&lt;title&gt;</span>Starmaker<span class="element">&lt;/title&gt;</span>, <span class="element">&lt;publisher&gt;</span>Methuen<span class="element">&lt;/publisher&gt;</span>, <span class="element">&lt;date&gt;</span>1937<span class="element">&lt;/date&gt;</span>
@@ -14849,7 +15389,7 @@ element witness
                         </tr>
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Members</span></td>
-                           <td class="wovenodd-col2"><span class="showmembers1"><a class="link_odd_elementSpec" href="#TEI.TEI" title="&lt;TEI&gt;">TEI</a> <a class="link_odd_elementSpec" href="#TEI.abbr" title="&lt;abbr&gt;">abbr</a> <a class="link_odd_elementSpec" href="#TEI.app" title="&lt;app&gt;">app</a> <a class="link_odd_elementSpec" href="#TEI.author" title="&lt;author&gt;">author</a> <a class="link_odd_elementSpec" href="#TEI.authority" title="&lt;authority&gt;">authority</a> <a class="link_odd_elementSpec" href="#TEI.back" title="&lt;back&gt;">back</a> <a class="link_odd_elementSpec" href="#TEI.bibl" title="&lt;bibl&gt;">bibl</a> <a class="link_odd_elementSpec" href="#TEI.biblStruct" title="&lt;biblStruct&gt;">biblStruct</a> <a class="link_odd_elementSpec" href="#TEI.body" title="&lt;body&gt;">body</a> <a class="link_odd_elementSpec" href="#TEI.byline" title="&lt;byline&gt;">byline</a> <a class="link_odd_elementSpec" href="#TEI.cb" title="&lt;cb&gt;">cb</a> <a class="link_odd_elementSpec" href="#TEI.change" title="&lt;change&gt;">change</a> <a class="link_odd_elementSpec" href="#TEI.cit" title="&lt;cit&gt;">cit</a> <a class="link_odd_elementSpec" href="#TEI.date" title="&lt;date&gt;">date</a> <a class="link_odd_elementSpec" href="#TEI.div" title="&lt;div&gt;">div</a> <a class="link_odd_elementSpec" href="#TEI.docImprint" title="&lt;docImprint&gt;">docImprint</a> <a class="link_odd_elementSpec" href="#TEI.docTitle" title="&lt;docTitle&gt;">docTitle</a> <a class="link_odd_elementSpec" href="#TEI.edition" title="&lt;edition&gt;">edition</a> <a class="link_odd_elementSpec" href="#TEI.editionStmt" title="&lt;editionStmt&gt;">editionStmt</a> <a class="link_odd_elementSpec" href="#TEI.emph" title="&lt;emph&gt;">emph</a> <a class="link_odd_elementSpec" href="#TEI.encodingDesc" title="&lt;encodingDesc&gt;">encodingDesc</a> <a class="link_odd_elementSpec" href="#TEI.epigraph" title="&lt;epigraph&gt;">epigraph</a> <a class="link_odd_elementSpec" href="#TEI.figDesc" title="&lt;figDesc&gt;">figDesc</a> <a class="link_odd_elementSpec" href="#TEI.figure" title="&lt;figure&gt;">figure</a> <a class="link_odd_elementSpec" href="#TEI.fileDesc" title="&lt;fileDesc&gt;">fileDesc</a> <a class="link_odd_elementSpec" href="#TEI.foreign" title="&lt;foreign&gt;">foreign</a> <a class="link_odd_elementSpec" href="#TEI.front" title="&lt;front&gt;">front</a> <a class="link_odd_elementSpec" href="#TEI.funder" title="&lt;funder&gt;">funder</a> <a class="link_odd_elementSpec" href="#TEI.fw" title="&lt;fw&gt;">fw</a> <a class="link_odd_elementSpec" href="#TEI.gloss" title="&lt;gloss&gt;">gloss</a> <a class="link_odd_elementSpec" href="#TEI.graphic" title="&lt;graphic&gt;">graphic</a> <a class="link_odd_elementSpec" href="#TEI.head" title="&lt;head&gt;">head</a> <a class="link_odd_elementSpec" href="#TEI.hi" title="&lt;hi&gt;">hi</a> <a class="link_odd_elementSpec" href="#TEI.imprimatur" title="&lt;imprimatur&gt;">imprimatur</a> <a class="link_odd_elementSpec" href="#TEI.imprint" title="&lt;imprint&gt;">imprint</a> <a class="link_odd_elementSpec" href="#TEI.item" title="&lt;item&gt;">item</a> <a class="link_odd_elementSpec" href="#TEI.l" title="&lt;l&gt;">l</a> <a class="link_odd_elementSpec" href="#TEI.lb" title="&lt;lb&gt;">lb</a> <a class="link_odd_elementSpec" href="#TEI.lem" title="&lt;lem&gt;">lem</a> <a class="link_odd_elementSpec" href="#TEI.lg" title="&lt;lg&gt;">lg</a> <a class="link_odd_elementSpec" href="#TEI.licence" title="&lt;licence&gt;">licence</a> <a class="link_odd_elementSpec" href="#TEI.list" title="&lt;list&gt;">list</a> <a class="link_odd_elementSpec" href="#TEI.listBibl" title="&lt;listBibl&gt;">listBibl</a> <a class="link_odd_elementSpec" href="#TEI.listChange" title="&lt;listChange&gt;">listChange</a> <a class="link_odd_elementSpec" href="#TEI.listWit" title="&lt;listWit&gt;">listWit</a> <a class="link_odd_elementSpec" href="#TEI.monogr" title="&lt;monogr&gt;">monogr</a> <a class="link_odd_elementSpec" href="#TEI.name" title="&lt;name&gt;">name</a> <a class="link_odd_elementSpec" href="#TEI.note" title="&lt;note&gt;">note</a> <a class="link_odd_elementSpec" href="#TEI.orgName" title="&lt;orgName&gt;">orgName</a> <a class="link_odd_elementSpec" href="#TEI.p" title="&lt;p&gt;">p</a> <a class="link_odd_elementSpec" href="#TEI.pb" title="&lt;pb&gt;">pb</a> <a class="link_odd_elementSpec" href="#TEI.persName" title="&lt;persName&gt;">persName</a> <a class="link_odd_elementSpec" href="#TEI.placeName" title="&lt;placeName&gt;">placeName</a> <a class="link_odd_elementSpec" href="#TEI.principal" title="&lt;principal&gt;">principal</a> <a class="link_odd_elementSpec" href="#TEI.ptr" title="&lt;ptr&gt;">ptr</a> <a class="link_odd_elementSpec" href="#TEI.pubPlace" title="&lt;pubPlace&gt;">pubPlace</a> <a class="link_odd_elementSpec" href="#TEI.publicationStmt" title="&lt;publicationStmt&gt;">publicationStmt</a> <a class="link_odd_elementSpec" href="#TEI.publisher" title="&lt;publisher&gt;">publisher</a> <a class="link_odd_elementSpec" href="#TEI.q" title="&lt;q&gt;">q</a> <a class="link_odd_elementSpec" href="#TEI.quote" title="&lt;quote&gt;">quote</a> <a class="link_odd_elementSpec" href="#TEI.rdg" title="&lt;rdg&gt;">rdg</a> <a class="link_odd_elementSpec" href="#TEI.ref" title="&lt;ref&gt;">ref</a> <a class="link_odd_elementSpec" href="#TEI.resp" title="&lt;resp&gt;">resp</a> <a class="link_odd_elementSpec" href="#TEI.respStmt" title="&lt;respStmt&gt;">respStmt</a> <a class="link_odd_elementSpec" href="#TEI.revisionDesc" title="&lt;revisionDesc&gt;">revisionDesc</a> <a class="link_odd_elementSpec" href="#TEI.s" title="&lt;s&gt;">s</a> <a class="link_odd_elementSpec" href="#TEI.seg" title="&lt;seg&gt;">seg</a> <a class="link_odd_elementSpec" href="#TEI.signed" title="&lt;signed&gt;">signed</a> <a class="link_odd_elementSpec" href="#TEI.sourceDesc" title="&lt;sourceDesc&gt;">sourceDesc</a> <a class="link_odd_elementSpec" href="#TEI.teiHeader" title="&lt;teiHeader&gt;">teiHeader</a> <a class="link_odd_elementSpec" href="#TEI.term" title="&lt;term&gt;">term</a> <a class="link_odd_elementSpec" href="#TEI.text" title="&lt;text&gt;">text</a> <a class="link_odd_elementSpec" href="#TEI.title" title="&lt;title&gt;">title</a> <a class="link_odd_elementSpec" href="#TEI.titlePage" title="&lt;titlePage&gt;">titlePage</a> <a class="link_odd_elementSpec" href="#TEI.titlePart" title="&lt;titlePart&gt;">titlePart</a> <a class="link_odd_elementSpec" href="#TEI.titleStmt" title="&lt;titleStmt&gt;">titleStmt</a> <a class="link_odd_elementSpec" href="#TEI.trailer" title="&lt;trailer&gt;">trailer</a> <a class="link_odd_elementSpec" href="#TEI.variantEncoding" title="&lt;variantEncoding&gt;">variantEncoding</a> <a class="link_odd_elementSpec" href="#TEI.w" title="&lt;w&gt;">w</a> <a class="link_odd_elementSpec" href="#TEI.witness" title="&lt;witness&gt;">witness</a></span></td>
+                           <td class="wovenodd-col2"><span class="showmembers1"><a class="link_odd_elementSpec" href="#TEI.TEI" title="&lt;TEI&gt;">TEI</a> <a class="link_odd_elementSpec" href="#TEI.abbr" title="&lt;abbr&gt;">abbr</a> <a class="link_odd_elementSpec" href="#TEI.app" title="&lt;app&gt;">app</a> <a class="link_odd_elementSpec" href="#TEI.author" title="&lt;author&gt;">author</a> <a class="link_odd_elementSpec" href="#TEI.authority" title="&lt;authority&gt;">authority</a> <a class="link_odd_elementSpec" href="#TEI.back" title="&lt;back&gt;">back</a> <a class="link_odd_elementSpec" href="#TEI.bibl" title="&lt;bibl&gt;">bibl</a> <a class="link_odd_elementSpec" href="#TEI.biblStruct" title="&lt;biblStruct&gt;">biblStruct</a> <a class="link_odd_elementSpec" href="#TEI.body" title="&lt;body&gt;">body</a> <a class="link_odd_elementSpec" href="#TEI.byline" title="&lt;byline&gt;">byline</a> <a class="link_odd_elementSpec" href="#TEI.cb" title="&lt;cb&gt;">cb</a> <a class="link_odd_elementSpec" href="#TEI.change" title="&lt;change&gt;">change</a> <a class="link_odd_elementSpec" href="#TEI.cit" title="&lt;cit&gt;">cit</a> <a class="link_odd_elementSpec" href="#TEI.date" title="&lt;date&gt;">date</a> <a class="link_odd_elementSpec" href="#TEI.div" title="&lt;div&gt;">div</a> <a class="link_odd_elementSpec" href="#TEI.docImprint" title="&lt;docImprint&gt;">docImprint</a> <a class="link_odd_elementSpec" href="#TEI.docTitle" title="&lt;docTitle&gt;">docTitle</a> <a class="link_odd_elementSpec" href="#TEI.edition" title="&lt;edition&gt;">edition</a> <a class="link_odd_elementSpec" href="#TEI.editionStmt" title="&lt;editionStmt&gt;">editionStmt</a> <a class="link_odd_elementSpec" href="#TEI.emph" title="&lt;emph&gt;">emph</a> <a class="link_odd_elementSpec" href="#TEI.encodingDesc" title="&lt;encodingDesc&gt;">encodingDesc</a> <a class="link_odd_elementSpec" href="#TEI.epigraph" title="&lt;epigraph&gt;">epigraph</a> <a class="link_odd_elementSpec" href="#TEI.figDesc" title="&lt;figDesc&gt;">figDesc</a> <a class="link_odd_elementSpec" href="#TEI.figure" title="&lt;figure&gt;">figure</a> <a class="link_odd_elementSpec" href="#TEI.fileDesc" title="&lt;fileDesc&gt;">fileDesc</a> <a class="link_odd_elementSpec" href="#TEI.foreign" title="&lt;foreign&gt;">foreign</a> <a class="link_odd_elementSpec" href="#TEI.front" title="&lt;front&gt;">front</a> <a class="link_odd_elementSpec" href="#TEI.funder" title="&lt;funder&gt;">funder</a> <a class="link_odd_elementSpec" href="#TEI.fw" title="&lt;fw&gt;">fw</a> <a class="link_odd_elementSpec" href="#TEI.gloss" title="&lt;gloss&gt;">gloss</a> <a class="link_odd_elementSpec" href="#TEI.graphic" title="&lt;graphic&gt;">graphic</a> <a class="link_odd_elementSpec" href="#TEI.head" title="&lt;head&gt;">head</a> <a class="link_odd_elementSpec" href="#TEI.hi" title="&lt;hi&gt;">hi</a> <a class="link_odd_elementSpec" href="#TEI.imprimatur" title="&lt;imprimatur&gt;">imprimatur</a> <a class="link_odd_elementSpec" href="#TEI.imprint" title="&lt;imprint&gt;">imprint</a> <a class="link_odd_elementSpec" href="#TEI.item" title="&lt;item&gt;">item</a> <a class="link_odd_elementSpec" href="#TEI.l" title="&lt;l&gt;">l</a> <a class="link_odd_elementSpec" href="#TEI.lb" title="&lt;lb&gt;">lb</a> <a class="link_odd_elementSpec" href="#TEI.lem" title="&lt;lem&gt;">lem</a> <a class="link_odd_elementSpec" href="#TEI.lg" title="&lt;lg&gt;">lg</a> <a class="link_odd_elementSpec" href="#TEI.licence" title="&lt;licence&gt;">licence</a> <a class="link_odd_elementSpec" href="#TEI.list" title="&lt;list&gt;">list</a> <a class="link_odd_elementSpec" href="#TEI.listBibl" title="&lt;listBibl&gt;">listBibl</a> <a class="link_odd_elementSpec" href="#TEI.listChange" title="&lt;listChange&gt;">listChange</a> <a class="link_odd_elementSpec" href="#TEI.listTranspose" title="&lt;listTranspose&gt;">listTranspose</a> <a class="link_odd_elementSpec" href="#TEI.listWit" title="&lt;listWit&gt;">listWit</a> <a class="link_odd_elementSpec" href="#TEI.monogr" title="&lt;monogr&gt;">monogr</a> <a class="link_odd_elementSpec" href="#TEI.name" title="&lt;name&gt;">name</a> <a class="link_odd_elementSpec" href="#TEI.note" title="&lt;note&gt;">note</a> <a class="link_odd_elementSpec" href="#TEI.orgName" title="&lt;orgName&gt;">orgName</a> <a class="link_odd_elementSpec" href="#TEI.p" title="&lt;p&gt;">p</a> <a class="link_odd_elementSpec" href="#TEI.pb" title="&lt;pb&gt;">pb</a> <a class="link_odd_elementSpec" href="#TEI.persName" title="&lt;persName&gt;">persName</a> <a class="link_odd_elementSpec" href="#TEI.placeName" title="&lt;placeName&gt;">placeName</a> <a class="link_odd_elementSpec" href="#TEI.principal" title="&lt;principal&gt;">principal</a> <a class="link_odd_elementSpec" href="#TEI.ptr" title="&lt;ptr&gt;">ptr</a> <a class="link_odd_elementSpec" href="#TEI.pubPlace" title="&lt;pubPlace&gt;">pubPlace</a> <a class="link_odd_elementSpec" href="#TEI.publicationStmt" title="&lt;publicationStmt&gt;">publicationStmt</a> <a class="link_odd_elementSpec" href="#TEI.publisher" title="&lt;publisher&gt;">publisher</a> <a class="link_odd_elementSpec" href="#TEI.q" title="&lt;q&gt;">q</a> <a class="link_odd_elementSpec" href="#TEI.quote" title="&lt;quote&gt;">quote</a> <a class="link_odd_elementSpec" href="#TEI.rdg" title="&lt;rdg&gt;">rdg</a> <a class="link_odd_elementSpec" href="#TEI.ref" title="&lt;ref&gt;">ref</a> <a class="link_odd_elementSpec" href="#TEI.resp" title="&lt;resp&gt;">resp</a> <a class="link_odd_elementSpec" href="#TEI.respStmt" title="&lt;respStmt&gt;">respStmt</a> <a class="link_odd_elementSpec" href="#TEI.revisionDesc" title="&lt;revisionDesc&gt;">revisionDesc</a> <a class="link_odd_elementSpec" href="#TEI.s" title="&lt;s&gt;">s</a> <a class="link_odd_elementSpec" href="#TEI.seg" title="&lt;seg&gt;">seg</a> <a class="link_odd_elementSpec" href="#TEI.signed" title="&lt;signed&gt;">signed</a> <a class="link_odd_elementSpec" href="#TEI.sourceDesc" title="&lt;sourceDesc&gt;">sourceDesc</a> <a class="link_odd_elementSpec" href="#TEI.standOff" title="&lt;standOff&gt;">standOff</a> <a class="link_odd_elementSpec" href="#TEI.teiHeader" title="&lt;teiHeader&gt;">teiHeader</a> <a class="link_odd_elementSpec" href="#TEI.term" title="&lt;term&gt;">term</a> <a class="link_odd_elementSpec" href="#TEI.text" title="&lt;text&gt;">text</a> <a class="link_odd_elementSpec" href="#TEI.title" title="&lt;title&gt;">title</a> <a class="link_odd_elementSpec" href="#TEI.titlePage" title="&lt;titlePage&gt;">titlePage</a> <a class="link_odd_elementSpec" href="#TEI.titlePart" title="&lt;titlePart&gt;">titlePart</a> <a class="link_odd_elementSpec" href="#TEI.titleStmt" title="&lt;titleStmt&gt;">titleStmt</a> <a class="link_odd_elementSpec" href="#TEI.trailer" title="&lt;trailer&gt;">trailer</a> <a class="link_odd_elementSpec" href="#TEI.transpose" title="&lt;transpose&gt;">transpose</a> <a class="link_odd_elementSpec" href="#TEI.variantEncoding" title="&lt;variantEncoding&gt;">variantEncoding</a> <a class="link_odd_elementSpec" href="#TEI.w" title="&lt;w&gt;">w</a> <a class="link_odd_elementSpec" href="#TEI.witness" title="&lt;witness&gt;">witness</a></span></td>
                         </tr>
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Attributes</span></td>
@@ -14920,7 +15460,7 @@ element witness
                                                 </tr>
                                                 <tr>
                                                    <td colspan="2">
-                                                      <div id="index.xml-egXML-d31e47830" class="pre egXML_valid"><span class="element">&lt;p&gt;</span> … The consequences of
+                                                      <div id="index.xml-egXML-d31e49524" class="pre egXML_valid"><span class="element">&lt;p&gt;</span> … The consequences of
                                                           this rapid depopulation were the loss of the last
                                                          <span class="element">&lt;foreign <span class="attribute">xml:lang</span>="<span class="attributevalue">rap</span>"&gt;</span>ariki<span class="element">&lt;/foreign&gt;</span> or chief
                                                           (Routledge 1920:205,210) and their connections to
@@ -14963,7 +15503,7 @@ element witness
                                                 </tr>
                                                 <tr>
                                                    <td colspan="2">
-                                                      <div id="index.xml-egXML-d31e47908" class="pre egXML_valid"><span class="element">&lt;div <span class="attribute">type</span>="<span class="attributevalue">bibl</span>"&gt;</span>
+                                                      <div id="index.xml-egXML-d31e49602" class="pre egXML_valid"><span class="element">&lt;div <span class="attribute">type</span>="<span class="attributevalue">bibl</span>"&gt;</span>
                                                           <span class="element">&lt;head&gt;</span>Bibliography<span class="element">&lt;/head&gt;</span>
                                                           <span class="element">&lt;listBibl <span class="attribute">xml:base</span>="<span class="attributevalue">http://www.lib.ucdavis.edu/BWRP/Works/</span>"&gt;</span>
                                                            <span class="element">&lt;bibl&gt;</span>
@@ -15053,7 +15593,7 @@ element witness
                         </tr>
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Members</span></td>
-                           <td class="wovenodd-col2"><span class="showmembers1"><a class="link_odd_classSpec" href="#TEI.att.global" title="att.global">att.global</a><span class="showmembers2">[<a class="link_odd_elementSpec" href="#TEI.TEI" title="&lt;TEI&gt;">TEI</a> <a class="link_odd_elementSpec" href="#TEI.abbr" title="&lt;abbr&gt;">abbr</a> <a class="link_odd_elementSpec" href="#TEI.app" title="&lt;app&gt;">app</a> <a class="link_odd_elementSpec" href="#TEI.author" title="&lt;author&gt;">author</a> <a class="link_odd_elementSpec" href="#TEI.authority" title="&lt;authority&gt;">authority</a> <a class="link_odd_elementSpec" href="#TEI.back" title="&lt;back&gt;">back</a> <a class="link_odd_elementSpec" href="#TEI.bibl" title="&lt;bibl&gt;">bibl</a> <a class="link_odd_elementSpec" href="#TEI.biblStruct" title="&lt;biblStruct&gt;">biblStruct</a> <a class="link_odd_elementSpec" href="#TEI.body" title="&lt;body&gt;">body</a> <a class="link_odd_elementSpec" href="#TEI.byline" title="&lt;byline&gt;">byline</a> <a class="link_odd_elementSpec" href="#TEI.cb" title="&lt;cb&gt;">cb</a> <a class="link_odd_elementSpec" href="#TEI.change" title="&lt;change&gt;">change</a> <a class="link_odd_elementSpec" href="#TEI.cit" title="&lt;cit&gt;">cit</a> <a class="link_odd_elementSpec" href="#TEI.date" title="&lt;date&gt;">date</a> <a class="link_odd_elementSpec" href="#TEI.div" title="&lt;div&gt;">div</a> <a class="link_odd_elementSpec" href="#TEI.docImprint" title="&lt;docImprint&gt;">docImprint</a> <a class="link_odd_elementSpec" href="#TEI.docTitle" title="&lt;docTitle&gt;">docTitle</a> <a class="link_odd_elementSpec" href="#TEI.edition" title="&lt;edition&gt;">edition</a> <a class="link_odd_elementSpec" href="#TEI.editionStmt" title="&lt;editionStmt&gt;">editionStmt</a> <a class="link_odd_elementSpec" href="#TEI.emph" title="&lt;emph&gt;">emph</a> <a class="link_odd_elementSpec" href="#TEI.encodingDesc" title="&lt;encodingDesc&gt;">encodingDesc</a> <a class="link_odd_elementSpec" href="#TEI.epigraph" title="&lt;epigraph&gt;">epigraph</a> <a class="link_odd_elementSpec" href="#TEI.figDesc" title="&lt;figDesc&gt;">figDesc</a> <a class="link_odd_elementSpec" href="#TEI.figure" title="&lt;figure&gt;">figure</a> <a class="link_odd_elementSpec" href="#TEI.fileDesc" title="&lt;fileDesc&gt;">fileDesc</a> <a class="link_odd_elementSpec" href="#TEI.foreign" title="&lt;foreign&gt;">foreign</a> <a class="link_odd_elementSpec" href="#TEI.front" title="&lt;front&gt;">front</a> <a class="link_odd_elementSpec" href="#TEI.funder" title="&lt;funder&gt;">funder</a> <a class="link_odd_elementSpec" href="#TEI.fw" title="&lt;fw&gt;">fw</a> <a class="link_odd_elementSpec" href="#TEI.gloss" title="&lt;gloss&gt;">gloss</a> <a class="link_odd_elementSpec" href="#TEI.graphic" title="&lt;graphic&gt;">graphic</a> <a class="link_odd_elementSpec" href="#TEI.head" title="&lt;head&gt;">head</a> <a class="link_odd_elementSpec" href="#TEI.hi" title="&lt;hi&gt;">hi</a> <a class="link_odd_elementSpec" href="#TEI.imprimatur" title="&lt;imprimatur&gt;">imprimatur</a> <a class="link_odd_elementSpec" href="#TEI.imprint" title="&lt;imprint&gt;">imprint</a> <a class="link_odd_elementSpec" href="#TEI.item" title="&lt;item&gt;">item</a> <a class="link_odd_elementSpec" href="#TEI.l" title="&lt;l&gt;">l</a> <a class="link_odd_elementSpec" href="#TEI.lb" title="&lt;lb&gt;">lb</a> <a class="link_odd_elementSpec" href="#TEI.lem" title="&lt;lem&gt;">lem</a> <a class="link_odd_elementSpec" href="#TEI.lg" title="&lt;lg&gt;">lg</a> <a class="link_odd_elementSpec" href="#TEI.licence" title="&lt;licence&gt;">licence</a> <a class="link_odd_elementSpec" href="#TEI.list" title="&lt;list&gt;">list</a> <a class="link_odd_elementSpec" href="#TEI.listBibl" title="&lt;listBibl&gt;">listBibl</a> <a class="link_odd_elementSpec" href="#TEI.listChange" title="&lt;listChange&gt;">listChange</a> <a class="link_odd_elementSpec" href="#TEI.listWit" title="&lt;listWit&gt;">listWit</a> <a class="link_odd_elementSpec" href="#TEI.monogr" title="&lt;monogr&gt;">monogr</a> <a class="link_odd_elementSpec" href="#TEI.name" title="&lt;name&gt;">name</a> <a class="link_odd_elementSpec" href="#TEI.note" title="&lt;note&gt;">note</a> <a class="link_odd_elementSpec" href="#TEI.orgName" title="&lt;orgName&gt;">orgName</a> <a class="link_odd_elementSpec" href="#TEI.p" title="&lt;p&gt;">p</a> <a class="link_odd_elementSpec" href="#TEI.pb" title="&lt;pb&gt;">pb</a> <a class="link_odd_elementSpec" href="#TEI.persName" title="&lt;persName&gt;">persName</a> <a class="link_odd_elementSpec" href="#TEI.placeName" title="&lt;placeName&gt;">placeName</a> <a class="link_odd_elementSpec" href="#TEI.principal" title="&lt;principal&gt;">principal</a> <a class="link_odd_elementSpec" href="#TEI.ptr" title="&lt;ptr&gt;">ptr</a> <a class="link_odd_elementSpec" href="#TEI.pubPlace" title="&lt;pubPlace&gt;">pubPlace</a> <a class="link_odd_elementSpec" href="#TEI.publicationStmt" title="&lt;publicationStmt&gt;">publicationStmt</a> <a class="link_odd_elementSpec" href="#TEI.publisher" title="&lt;publisher&gt;">publisher</a> <a class="link_odd_elementSpec" href="#TEI.q" title="&lt;q&gt;">q</a> <a class="link_odd_elementSpec" href="#TEI.quote" title="&lt;quote&gt;">quote</a> <a class="link_odd_elementSpec" href="#TEI.rdg" title="&lt;rdg&gt;">rdg</a> <a class="link_odd_elementSpec" href="#TEI.ref" title="&lt;ref&gt;">ref</a> <a class="link_odd_elementSpec" href="#TEI.resp" title="&lt;resp&gt;">resp</a> <a class="link_odd_elementSpec" href="#TEI.respStmt" title="&lt;respStmt&gt;">respStmt</a> <a class="link_odd_elementSpec" href="#TEI.revisionDesc" title="&lt;revisionDesc&gt;">revisionDesc</a> <a class="link_odd_elementSpec" href="#TEI.s" title="&lt;s&gt;">s</a> <a class="link_odd_elementSpec" href="#TEI.seg" title="&lt;seg&gt;">seg</a> <a class="link_odd_elementSpec" href="#TEI.signed" title="&lt;signed&gt;">signed</a> <a class="link_odd_elementSpec" href="#TEI.sourceDesc" title="&lt;sourceDesc&gt;">sourceDesc</a> <a class="link_odd_elementSpec" href="#TEI.teiHeader" title="&lt;teiHeader&gt;">teiHeader</a> <a class="link_odd_elementSpec" href="#TEI.term" title="&lt;term&gt;">term</a> <a class="link_odd_elementSpec" href="#TEI.text" title="&lt;text&gt;">text</a> <a class="link_odd_elementSpec" href="#TEI.title" title="&lt;title&gt;">title</a> <a class="link_odd_elementSpec" href="#TEI.titlePage" title="&lt;titlePage&gt;">titlePage</a> <a class="link_odd_elementSpec" href="#TEI.titlePart" title="&lt;titlePart&gt;">titlePart</a> <a class="link_odd_elementSpec" href="#TEI.titleStmt" title="&lt;titleStmt&gt;">titleStmt</a> <a class="link_odd_elementSpec" href="#TEI.trailer" title="&lt;trailer&gt;">trailer</a> <a class="link_odd_elementSpec" href="#TEI.variantEncoding" title="&lt;variantEncoding&gt;">variantEncoding</a> <a class="link_odd_elementSpec" href="#TEI.w" title="&lt;w&gt;">w</a> <a class="link_odd_elementSpec" href="#TEI.witness" title="&lt;witness&gt;">witness</a>]</span></span></td>
+                           <td class="wovenodd-col2"><span class="showmembers1"><a class="link_odd_classSpec" href="#TEI.att.global" title="att.global">att.global</a><span class="showmembers2">[<a class="link_odd_elementSpec" href="#TEI.TEI" title="&lt;TEI&gt;">TEI</a> <a class="link_odd_elementSpec" href="#TEI.abbr" title="&lt;abbr&gt;">abbr</a> <a class="link_odd_elementSpec" href="#TEI.app" title="&lt;app&gt;">app</a> <a class="link_odd_elementSpec" href="#TEI.author" title="&lt;author&gt;">author</a> <a class="link_odd_elementSpec" href="#TEI.authority" title="&lt;authority&gt;">authority</a> <a class="link_odd_elementSpec" href="#TEI.back" title="&lt;back&gt;">back</a> <a class="link_odd_elementSpec" href="#TEI.bibl" title="&lt;bibl&gt;">bibl</a> <a class="link_odd_elementSpec" href="#TEI.biblStruct" title="&lt;biblStruct&gt;">biblStruct</a> <a class="link_odd_elementSpec" href="#TEI.body" title="&lt;body&gt;">body</a> <a class="link_odd_elementSpec" href="#TEI.byline" title="&lt;byline&gt;">byline</a> <a class="link_odd_elementSpec" href="#TEI.cb" title="&lt;cb&gt;">cb</a> <a class="link_odd_elementSpec" href="#TEI.change" title="&lt;change&gt;">change</a> <a class="link_odd_elementSpec" href="#TEI.cit" title="&lt;cit&gt;">cit</a> <a class="link_odd_elementSpec" href="#TEI.date" title="&lt;date&gt;">date</a> <a class="link_odd_elementSpec" href="#TEI.div" title="&lt;div&gt;">div</a> <a class="link_odd_elementSpec" href="#TEI.docImprint" title="&lt;docImprint&gt;">docImprint</a> <a class="link_odd_elementSpec" href="#TEI.docTitle" title="&lt;docTitle&gt;">docTitle</a> <a class="link_odd_elementSpec" href="#TEI.edition" title="&lt;edition&gt;">edition</a> <a class="link_odd_elementSpec" href="#TEI.editionStmt" title="&lt;editionStmt&gt;">editionStmt</a> <a class="link_odd_elementSpec" href="#TEI.emph" title="&lt;emph&gt;">emph</a> <a class="link_odd_elementSpec" href="#TEI.encodingDesc" title="&lt;encodingDesc&gt;">encodingDesc</a> <a class="link_odd_elementSpec" href="#TEI.epigraph" title="&lt;epigraph&gt;">epigraph</a> <a class="link_odd_elementSpec" href="#TEI.figDesc" title="&lt;figDesc&gt;">figDesc</a> <a class="link_odd_elementSpec" href="#TEI.figure" title="&lt;figure&gt;">figure</a> <a class="link_odd_elementSpec" href="#TEI.fileDesc" title="&lt;fileDesc&gt;">fileDesc</a> <a class="link_odd_elementSpec" href="#TEI.foreign" title="&lt;foreign&gt;">foreign</a> <a class="link_odd_elementSpec" href="#TEI.front" title="&lt;front&gt;">front</a> <a class="link_odd_elementSpec" href="#TEI.funder" title="&lt;funder&gt;">funder</a> <a class="link_odd_elementSpec" href="#TEI.fw" title="&lt;fw&gt;">fw</a> <a class="link_odd_elementSpec" href="#TEI.gloss" title="&lt;gloss&gt;">gloss</a> <a class="link_odd_elementSpec" href="#TEI.graphic" title="&lt;graphic&gt;">graphic</a> <a class="link_odd_elementSpec" href="#TEI.head" title="&lt;head&gt;">head</a> <a class="link_odd_elementSpec" href="#TEI.hi" title="&lt;hi&gt;">hi</a> <a class="link_odd_elementSpec" href="#TEI.imprimatur" title="&lt;imprimatur&gt;">imprimatur</a> <a class="link_odd_elementSpec" href="#TEI.imprint" title="&lt;imprint&gt;">imprint</a> <a class="link_odd_elementSpec" href="#TEI.item" title="&lt;item&gt;">item</a> <a class="link_odd_elementSpec" href="#TEI.l" title="&lt;l&gt;">l</a> <a class="link_odd_elementSpec" href="#TEI.lb" title="&lt;lb&gt;">lb</a> <a class="link_odd_elementSpec" href="#TEI.lem" title="&lt;lem&gt;">lem</a> <a class="link_odd_elementSpec" href="#TEI.lg" title="&lt;lg&gt;">lg</a> <a class="link_odd_elementSpec" href="#TEI.licence" title="&lt;licence&gt;">licence</a> <a class="link_odd_elementSpec" href="#TEI.list" title="&lt;list&gt;">list</a> <a class="link_odd_elementSpec" href="#TEI.listBibl" title="&lt;listBibl&gt;">listBibl</a> <a class="link_odd_elementSpec" href="#TEI.listChange" title="&lt;listChange&gt;">listChange</a> <a class="link_odd_elementSpec" href="#TEI.listTranspose" title="&lt;listTranspose&gt;">listTranspose</a> <a class="link_odd_elementSpec" href="#TEI.listWit" title="&lt;listWit&gt;">listWit</a> <a class="link_odd_elementSpec" href="#TEI.monogr" title="&lt;monogr&gt;">monogr</a> <a class="link_odd_elementSpec" href="#TEI.name" title="&lt;name&gt;">name</a> <a class="link_odd_elementSpec" href="#TEI.note" title="&lt;note&gt;">note</a> <a class="link_odd_elementSpec" href="#TEI.orgName" title="&lt;orgName&gt;">orgName</a> <a class="link_odd_elementSpec" href="#TEI.p" title="&lt;p&gt;">p</a> <a class="link_odd_elementSpec" href="#TEI.pb" title="&lt;pb&gt;">pb</a> <a class="link_odd_elementSpec" href="#TEI.persName" title="&lt;persName&gt;">persName</a> <a class="link_odd_elementSpec" href="#TEI.placeName" title="&lt;placeName&gt;">placeName</a> <a class="link_odd_elementSpec" href="#TEI.principal" title="&lt;principal&gt;">principal</a> <a class="link_odd_elementSpec" href="#TEI.ptr" title="&lt;ptr&gt;">ptr</a> <a class="link_odd_elementSpec" href="#TEI.pubPlace" title="&lt;pubPlace&gt;">pubPlace</a> <a class="link_odd_elementSpec" href="#TEI.publicationStmt" title="&lt;publicationStmt&gt;">publicationStmt</a> <a class="link_odd_elementSpec" href="#TEI.publisher" title="&lt;publisher&gt;">publisher</a> <a class="link_odd_elementSpec" href="#TEI.q" title="&lt;q&gt;">q</a> <a class="link_odd_elementSpec" href="#TEI.quote" title="&lt;quote&gt;">quote</a> <a class="link_odd_elementSpec" href="#TEI.rdg" title="&lt;rdg&gt;">rdg</a> <a class="link_odd_elementSpec" href="#TEI.ref" title="&lt;ref&gt;">ref</a> <a class="link_odd_elementSpec" href="#TEI.resp" title="&lt;resp&gt;">resp</a> <a class="link_odd_elementSpec" href="#TEI.respStmt" title="&lt;respStmt&gt;">respStmt</a> <a class="link_odd_elementSpec" href="#TEI.revisionDesc" title="&lt;revisionDesc&gt;">revisionDesc</a> <a class="link_odd_elementSpec" href="#TEI.s" title="&lt;s&gt;">s</a> <a class="link_odd_elementSpec" href="#TEI.seg" title="&lt;seg&gt;">seg</a> <a class="link_odd_elementSpec" href="#TEI.signed" title="&lt;signed&gt;">signed</a> <a class="link_odd_elementSpec" href="#TEI.sourceDesc" title="&lt;sourceDesc&gt;">sourceDesc</a> <a class="link_odd_elementSpec" href="#TEI.standOff" title="&lt;standOff&gt;">standOff</a> <a class="link_odd_elementSpec" href="#TEI.teiHeader" title="&lt;teiHeader&gt;">teiHeader</a> <a class="link_odd_elementSpec" href="#TEI.term" title="&lt;term&gt;">term</a> <a class="link_odd_elementSpec" href="#TEI.text" title="&lt;text&gt;">text</a> <a class="link_odd_elementSpec" href="#TEI.title" title="&lt;title&gt;">title</a> <a class="link_odd_elementSpec" href="#TEI.titlePage" title="&lt;titlePage&gt;">titlePage</a> <a class="link_odd_elementSpec" href="#TEI.titlePart" title="&lt;titlePart&gt;">titlePart</a> <a class="link_odd_elementSpec" href="#TEI.titleStmt" title="&lt;titleStmt&gt;">titleStmt</a> <a class="link_odd_elementSpec" href="#TEI.trailer" title="&lt;trailer&gt;">trailer</a> <a class="link_odd_elementSpec" href="#TEI.transpose" title="&lt;transpose&gt;">transpose</a> <a class="link_odd_elementSpec" href="#TEI.variantEncoding" title="&lt;variantEncoding&gt;">variantEncoding</a> <a class="link_odd_elementSpec" href="#TEI.w" title="&lt;w&gt;">w</a> <a class="link_odd_elementSpec" href="#TEI.witness" title="&lt;witness&gt;">witness</a>]</span></span></td>
                         </tr>
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Attributes</span></td>
@@ -15106,7 +15646,7 @@ element witness
                         </tr>
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Members</span></td>
-                           <td class="wovenodd-col2"><span class="showmembers1"><a class="link_odd_classSpec" href="#TEI.att.global" title="att.global">att.global</a><span class="showmembers2">[<a class="link_odd_elementSpec" href="#TEI.TEI" title="&lt;TEI&gt;">TEI</a> <a class="link_odd_elementSpec" href="#TEI.abbr" title="&lt;abbr&gt;">abbr</a> <a class="link_odd_elementSpec" href="#TEI.app" title="&lt;app&gt;">app</a> <a class="link_odd_elementSpec" href="#TEI.author" title="&lt;author&gt;">author</a> <a class="link_odd_elementSpec" href="#TEI.authority" title="&lt;authority&gt;">authority</a> <a class="link_odd_elementSpec" href="#TEI.back" title="&lt;back&gt;">back</a> <a class="link_odd_elementSpec" href="#TEI.bibl" title="&lt;bibl&gt;">bibl</a> <a class="link_odd_elementSpec" href="#TEI.biblStruct" title="&lt;biblStruct&gt;">biblStruct</a> <a class="link_odd_elementSpec" href="#TEI.body" title="&lt;body&gt;">body</a> <a class="link_odd_elementSpec" href="#TEI.byline" title="&lt;byline&gt;">byline</a> <a class="link_odd_elementSpec" href="#TEI.cb" title="&lt;cb&gt;">cb</a> <a class="link_odd_elementSpec" href="#TEI.change" title="&lt;change&gt;">change</a> <a class="link_odd_elementSpec" href="#TEI.cit" title="&lt;cit&gt;">cit</a> <a class="link_odd_elementSpec" href="#TEI.date" title="&lt;date&gt;">date</a> <a class="link_odd_elementSpec" href="#TEI.div" title="&lt;div&gt;">div</a> <a class="link_odd_elementSpec" href="#TEI.docImprint" title="&lt;docImprint&gt;">docImprint</a> <a class="link_odd_elementSpec" href="#TEI.docTitle" title="&lt;docTitle&gt;">docTitle</a> <a class="link_odd_elementSpec" href="#TEI.edition" title="&lt;edition&gt;">edition</a> <a class="link_odd_elementSpec" href="#TEI.editionStmt" title="&lt;editionStmt&gt;">editionStmt</a> <a class="link_odd_elementSpec" href="#TEI.emph" title="&lt;emph&gt;">emph</a> <a class="link_odd_elementSpec" href="#TEI.encodingDesc" title="&lt;encodingDesc&gt;">encodingDesc</a> <a class="link_odd_elementSpec" href="#TEI.epigraph" title="&lt;epigraph&gt;">epigraph</a> <a class="link_odd_elementSpec" href="#TEI.figDesc" title="&lt;figDesc&gt;">figDesc</a> <a class="link_odd_elementSpec" href="#TEI.figure" title="&lt;figure&gt;">figure</a> <a class="link_odd_elementSpec" href="#TEI.fileDesc" title="&lt;fileDesc&gt;">fileDesc</a> <a class="link_odd_elementSpec" href="#TEI.foreign" title="&lt;foreign&gt;">foreign</a> <a class="link_odd_elementSpec" href="#TEI.front" title="&lt;front&gt;">front</a> <a class="link_odd_elementSpec" href="#TEI.funder" title="&lt;funder&gt;">funder</a> <a class="link_odd_elementSpec" href="#TEI.fw" title="&lt;fw&gt;">fw</a> <a class="link_odd_elementSpec" href="#TEI.gloss" title="&lt;gloss&gt;">gloss</a> <a class="link_odd_elementSpec" href="#TEI.graphic" title="&lt;graphic&gt;">graphic</a> <a class="link_odd_elementSpec" href="#TEI.head" title="&lt;head&gt;">head</a> <a class="link_odd_elementSpec" href="#TEI.hi" title="&lt;hi&gt;">hi</a> <a class="link_odd_elementSpec" href="#TEI.imprimatur" title="&lt;imprimatur&gt;">imprimatur</a> <a class="link_odd_elementSpec" href="#TEI.imprint" title="&lt;imprint&gt;">imprint</a> <a class="link_odd_elementSpec" href="#TEI.item" title="&lt;item&gt;">item</a> <a class="link_odd_elementSpec" href="#TEI.l" title="&lt;l&gt;">l</a> <a class="link_odd_elementSpec" href="#TEI.lb" title="&lt;lb&gt;">lb</a> <a class="link_odd_elementSpec" href="#TEI.lem" title="&lt;lem&gt;">lem</a> <a class="link_odd_elementSpec" href="#TEI.lg" title="&lt;lg&gt;">lg</a> <a class="link_odd_elementSpec" href="#TEI.licence" title="&lt;licence&gt;">licence</a> <a class="link_odd_elementSpec" href="#TEI.list" title="&lt;list&gt;">list</a> <a class="link_odd_elementSpec" href="#TEI.listBibl" title="&lt;listBibl&gt;">listBibl</a> <a class="link_odd_elementSpec" href="#TEI.listChange" title="&lt;listChange&gt;">listChange</a> <a class="link_odd_elementSpec" href="#TEI.listWit" title="&lt;listWit&gt;">listWit</a> <a class="link_odd_elementSpec" href="#TEI.monogr" title="&lt;monogr&gt;">monogr</a> <a class="link_odd_elementSpec" href="#TEI.name" title="&lt;name&gt;">name</a> <a class="link_odd_elementSpec" href="#TEI.note" title="&lt;note&gt;">note</a> <a class="link_odd_elementSpec" href="#TEI.orgName" title="&lt;orgName&gt;">orgName</a> <a class="link_odd_elementSpec" href="#TEI.p" title="&lt;p&gt;">p</a> <a class="link_odd_elementSpec" href="#TEI.pb" title="&lt;pb&gt;">pb</a> <a class="link_odd_elementSpec" href="#TEI.persName" title="&lt;persName&gt;">persName</a> <a class="link_odd_elementSpec" href="#TEI.placeName" title="&lt;placeName&gt;">placeName</a> <a class="link_odd_elementSpec" href="#TEI.principal" title="&lt;principal&gt;">principal</a> <a class="link_odd_elementSpec" href="#TEI.ptr" title="&lt;ptr&gt;">ptr</a> <a class="link_odd_elementSpec" href="#TEI.pubPlace" title="&lt;pubPlace&gt;">pubPlace</a> <a class="link_odd_elementSpec" href="#TEI.publicationStmt" title="&lt;publicationStmt&gt;">publicationStmt</a> <a class="link_odd_elementSpec" href="#TEI.publisher" title="&lt;publisher&gt;">publisher</a> <a class="link_odd_elementSpec" href="#TEI.q" title="&lt;q&gt;">q</a> <a class="link_odd_elementSpec" href="#TEI.quote" title="&lt;quote&gt;">quote</a> <a class="link_odd_elementSpec" href="#TEI.rdg" title="&lt;rdg&gt;">rdg</a> <a class="link_odd_elementSpec" href="#TEI.ref" title="&lt;ref&gt;">ref</a> <a class="link_odd_elementSpec" href="#TEI.resp" title="&lt;resp&gt;">resp</a> <a class="link_odd_elementSpec" href="#TEI.respStmt" title="&lt;respStmt&gt;">respStmt</a> <a class="link_odd_elementSpec" href="#TEI.revisionDesc" title="&lt;revisionDesc&gt;">revisionDesc</a> <a class="link_odd_elementSpec" href="#TEI.s" title="&lt;s&gt;">s</a> <a class="link_odd_elementSpec" href="#TEI.seg" title="&lt;seg&gt;">seg</a> <a class="link_odd_elementSpec" href="#TEI.signed" title="&lt;signed&gt;">signed</a> <a class="link_odd_elementSpec" href="#TEI.sourceDesc" title="&lt;sourceDesc&gt;">sourceDesc</a> <a class="link_odd_elementSpec" href="#TEI.teiHeader" title="&lt;teiHeader&gt;">teiHeader</a> <a class="link_odd_elementSpec" href="#TEI.term" title="&lt;term&gt;">term</a> <a class="link_odd_elementSpec" href="#TEI.text" title="&lt;text&gt;">text</a> <a class="link_odd_elementSpec" href="#TEI.title" title="&lt;title&gt;">title</a> <a class="link_odd_elementSpec" href="#TEI.titlePage" title="&lt;titlePage&gt;">titlePage</a> <a class="link_odd_elementSpec" href="#TEI.titlePart" title="&lt;titlePart&gt;">titlePart</a> <a class="link_odd_elementSpec" href="#TEI.titleStmt" title="&lt;titleStmt&gt;">titleStmt</a> <a class="link_odd_elementSpec" href="#TEI.trailer" title="&lt;trailer&gt;">trailer</a> <a class="link_odd_elementSpec" href="#TEI.variantEncoding" title="&lt;variantEncoding&gt;">variantEncoding</a> <a class="link_odd_elementSpec" href="#TEI.w" title="&lt;w&gt;">w</a> <a class="link_odd_elementSpec" href="#TEI.witness" title="&lt;witness&gt;">witness</a>]</span></span></td>
+                           <td class="wovenodd-col2"><span class="showmembers1"><a class="link_odd_classSpec" href="#TEI.att.global" title="att.global">att.global</a><span class="showmembers2">[<a class="link_odd_elementSpec" href="#TEI.TEI" title="&lt;TEI&gt;">TEI</a> <a class="link_odd_elementSpec" href="#TEI.abbr" title="&lt;abbr&gt;">abbr</a> <a class="link_odd_elementSpec" href="#TEI.app" title="&lt;app&gt;">app</a> <a class="link_odd_elementSpec" href="#TEI.author" title="&lt;author&gt;">author</a> <a class="link_odd_elementSpec" href="#TEI.authority" title="&lt;authority&gt;">authority</a> <a class="link_odd_elementSpec" href="#TEI.back" title="&lt;back&gt;">back</a> <a class="link_odd_elementSpec" href="#TEI.bibl" title="&lt;bibl&gt;">bibl</a> <a class="link_odd_elementSpec" href="#TEI.biblStruct" title="&lt;biblStruct&gt;">biblStruct</a> <a class="link_odd_elementSpec" href="#TEI.body" title="&lt;body&gt;">body</a> <a class="link_odd_elementSpec" href="#TEI.byline" title="&lt;byline&gt;">byline</a> <a class="link_odd_elementSpec" href="#TEI.cb" title="&lt;cb&gt;">cb</a> <a class="link_odd_elementSpec" href="#TEI.change" title="&lt;change&gt;">change</a> <a class="link_odd_elementSpec" href="#TEI.cit" title="&lt;cit&gt;">cit</a> <a class="link_odd_elementSpec" href="#TEI.date" title="&lt;date&gt;">date</a> <a class="link_odd_elementSpec" href="#TEI.div" title="&lt;div&gt;">div</a> <a class="link_odd_elementSpec" href="#TEI.docImprint" title="&lt;docImprint&gt;">docImprint</a> <a class="link_odd_elementSpec" href="#TEI.docTitle" title="&lt;docTitle&gt;">docTitle</a> <a class="link_odd_elementSpec" href="#TEI.edition" title="&lt;edition&gt;">edition</a> <a class="link_odd_elementSpec" href="#TEI.editionStmt" title="&lt;editionStmt&gt;">editionStmt</a> <a class="link_odd_elementSpec" href="#TEI.emph" title="&lt;emph&gt;">emph</a> <a class="link_odd_elementSpec" href="#TEI.encodingDesc" title="&lt;encodingDesc&gt;">encodingDesc</a> <a class="link_odd_elementSpec" href="#TEI.epigraph" title="&lt;epigraph&gt;">epigraph</a> <a class="link_odd_elementSpec" href="#TEI.figDesc" title="&lt;figDesc&gt;">figDesc</a> <a class="link_odd_elementSpec" href="#TEI.figure" title="&lt;figure&gt;">figure</a> <a class="link_odd_elementSpec" href="#TEI.fileDesc" title="&lt;fileDesc&gt;">fileDesc</a> <a class="link_odd_elementSpec" href="#TEI.foreign" title="&lt;foreign&gt;">foreign</a> <a class="link_odd_elementSpec" href="#TEI.front" title="&lt;front&gt;">front</a> <a class="link_odd_elementSpec" href="#TEI.funder" title="&lt;funder&gt;">funder</a> <a class="link_odd_elementSpec" href="#TEI.fw" title="&lt;fw&gt;">fw</a> <a class="link_odd_elementSpec" href="#TEI.gloss" title="&lt;gloss&gt;">gloss</a> <a class="link_odd_elementSpec" href="#TEI.graphic" title="&lt;graphic&gt;">graphic</a> <a class="link_odd_elementSpec" href="#TEI.head" title="&lt;head&gt;">head</a> <a class="link_odd_elementSpec" href="#TEI.hi" title="&lt;hi&gt;">hi</a> <a class="link_odd_elementSpec" href="#TEI.imprimatur" title="&lt;imprimatur&gt;">imprimatur</a> <a class="link_odd_elementSpec" href="#TEI.imprint" title="&lt;imprint&gt;">imprint</a> <a class="link_odd_elementSpec" href="#TEI.item" title="&lt;item&gt;">item</a> <a class="link_odd_elementSpec" href="#TEI.l" title="&lt;l&gt;">l</a> <a class="link_odd_elementSpec" href="#TEI.lb" title="&lt;lb&gt;">lb</a> <a class="link_odd_elementSpec" href="#TEI.lem" title="&lt;lem&gt;">lem</a> <a class="link_odd_elementSpec" href="#TEI.lg" title="&lt;lg&gt;">lg</a> <a class="link_odd_elementSpec" href="#TEI.licence" title="&lt;licence&gt;">licence</a> <a class="link_odd_elementSpec" href="#TEI.list" title="&lt;list&gt;">list</a> <a class="link_odd_elementSpec" href="#TEI.listBibl" title="&lt;listBibl&gt;">listBibl</a> <a class="link_odd_elementSpec" href="#TEI.listChange" title="&lt;listChange&gt;">listChange</a> <a class="link_odd_elementSpec" href="#TEI.listTranspose" title="&lt;listTranspose&gt;">listTranspose</a> <a class="link_odd_elementSpec" href="#TEI.listWit" title="&lt;listWit&gt;">listWit</a> <a class="link_odd_elementSpec" href="#TEI.monogr" title="&lt;monogr&gt;">monogr</a> <a class="link_odd_elementSpec" href="#TEI.name" title="&lt;name&gt;">name</a> <a class="link_odd_elementSpec" href="#TEI.note" title="&lt;note&gt;">note</a> <a class="link_odd_elementSpec" href="#TEI.orgName" title="&lt;orgName&gt;">orgName</a> <a class="link_odd_elementSpec" href="#TEI.p" title="&lt;p&gt;">p</a> <a class="link_odd_elementSpec" href="#TEI.pb" title="&lt;pb&gt;">pb</a> <a class="link_odd_elementSpec" href="#TEI.persName" title="&lt;persName&gt;">persName</a> <a class="link_odd_elementSpec" href="#TEI.placeName" title="&lt;placeName&gt;">placeName</a> <a class="link_odd_elementSpec" href="#TEI.principal" title="&lt;principal&gt;">principal</a> <a class="link_odd_elementSpec" href="#TEI.ptr" title="&lt;ptr&gt;">ptr</a> <a class="link_odd_elementSpec" href="#TEI.pubPlace" title="&lt;pubPlace&gt;">pubPlace</a> <a class="link_odd_elementSpec" href="#TEI.publicationStmt" title="&lt;publicationStmt&gt;">publicationStmt</a> <a class="link_odd_elementSpec" href="#TEI.publisher" title="&lt;publisher&gt;">publisher</a> <a class="link_odd_elementSpec" href="#TEI.q" title="&lt;q&gt;">q</a> <a class="link_odd_elementSpec" href="#TEI.quote" title="&lt;quote&gt;">quote</a> <a class="link_odd_elementSpec" href="#TEI.rdg" title="&lt;rdg&gt;">rdg</a> <a class="link_odd_elementSpec" href="#TEI.ref" title="&lt;ref&gt;">ref</a> <a class="link_odd_elementSpec" href="#TEI.resp" title="&lt;resp&gt;">resp</a> <a class="link_odd_elementSpec" href="#TEI.respStmt" title="&lt;respStmt&gt;">respStmt</a> <a class="link_odd_elementSpec" href="#TEI.revisionDesc" title="&lt;revisionDesc&gt;">revisionDesc</a> <a class="link_odd_elementSpec" href="#TEI.s" title="&lt;s&gt;">s</a> <a class="link_odd_elementSpec" href="#TEI.seg" title="&lt;seg&gt;">seg</a> <a class="link_odd_elementSpec" href="#TEI.signed" title="&lt;signed&gt;">signed</a> <a class="link_odd_elementSpec" href="#TEI.sourceDesc" title="&lt;sourceDesc&gt;">sourceDesc</a> <a class="link_odd_elementSpec" href="#TEI.standOff" title="&lt;standOff&gt;">standOff</a> <a class="link_odd_elementSpec" href="#TEI.teiHeader" title="&lt;teiHeader&gt;">teiHeader</a> <a class="link_odd_elementSpec" href="#TEI.term" title="&lt;term&gt;">term</a> <a class="link_odd_elementSpec" href="#TEI.text" title="&lt;text&gt;">text</a> <a class="link_odd_elementSpec" href="#TEI.title" title="&lt;title&gt;">title</a> <a class="link_odd_elementSpec" href="#TEI.titlePage" title="&lt;titlePage&gt;">titlePage</a> <a class="link_odd_elementSpec" href="#TEI.titlePart" title="&lt;titlePart&gt;">titlePart</a> <a class="link_odd_elementSpec" href="#TEI.titleStmt" title="&lt;titleStmt&gt;">titleStmt</a> <a class="link_odd_elementSpec" href="#TEI.trailer" title="&lt;trailer&gt;">trailer</a> <a class="link_odd_elementSpec" href="#TEI.transpose" title="&lt;transpose&gt;">transpose</a> <a class="link_odd_elementSpec" href="#TEI.variantEncoding" title="&lt;variantEncoding&gt;">variantEncoding</a> <a class="link_odd_elementSpec" href="#TEI.w" title="&lt;w&gt;">w</a> <a class="link_odd_elementSpec" href="#TEI.witness" title="&lt;witness&gt;">witness</a>]</span></span></td>
                         </tr>
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Attributes</span></td>
@@ -15151,7 +15691,7 @@ element witness
                         </tr>
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Members</span></td>
-                           <td class="wovenodd-col2"><span class="showmembers1"><a class="link_odd_classSpec" href="#TEI.att.global" title="att.global">att.global</a><span class="showmembers2">[<a class="link_odd_elementSpec" href="#TEI.TEI" title="&lt;TEI&gt;">TEI</a> <a class="link_odd_elementSpec" href="#TEI.abbr" title="&lt;abbr&gt;">abbr</a> <a class="link_odd_elementSpec" href="#TEI.app" title="&lt;app&gt;">app</a> <a class="link_odd_elementSpec" href="#TEI.author" title="&lt;author&gt;">author</a> <a class="link_odd_elementSpec" href="#TEI.authority" title="&lt;authority&gt;">authority</a> <a class="link_odd_elementSpec" href="#TEI.back" title="&lt;back&gt;">back</a> <a class="link_odd_elementSpec" href="#TEI.bibl" title="&lt;bibl&gt;">bibl</a> <a class="link_odd_elementSpec" href="#TEI.biblStruct" title="&lt;biblStruct&gt;">biblStruct</a> <a class="link_odd_elementSpec" href="#TEI.body" title="&lt;body&gt;">body</a> <a class="link_odd_elementSpec" href="#TEI.byline" title="&lt;byline&gt;">byline</a> <a class="link_odd_elementSpec" href="#TEI.cb" title="&lt;cb&gt;">cb</a> <a class="link_odd_elementSpec" href="#TEI.change" title="&lt;change&gt;">change</a> <a class="link_odd_elementSpec" href="#TEI.cit" title="&lt;cit&gt;">cit</a> <a class="link_odd_elementSpec" href="#TEI.date" title="&lt;date&gt;">date</a> <a class="link_odd_elementSpec" href="#TEI.div" title="&lt;div&gt;">div</a> <a class="link_odd_elementSpec" href="#TEI.docImprint" title="&lt;docImprint&gt;">docImprint</a> <a class="link_odd_elementSpec" href="#TEI.docTitle" title="&lt;docTitle&gt;">docTitle</a> <a class="link_odd_elementSpec" href="#TEI.edition" title="&lt;edition&gt;">edition</a> <a class="link_odd_elementSpec" href="#TEI.editionStmt" title="&lt;editionStmt&gt;">editionStmt</a> <a class="link_odd_elementSpec" href="#TEI.emph" title="&lt;emph&gt;">emph</a> <a class="link_odd_elementSpec" href="#TEI.encodingDesc" title="&lt;encodingDesc&gt;">encodingDesc</a> <a class="link_odd_elementSpec" href="#TEI.epigraph" title="&lt;epigraph&gt;">epigraph</a> <a class="link_odd_elementSpec" href="#TEI.figDesc" title="&lt;figDesc&gt;">figDesc</a> <a class="link_odd_elementSpec" href="#TEI.figure" title="&lt;figure&gt;">figure</a> <a class="link_odd_elementSpec" href="#TEI.fileDesc" title="&lt;fileDesc&gt;">fileDesc</a> <a class="link_odd_elementSpec" href="#TEI.foreign" title="&lt;foreign&gt;">foreign</a> <a class="link_odd_elementSpec" href="#TEI.front" title="&lt;front&gt;">front</a> <a class="link_odd_elementSpec" href="#TEI.funder" title="&lt;funder&gt;">funder</a> <a class="link_odd_elementSpec" href="#TEI.fw" title="&lt;fw&gt;">fw</a> <a class="link_odd_elementSpec" href="#TEI.gloss" title="&lt;gloss&gt;">gloss</a> <a class="link_odd_elementSpec" href="#TEI.graphic" title="&lt;graphic&gt;">graphic</a> <a class="link_odd_elementSpec" href="#TEI.head" title="&lt;head&gt;">head</a> <a class="link_odd_elementSpec" href="#TEI.hi" title="&lt;hi&gt;">hi</a> <a class="link_odd_elementSpec" href="#TEI.imprimatur" title="&lt;imprimatur&gt;">imprimatur</a> <a class="link_odd_elementSpec" href="#TEI.imprint" title="&lt;imprint&gt;">imprint</a> <a class="link_odd_elementSpec" href="#TEI.item" title="&lt;item&gt;">item</a> <a class="link_odd_elementSpec" href="#TEI.l" title="&lt;l&gt;">l</a> <a class="link_odd_elementSpec" href="#TEI.lb" title="&lt;lb&gt;">lb</a> <a class="link_odd_elementSpec" href="#TEI.lem" title="&lt;lem&gt;">lem</a> <a class="link_odd_elementSpec" href="#TEI.lg" title="&lt;lg&gt;">lg</a> <a class="link_odd_elementSpec" href="#TEI.licence" title="&lt;licence&gt;">licence</a> <a class="link_odd_elementSpec" href="#TEI.list" title="&lt;list&gt;">list</a> <a class="link_odd_elementSpec" href="#TEI.listBibl" title="&lt;listBibl&gt;">listBibl</a> <a class="link_odd_elementSpec" href="#TEI.listChange" title="&lt;listChange&gt;">listChange</a> <a class="link_odd_elementSpec" href="#TEI.listWit" title="&lt;listWit&gt;">listWit</a> <a class="link_odd_elementSpec" href="#TEI.monogr" title="&lt;monogr&gt;">monogr</a> <a class="link_odd_elementSpec" href="#TEI.name" title="&lt;name&gt;">name</a> <a class="link_odd_elementSpec" href="#TEI.note" title="&lt;note&gt;">note</a> <a class="link_odd_elementSpec" href="#TEI.orgName" title="&lt;orgName&gt;">orgName</a> <a class="link_odd_elementSpec" href="#TEI.p" title="&lt;p&gt;">p</a> <a class="link_odd_elementSpec" href="#TEI.pb" title="&lt;pb&gt;">pb</a> <a class="link_odd_elementSpec" href="#TEI.persName" title="&lt;persName&gt;">persName</a> <a class="link_odd_elementSpec" href="#TEI.placeName" title="&lt;placeName&gt;">placeName</a> <a class="link_odd_elementSpec" href="#TEI.principal" title="&lt;principal&gt;">principal</a> <a class="link_odd_elementSpec" href="#TEI.ptr" title="&lt;ptr&gt;">ptr</a> <a class="link_odd_elementSpec" href="#TEI.pubPlace" title="&lt;pubPlace&gt;">pubPlace</a> <a class="link_odd_elementSpec" href="#TEI.publicationStmt" title="&lt;publicationStmt&gt;">publicationStmt</a> <a class="link_odd_elementSpec" href="#TEI.publisher" title="&lt;publisher&gt;">publisher</a> <a class="link_odd_elementSpec" href="#TEI.q" title="&lt;q&gt;">q</a> <a class="link_odd_elementSpec" href="#TEI.quote" title="&lt;quote&gt;">quote</a> <a class="link_odd_elementSpec" href="#TEI.rdg" title="&lt;rdg&gt;">rdg</a> <a class="link_odd_elementSpec" href="#TEI.ref" title="&lt;ref&gt;">ref</a> <a class="link_odd_elementSpec" href="#TEI.resp" title="&lt;resp&gt;">resp</a> <a class="link_odd_elementSpec" href="#TEI.respStmt" title="&lt;respStmt&gt;">respStmt</a> <a class="link_odd_elementSpec" href="#TEI.revisionDesc" title="&lt;revisionDesc&gt;">revisionDesc</a> <a class="link_odd_elementSpec" href="#TEI.s" title="&lt;s&gt;">s</a> <a class="link_odd_elementSpec" href="#TEI.seg" title="&lt;seg&gt;">seg</a> <a class="link_odd_elementSpec" href="#TEI.signed" title="&lt;signed&gt;">signed</a> <a class="link_odd_elementSpec" href="#TEI.sourceDesc" title="&lt;sourceDesc&gt;">sourceDesc</a> <a class="link_odd_elementSpec" href="#TEI.teiHeader" title="&lt;teiHeader&gt;">teiHeader</a> <a class="link_odd_elementSpec" href="#TEI.term" title="&lt;term&gt;">term</a> <a class="link_odd_elementSpec" href="#TEI.text" title="&lt;text&gt;">text</a> <a class="link_odd_elementSpec" href="#TEI.title" title="&lt;title&gt;">title</a> <a class="link_odd_elementSpec" href="#TEI.titlePage" title="&lt;titlePage&gt;">titlePage</a> <a class="link_odd_elementSpec" href="#TEI.titlePart" title="&lt;titlePart&gt;">titlePart</a> <a class="link_odd_elementSpec" href="#TEI.titleStmt" title="&lt;titleStmt&gt;">titleStmt</a> <a class="link_odd_elementSpec" href="#TEI.trailer" title="&lt;trailer&gt;">trailer</a> <a class="link_odd_elementSpec" href="#TEI.variantEncoding" title="&lt;variantEncoding&gt;">variantEncoding</a> <a class="link_odd_elementSpec" href="#TEI.w" title="&lt;w&gt;">w</a> <a class="link_odd_elementSpec" href="#TEI.witness" title="&lt;witness&gt;">witness</a>]</span></span></td>
+                           <td class="wovenodd-col2"><span class="showmembers1"><a class="link_odd_classSpec" href="#TEI.att.global" title="att.global">att.global</a><span class="showmembers2">[<a class="link_odd_elementSpec" href="#TEI.TEI" title="&lt;TEI&gt;">TEI</a> <a class="link_odd_elementSpec" href="#TEI.abbr" title="&lt;abbr&gt;">abbr</a> <a class="link_odd_elementSpec" href="#TEI.app" title="&lt;app&gt;">app</a> <a class="link_odd_elementSpec" href="#TEI.author" title="&lt;author&gt;">author</a> <a class="link_odd_elementSpec" href="#TEI.authority" title="&lt;authority&gt;">authority</a> <a class="link_odd_elementSpec" href="#TEI.back" title="&lt;back&gt;">back</a> <a class="link_odd_elementSpec" href="#TEI.bibl" title="&lt;bibl&gt;">bibl</a> <a class="link_odd_elementSpec" href="#TEI.biblStruct" title="&lt;biblStruct&gt;">biblStruct</a> <a class="link_odd_elementSpec" href="#TEI.body" title="&lt;body&gt;">body</a> <a class="link_odd_elementSpec" href="#TEI.byline" title="&lt;byline&gt;">byline</a> <a class="link_odd_elementSpec" href="#TEI.cb" title="&lt;cb&gt;">cb</a> <a class="link_odd_elementSpec" href="#TEI.change" title="&lt;change&gt;">change</a> <a class="link_odd_elementSpec" href="#TEI.cit" title="&lt;cit&gt;">cit</a> <a class="link_odd_elementSpec" href="#TEI.date" title="&lt;date&gt;">date</a> <a class="link_odd_elementSpec" href="#TEI.div" title="&lt;div&gt;">div</a> <a class="link_odd_elementSpec" href="#TEI.docImprint" title="&lt;docImprint&gt;">docImprint</a> <a class="link_odd_elementSpec" href="#TEI.docTitle" title="&lt;docTitle&gt;">docTitle</a> <a class="link_odd_elementSpec" href="#TEI.edition" title="&lt;edition&gt;">edition</a> <a class="link_odd_elementSpec" href="#TEI.editionStmt" title="&lt;editionStmt&gt;">editionStmt</a> <a class="link_odd_elementSpec" href="#TEI.emph" title="&lt;emph&gt;">emph</a> <a class="link_odd_elementSpec" href="#TEI.encodingDesc" title="&lt;encodingDesc&gt;">encodingDesc</a> <a class="link_odd_elementSpec" href="#TEI.epigraph" title="&lt;epigraph&gt;">epigraph</a> <a class="link_odd_elementSpec" href="#TEI.figDesc" title="&lt;figDesc&gt;">figDesc</a> <a class="link_odd_elementSpec" href="#TEI.figure" title="&lt;figure&gt;">figure</a> <a class="link_odd_elementSpec" href="#TEI.fileDesc" title="&lt;fileDesc&gt;">fileDesc</a> <a class="link_odd_elementSpec" href="#TEI.foreign" title="&lt;foreign&gt;">foreign</a> <a class="link_odd_elementSpec" href="#TEI.front" title="&lt;front&gt;">front</a> <a class="link_odd_elementSpec" href="#TEI.funder" title="&lt;funder&gt;">funder</a> <a class="link_odd_elementSpec" href="#TEI.fw" title="&lt;fw&gt;">fw</a> <a class="link_odd_elementSpec" href="#TEI.gloss" title="&lt;gloss&gt;">gloss</a> <a class="link_odd_elementSpec" href="#TEI.graphic" title="&lt;graphic&gt;">graphic</a> <a class="link_odd_elementSpec" href="#TEI.head" title="&lt;head&gt;">head</a> <a class="link_odd_elementSpec" href="#TEI.hi" title="&lt;hi&gt;">hi</a> <a class="link_odd_elementSpec" href="#TEI.imprimatur" title="&lt;imprimatur&gt;">imprimatur</a> <a class="link_odd_elementSpec" href="#TEI.imprint" title="&lt;imprint&gt;">imprint</a> <a class="link_odd_elementSpec" href="#TEI.item" title="&lt;item&gt;">item</a> <a class="link_odd_elementSpec" href="#TEI.l" title="&lt;l&gt;">l</a> <a class="link_odd_elementSpec" href="#TEI.lb" title="&lt;lb&gt;">lb</a> <a class="link_odd_elementSpec" href="#TEI.lem" title="&lt;lem&gt;">lem</a> <a class="link_odd_elementSpec" href="#TEI.lg" title="&lt;lg&gt;">lg</a> <a class="link_odd_elementSpec" href="#TEI.licence" title="&lt;licence&gt;">licence</a> <a class="link_odd_elementSpec" href="#TEI.list" title="&lt;list&gt;">list</a> <a class="link_odd_elementSpec" href="#TEI.listBibl" title="&lt;listBibl&gt;">listBibl</a> <a class="link_odd_elementSpec" href="#TEI.listChange" title="&lt;listChange&gt;">listChange</a> <a class="link_odd_elementSpec" href="#TEI.listTranspose" title="&lt;listTranspose&gt;">listTranspose</a> <a class="link_odd_elementSpec" href="#TEI.listWit" title="&lt;listWit&gt;">listWit</a> <a class="link_odd_elementSpec" href="#TEI.monogr" title="&lt;monogr&gt;">monogr</a> <a class="link_odd_elementSpec" href="#TEI.name" title="&lt;name&gt;">name</a> <a class="link_odd_elementSpec" href="#TEI.note" title="&lt;note&gt;">note</a> <a class="link_odd_elementSpec" href="#TEI.orgName" title="&lt;orgName&gt;">orgName</a> <a class="link_odd_elementSpec" href="#TEI.p" title="&lt;p&gt;">p</a> <a class="link_odd_elementSpec" href="#TEI.pb" title="&lt;pb&gt;">pb</a> <a class="link_odd_elementSpec" href="#TEI.persName" title="&lt;persName&gt;">persName</a> <a class="link_odd_elementSpec" href="#TEI.placeName" title="&lt;placeName&gt;">placeName</a> <a class="link_odd_elementSpec" href="#TEI.principal" title="&lt;principal&gt;">principal</a> <a class="link_odd_elementSpec" href="#TEI.ptr" title="&lt;ptr&gt;">ptr</a> <a class="link_odd_elementSpec" href="#TEI.pubPlace" title="&lt;pubPlace&gt;">pubPlace</a> <a class="link_odd_elementSpec" href="#TEI.publicationStmt" title="&lt;publicationStmt&gt;">publicationStmt</a> <a class="link_odd_elementSpec" href="#TEI.publisher" title="&lt;publisher&gt;">publisher</a> <a class="link_odd_elementSpec" href="#TEI.q" title="&lt;q&gt;">q</a> <a class="link_odd_elementSpec" href="#TEI.quote" title="&lt;quote&gt;">quote</a> <a class="link_odd_elementSpec" href="#TEI.rdg" title="&lt;rdg&gt;">rdg</a> <a class="link_odd_elementSpec" href="#TEI.ref" title="&lt;ref&gt;">ref</a> <a class="link_odd_elementSpec" href="#TEI.resp" title="&lt;resp&gt;">resp</a> <a class="link_odd_elementSpec" href="#TEI.respStmt" title="&lt;respStmt&gt;">respStmt</a> <a class="link_odd_elementSpec" href="#TEI.revisionDesc" title="&lt;revisionDesc&gt;">revisionDesc</a> <a class="link_odd_elementSpec" href="#TEI.s" title="&lt;s&gt;">s</a> <a class="link_odd_elementSpec" href="#TEI.seg" title="&lt;seg&gt;">seg</a> <a class="link_odd_elementSpec" href="#TEI.signed" title="&lt;signed&gt;">signed</a> <a class="link_odd_elementSpec" href="#TEI.sourceDesc" title="&lt;sourceDesc&gt;">sourceDesc</a> <a class="link_odd_elementSpec" href="#TEI.standOff" title="&lt;standOff&gt;">standOff</a> <a class="link_odd_elementSpec" href="#TEI.teiHeader" title="&lt;teiHeader&gt;">teiHeader</a> <a class="link_odd_elementSpec" href="#TEI.term" title="&lt;term&gt;">term</a> <a class="link_odd_elementSpec" href="#TEI.text" title="&lt;text&gt;">text</a> <a class="link_odd_elementSpec" href="#TEI.title" title="&lt;title&gt;">title</a> <a class="link_odd_elementSpec" href="#TEI.titlePage" title="&lt;titlePage&gt;">titlePage</a> <a class="link_odd_elementSpec" href="#TEI.titlePart" title="&lt;titlePart&gt;">titlePart</a> <a class="link_odd_elementSpec" href="#TEI.titleStmt" title="&lt;titleStmt&gt;">titleStmt</a> <a class="link_odd_elementSpec" href="#TEI.trailer" title="&lt;trailer&gt;">trailer</a> <a class="link_odd_elementSpec" href="#TEI.transpose" title="&lt;transpose&gt;">transpose</a> <a class="link_odd_elementSpec" href="#TEI.variantEncoding" title="&lt;variantEncoding&gt;">variantEncoding</a> <a class="link_odd_elementSpec" href="#TEI.w" title="&lt;w&gt;">w</a> <a class="link_odd_elementSpec" href="#TEI.witness" title="&lt;witness&gt;">witness</a>]</span></span></td>
                         </tr>
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Attributes</span></td>
@@ -15195,7 +15735,7 @@ element witness
                         </tr>
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Members</span></td>
-                           <td class="wovenodd-col2"><span class="showmembers1"><a class="link_odd_classSpec" href="#TEI.att.global" title="att.global">att.global</a><span class="showmembers2">[<a class="link_odd_elementSpec" href="#TEI.TEI" title="&lt;TEI&gt;">TEI</a> <a class="link_odd_elementSpec" href="#TEI.abbr" title="&lt;abbr&gt;">abbr</a> <a class="link_odd_elementSpec" href="#TEI.app" title="&lt;app&gt;">app</a> <a class="link_odd_elementSpec" href="#TEI.author" title="&lt;author&gt;">author</a> <a class="link_odd_elementSpec" href="#TEI.authority" title="&lt;authority&gt;">authority</a> <a class="link_odd_elementSpec" href="#TEI.back" title="&lt;back&gt;">back</a> <a class="link_odd_elementSpec" href="#TEI.bibl" title="&lt;bibl&gt;">bibl</a> <a class="link_odd_elementSpec" href="#TEI.biblStruct" title="&lt;biblStruct&gt;">biblStruct</a> <a class="link_odd_elementSpec" href="#TEI.body" title="&lt;body&gt;">body</a> <a class="link_odd_elementSpec" href="#TEI.byline" title="&lt;byline&gt;">byline</a> <a class="link_odd_elementSpec" href="#TEI.cb" title="&lt;cb&gt;">cb</a> <a class="link_odd_elementSpec" href="#TEI.change" title="&lt;change&gt;">change</a> <a class="link_odd_elementSpec" href="#TEI.cit" title="&lt;cit&gt;">cit</a> <a class="link_odd_elementSpec" href="#TEI.date" title="&lt;date&gt;">date</a> <a class="link_odd_elementSpec" href="#TEI.div" title="&lt;div&gt;">div</a> <a class="link_odd_elementSpec" href="#TEI.docImprint" title="&lt;docImprint&gt;">docImprint</a> <a class="link_odd_elementSpec" href="#TEI.docTitle" title="&lt;docTitle&gt;">docTitle</a> <a class="link_odd_elementSpec" href="#TEI.edition" title="&lt;edition&gt;">edition</a> <a class="link_odd_elementSpec" href="#TEI.editionStmt" title="&lt;editionStmt&gt;">editionStmt</a> <a class="link_odd_elementSpec" href="#TEI.emph" title="&lt;emph&gt;">emph</a> <a class="link_odd_elementSpec" href="#TEI.encodingDesc" title="&lt;encodingDesc&gt;">encodingDesc</a> <a class="link_odd_elementSpec" href="#TEI.epigraph" title="&lt;epigraph&gt;">epigraph</a> <a class="link_odd_elementSpec" href="#TEI.figDesc" title="&lt;figDesc&gt;">figDesc</a> <a class="link_odd_elementSpec" href="#TEI.figure" title="&lt;figure&gt;">figure</a> <a class="link_odd_elementSpec" href="#TEI.fileDesc" title="&lt;fileDesc&gt;">fileDesc</a> <a class="link_odd_elementSpec" href="#TEI.foreign" title="&lt;foreign&gt;">foreign</a> <a class="link_odd_elementSpec" href="#TEI.front" title="&lt;front&gt;">front</a> <a class="link_odd_elementSpec" href="#TEI.funder" title="&lt;funder&gt;">funder</a> <a class="link_odd_elementSpec" href="#TEI.fw" title="&lt;fw&gt;">fw</a> <a class="link_odd_elementSpec" href="#TEI.gloss" title="&lt;gloss&gt;">gloss</a> <a class="link_odd_elementSpec" href="#TEI.graphic" title="&lt;graphic&gt;">graphic</a> <a class="link_odd_elementSpec" href="#TEI.head" title="&lt;head&gt;">head</a> <a class="link_odd_elementSpec" href="#TEI.hi" title="&lt;hi&gt;">hi</a> <a class="link_odd_elementSpec" href="#TEI.imprimatur" title="&lt;imprimatur&gt;">imprimatur</a> <a class="link_odd_elementSpec" href="#TEI.imprint" title="&lt;imprint&gt;">imprint</a> <a class="link_odd_elementSpec" href="#TEI.item" title="&lt;item&gt;">item</a> <a class="link_odd_elementSpec" href="#TEI.l" title="&lt;l&gt;">l</a> <a class="link_odd_elementSpec" href="#TEI.lb" title="&lt;lb&gt;">lb</a> <a class="link_odd_elementSpec" href="#TEI.lem" title="&lt;lem&gt;">lem</a> <a class="link_odd_elementSpec" href="#TEI.lg" title="&lt;lg&gt;">lg</a> <a class="link_odd_elementSpec" href="#TEI.licence" title="&lt;licence&gt;">licence</a> <a class="link_odd_elementSpec" href="#TEI.list" title="&lt;list&gt;">list</a> <a class="link_odd_elementSpec" href="#TEI.listBibl" title="&lt;listBibl&gt;">listBibl</a> <a class="link_odd_elementSpec" href="#TEI.listChange" title="&lt;listChange&gt;">listChange</a> <a class="link_odd_elementSpec" href="#TEI.listWit" title="&lt;listWit&gt;">listWit</a> <a class="link_odd_elementSpec" href="#TEI.monogr" title="&lt;monogr&gt;">monogr</a> <a class="link_odd_elementSpec" href="#TEI.name" title="&lt;name&gt;">name</a> <a class="link_odd_elementSpec" href="#TEI.note" title="&lt;note&gt;">note</a> <a class="link_odd_elementSpec" href="#TEI.orgName" title="&lt;orgName&gt;">orgName</a> <a class="link_odd_elementSpec" href="#TEI.p" title="&lt;p&gt;">p</a> <a class="link_odd_elementSpec" href="#TEI.pb" title="&lt;pb&gt;">pb</a> <a class="link_odd_elementSpec" href="#TEI.persName" title="&lt;persName&gt;">persName</a> <a class="link_odd_elementSpec" href="#TEI.placeName" title="&lt;placeName&gt;">placeName</a> <a class="link_odd_elementSpec" href="#TEI.principal" title="&lt;principal&gt;">principal</a> <a class="link_odd_elementSpec" href="#TEI.ptr" title="&lt;ptr&gt;">ptr</a> <a class="link_odd_elementSpec" href="#TEI.pubPlace" title="&lt;pubPlace&gt;">pubPlace</a> <a class="link_odd_elementSpec" href="#TEI.publicationStmt" title="&lt;publicationStmt&gt;">publicationStmt</a> <a class="link_odd_elementSpec" href="#TEI.publisher" title="&lt;publisher&gt;">publisher</a> <a class="link_odd_elementSpec" href="#TEI.q" title="&lt;q&gt;">q</a> <a class="link_odd_elementSpec" href="#TEI.quote" title="&lt;quote&gt;">quote</a> <a class="link_odd_elementSpec" href="#TEI.rdg" title="&lt;rdg&gt;">rdg</a> <a class="link_odd_elementSpec" href="#TEI.ref" title="&lt;ref&gt;">ref</a> <a class="link_odd_elementSpec" href="#TEI.resp" title="&lt;resp&gt;">resp</a> <a class="link_odd_elementSpec" href="#TEI.respStmt" title="&lt;respStmt&gt;">respStmt</a> <a class="link_odd_elementSpec" href="#TEI.revisionDesc" title="&lt;revisionDesc&gt;">revisionDesc</a> <a class="link_odd_elementSpec" href="#TEI.s" title="&lt;s&gt;">s</a> <a class="link_odd_elementSpec" href="#TEI.seg" title="&lt;seg&gt;">seg</a> <a class="link_odd_elementSpec" href="#TEI.signed" title="&lt;signed&gt;">signed</a> <a class="link_odd_elementSpec" href="#TEI.sourceDesc" title="&lt;sourceDesc&gt;">sourceDesc</a> <a class="link_odd_elementSpec" href="#TEI.teiHeader" title="&lt;teiHeader&gt;">teiHeader</a> <a class="link_odd_elementSpec" href="#TEI.term" title="&lt;term&gt;">term</a> <a class="link_odd_elementSpec" href="#TEI.text" title="&lt;text&gt;">text</a> <a class="link_odd_elementSpec" href="#TEI.title" title="&lt;title&gt;">title</a> <a class="link_odd_elementSpec" href="#TEI.titlePage" title="&lt;titlePage&gt;">titlePage</a> <a class="link_odd_elementSpec" href="#TEI.titlePart" title="&lt;titlePart&gt;">titlePart</a> <a class="link_odd_elementSpec" href="#TEI.titleStmt" title="&lt;titleStmt&gt;">titleStmt</a> <a class="link_odd_elementSpec" href="#TEI.trailer" title="&lt;trailer&gt;">trailer</a> <a class="link_odd_elementSpec" href="#TEI.variantEncoding" title="&lt;variantEncoding&gt;">variantEncoding</a> <a class="link_odd_elementSpec" href="#TEI.w" title="&lt;w&gt;">w</a> <a class="link_odd_elementSpec" href="#TEI.witness" title="&lt;witness&gt;">witness</a>]</span></span></td>
+                           <td class="wovenodd-col2"><span class="showmembers1"><a class="link_odd_classSpec" href="#TEI.att.global" title="att.global">att.global</a><span class="showmembers2">[<a class="link_odd_elementSpec" href="#TEI.TEI" title="&lt;TEI&gt;">TEI</a> <a class="link_odd_elementSpec" href="#TEI.abbr" title="&lt;abbr&gt;">abbr</a> <a class="link_odd_elementSpec" href="#TEI.app" title="&lt;app&gt;">app</a> <a class="link_odd_elementSpec" href="#TEI.author" title="&lt;author&gt;">author</a> <a class="link_odd_elementSpec" href="#TEI.authority" title="&lt;authority&gt;">authority</a> <a class="link_odd_elementSpec" href="#TEI.back" title="&lt;back&gt;">back</a> <a class="link_odd_elementSpec" href="#TEI.bibl" title="&lt;bibl&gt;">bibl</a> <a class="link_odd_elementSpec" href="#TEI.biblStruct" title="&lt;biblStruct&gt;">biblStruct</a> <a class="link_odd_elementSpec" href="#TEI.body" title="&lt;body&gt;">body</a> <a class="link_odd_elementSpec" href="#TEI.byline" title="&lt;byline&gt;">byline</a> <a class="link_odd_elementSpec" href="#TEI.cb" title="&lt;cb&gt;">cb</a> <a class="link_odd_elementSpec" href="#TEI.change" title="&lt;change&gt;">change</a> <a class="link_odd_elementSpec" href="#TEI.cit" title="&lt;cit&gt;">cit</a> <a class="link_odd_elementSpec" href="#TEI.date" title="&lt;date&gt;">date</a> <a class="link_odd_elementSpec" href="#TEI.div" title="&lt;div&gt;">div</a> <a class="link_odd_elementSpec" href="#TEI.docImprint" title="&lt;docImprint&gt;">docImprint</a> <a class="link_odd_elementSpec" href="#TEI.docTitle" title="&lt;docTitle&gt;">docTitle</a> <a class="link_odd_elementSpec" href="#TEI.edition" title="&lt;edition&gt;">edition</a> <a class="link_odd_elementSpec" href="#TEI.editionStmt" title="&lt;editionStmt&gt;">editionStmt</a> <a class="link_odd_elementSpec" href="#TEI.emph" title="&lt;emph&gt;">emph</a> <a class="link_odd_elementSpec" href="#TEI.encodingDesc" title="&lt;encodingDesc&gt;">encodingDesc</a> <a class="link_odd_elementSpec" href="#TEI.epigraph" title="&lt;epigraph&gt;">epigraph</a> <a class="link_odd_elementSpec" href="#TEI.figDesc" title="&lt;figDesc&gt;">figDesc</a> <a class="link_odd_elementSpec" href="#TEI.figure" title="&lt;figure&gt;">figure</a> <a class="link_odd_elementSpec" href="#TEI.fileDesc" title="&lt;fileDesc&gt;">fileDesc</a> <a class="link_odd_elementSpec" href="#TEI.foreign" title="&lt;foreign&gt;">foreign</a> <a class="link_odd_elementSpec" href="#TEI.front" title="&lt;front&gt;">front</a> <a class="link_odd_elementSpec" href="#TEI.funder" title="&lt;funder&gt;">funder</a> <a class="link_odd_elementSpec" href="#TEI.fw" title="&lt;fw&gt;">fw</a> <a class="link_odd_elementSpec" href="#TEI.gloss" title="&lt;gloss&gt;">gloss</a> <a class="link_odd_elementSpec" href="#TEI.graphic" title="&lt;graphic&gt;">graphic</a> <a class="link_odd_elementSpec" href="#TEI.head" title="&lt;head&gt;">head</a> <a class="link_odd_elementSpec" href="#TEI.hi" title="&lt;hi&gt;">hi</a> <a class="link_odd_elementSpec" href="#TEI.imprimatur" title="&lt;imprimatur&gt;">imprimatur</a> <a class="link_odd_elementSpec" href="#TEI.imprint" title="&lt;imprint&gt;">imprint</a> <a class="link_odd_elementSpec" href="#TEI.item" title="&lt;item&gt;">item</a> <a class="link_odd_elementSpec" href="#TEI.l" title="&lt;l&gt;">l</a> <a class="link_odd_elementSpec" href="#TEI.lb" title="&lt;lb&gt;">lb</a> <a class="link_odd_elementSpec" href="#TEI.lem" title="&lt;lem&gt;">lem</a> <a class="link_odd_elementSpec" href="#TEI.lg" title="&lt;lg&gt;">lg</a> <a class="link_odd_elementSpec" href="#TEI.licence" title="&lt;licence&gt;">licence</a> <a class="link_odd_elementSpec" href="#TEI.list" title="&lt;list&gt;">list</a> <a class="link_odd_elementSpec" href="#TEI.listBibl" title="&lt;listBibl&gt;">listBibl</a> <a class="link_odd_elementSpec" href="#TEI.listChange" title="&lt;listChange&gt;">listChange</a> <a class="link_odd_elementSpec" href="#TEI.listTranspose" title="&lt;listTranspose&gt;">listTranspose</a> <a class="link_odd_elementSpec" href="#TEI.listWit" title="&lt;listWit&gt;">listWit</a> <a class="link_odd_elementSpec" href="#TEI.monogr" title="&lt;monogr&gt;">monogr</a> <a class="link_odd_elementSpec" href="#TEI.name" title="&lt;name&gt;">name</a> <a class="link_odd_elementSpec" href="#TEI.note" title="&lt;note&gt;">note</a> <a class="link_odd_elementSpec" href="#TEI.orgName" title="&lt;orgName&gt;">orgName</a> <a class="link_odd_elementSpec" href="#TEI.p" title="&lt;p&gt;">p</a> <a class="link_odd_elementSpec" href="#TEI.pb" title="&lt;pb&gt;">pb</a> <a class="link_odd_elementSpec" href="#TEI.persName" title="&lt;persName&gt;">persName</a> <a class="link_odd_elementSpec" href="#TEI.placeName" title="&lt;placeName&gt;">placeName</a> <a class="link_odd_elementSpec" href="#TEI.principal" title="&lt;principal&gt;">principal</a> <a class="link_odd_elementSpec" href="#TEI.ptr" title="&lt;ptr&gt;">ptr</a> <a class="link_odd_elementSpec" href="#TEI.pubPlace" title="&lt;pubPlace&gt;">pubPlace</a> <a class="link_odd_elementSpec" href="#TEI.publicationStmt" title="&lt;publicationStmt&gt;">publicationStmt</a> <a class="link_odd_elementSpec" href="#TEI.publisher" title="&lt;publisher&gt;">publisher</a> <a class="link_odd_elementSpec" href="#TEI.q" title="&lt;q&gt;">q</a> <a class="link_odd_elementSpec" href="#TEI.quote" title="&lt;quote&gt;">quote</a> <a class="link_odd_elementSpec" href="#TEI.rdg" title="&lt;rdg&gt;">rdg</a> <a class="link_odd_elementSpec" href="#TEI.ref" title="&lt;ref&gt;">ref</a> <a class="link_odd_elementSpec" href="#TEI.resp" title="&lt;resp&gt;">resp</a> <a class="link_odd_elementSpec" href="#TEI.respStmt" title="&lt;respStmt&gt;">respStmt</a> <a class="link_odd_elementSpec" href="#TEI.revisionDesc" title="&lt;revisionDesc&gt;">revisionDesc</a> <a class="link_odd_elementSpec" href="#TEI.s" title="&lt;s&gt;">s</a> <a class="link_odd_elementSpec" href="#TEI.seg" title="&lt;seg&gt;">seg</a> <a class="link_odd_elementSpec" href="#TEI.signed" title="&lt;signed&gt;">signed</a> <a class="link_odd_elementSpec" href="#TEI.sourceDesc" title="&lt;sourceDesc&gt;">sourceDesc</a> <a class="link_odd_elementSpec" href="#TEI.standOff" title="&lt;standOff&gt;">standOff</a> <a class="link_odd_elementSpec" href="#TEI.teiHeader" title="&lt;teiHeader&gt;">teiHeader</a> <a class="link_odd_elementSpec" href="#TEI.term" title="&lt;term&gt;">term</a> <a class="link_odd_elementSpec" href="#TEI.text" title="&lt;text&gt;">text</a> <a class="link_odd_elementSpec" href="#TEI.title" title="&lt;title&gt;">title</a> <a class="link_odd_elementSpec" href="#TEI.titlePage" title="&lt;titlePage&gt;">titlePage</a> <a class="link_odd_elementSpec" href="#TEI.titlePart" title="&lt;titlePart&gt;">titlePart</a> <a class="link_odd_elementSpec" href="#TEI.titleStmt" title="&lt;titleStmt&gt;">titleStmt</a> <a class="link_odd_elementSpec" href="#TEI.trailer" title="&lt;trailer&gt;">trailer</a> <a class="link_odd_elementSpec" href="#TEI.transpose" title="&lt;transpose&gt;">transpose</a> <a class="link_odd_elementSpec" href="#TEI.variantEncoding" title="&lt;variantEncoding&gt;">variantEncoding</a> <a class="link_odd_elementSpec" href="#TEI.w" title="&lt;w&gt;">w</a> <a class="link_odd_elementSpec" href="#TEI.witness" title="&lt;witness&gt;">witness</a>]</span></span></td>
                         </tr>
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Attributes</span></td>
@@ -15216,7 +15756,7 @@ element witness
                                                 </tr>
                                                 <tr>
                                                    <td colspan="2">
-                                                      <div id="index.xml-egXML-d31e49642" class="pre egXML_valid"><span class="element">&lt;group&gt;</span>
+                                                      <div id="index.xml-egXML-d31e51388" class="pre egXML_valid"><span class="element">&lt;group&gt;</span>
                                                           <span class="element">&lt;text <span class="attribute">xml:id</span>="<span class="attributevalue">t1-g1-t1</span>"
                                                               <span class="attribute">xml:lang</span>="<span class="attributevalue">mi</span>"&gt;</span>
                                                            <span class="element">&lt;body <span class="attribute">xml:id</span>="<span class="attributevalue">t1-g1-t1-body1</span>"&gt;</span>
@@ -15241,7 +15781,7 @@ element witness
                                                 </tr>
                                                 <tr>
                                                    <td colspan="2">
-                                                      <div id="index.xml-egXML-d31e49675" class="pre egXML_valid">
+                                                      <div id="index.xml-egXML-d31e51421" class="pre egXML_valid">
                                                          <span class="comment">&lt;!-- In a placeography called "places.xml" --&gt;</span><span class="element">&lt;place <span class="attribute">xml:id</span>="<span class="attributevalue">LOND1</span>"
                                                              <span class="attribute">corresp</span>="<span class="attributevalue">people.xml#LOND2 people.xml#GENI1</span>"&gt;</span>
                                                           <span class="element">&lt;placeName&gt;</span>London<span class="element">&lt;/placeName&gt;</span>
@@ -15436,7 +15976,7 @@ element witness
                         </tr>
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Members</span></td>
-                           <td class="wovenodd-col2"><span class="showmembers1"><a class="link_odd_classSpec" href="#TEI.att.global" title="att.global">att.global</a><span class="showmembers2">[<a class="link_odd_elementSpec" href="#TEI.TEI" title="&lt;TEI&gt;">TEI</a> <a class="link_odd_elementSpec" href="#TEI.abbr" title="&lt;abbr&gt;">abbr</a> <a class="link_odd_elementSpec" href="#TEI.app" title="&lt;app&gt;">app</a> <a class="link_odd_elementSpec" href="#TEI.author" title="&lt;author&gt;">author</a> <a class="link_odd_elementSpec" href="#TEI.authority" title="&lt;authority&gt;">authority</a> <a class="link_odd_elementSpec" href="#TEI.back" title="&lt;back&gt;">back</a> <a class="link_odd_elementSpec" href="#TEI.bibl" title="&lt;bibl&gt;">bibl</a> <a class="link_odd_elementSpec" href="#TEI.biblStruct" title="&lt;biblStruct&gt;">biblStruct</a> <a class="link_odd_elementSpec" href="#TEI.body" title="&lt;body&gt;">body</a> <a class="link_odd_elementSpec" href="#TEI.byline" title="&lt;byline&gt;">byline</a> <a class="link_odd_elementSpec" href="#TEI.cb" title="&lt;cb&gt;">cb</a> <a class="link_odd_elementSpec" href="#TEI.change" title="&lt;change&gt;">change</a> <a class="link_odd_elementSpec" href="#TEI.cit" title="&lt;cit&gt;">cit</a> <a class="link_odd_elementSpec" href="#TEI.date" title="&lt;date&gt;">date</a> <a class="link_odd_elementSpec" href="#TEI.div" title="&lt;div&gt;">div</a> <a class="link_odd_elementSpec" href="#TEI.docImprint" title="&lt;docImprint&gt;">docImprint</a> <a class="link_odd_elementSpec" href="#TEI.docTitle" title="&lt;docTitle&gt;">docTitle</a> <a class="link_odd_elementSpec" href="#TEI.edition" title="&lt;edition&gt;">edition</a> <a class="link_odd_elementSpec" href="#TEI.editionStmt" title="&lt;editionStmt&gt;">editionStmt</a> <a class="link_odd_elementSpec" href="#TEI.emph" title="&lt;emph&gt;">emph</a> <a class="link_odd_elementSpec" href="#TEI.encodingDesc" title="&lt;encodingDesc&gt;">encodingDesc</a> <a class="link_odd_elementSpec" href="#TEI.epigraph" title="&lt;epigraph&gt;">epigraph</a> <a class="link_odd_elementSpec" href="#TEI.figDesc" title="&lt;figDesc&gt;">figDesc</a> <a class="link_odd_elementSpec" href="#TEI.figure" title="&lt;figure&gt;">figure</a> <a class="link_odd_elementSpec" href="#TEI.fileDesc" title="&lt;fileDesc&gt;">fileDesc</a> <a class="link_odd_elementSpec" href="#TEI.foreign" title="&lt;foreign&gt;">foreign</a> <a class="link_odd_elementSpec" href="#TEI.front" title="&lt;front&gt;">front</a> <a class="link_odd_elementSpec" href="#TEI.funder" title="&lt;funder&gt;">funder</a> <a class="link_odd_elementSpec" href="#TEI.fw" title="&lt;fw&gt;">fw</a> <a class="link_odd_elementSpec" href="#TEI.gloss" title="&lt;gloss&gt;">gloss</a> <a class="link_odd_elementSpec" href="#TEI.graphic" title="&lt;graphic&gt;">graphic</a> <a class="link_odd_elementSpec" href="#TEI.head" title="&lt;head&gt;">head</a> <a class="link_odd_elementSpec" href="#TEI.hi" title="&lt;hi&gt;">hi</a> <a class="link_odd_elementSpec" href="#TEI.imprimatur" title="&lt;imprimatur&gt;">imprimatur</a> <a class="link_odd_elementSpec" href="#TEI.imprint" title="&lt;imprint&gt;">imprint</a> <a class="link_odd_elementSpec" href="#TEI.item" title="&lt;item&gt;">item</a> <a class="link_odd_elementSpec" href="#TEI.l" title="&lt;l&gt;">l</a> <a class="link_odd_elementSpec" href="#TEI.lb" title="&lt;lb&gt;">lb</a> <a class="link_odd_elementSpec" href="#TEI.lem" title="&lt;lem&gt;">lem</a> <a class="link_odd_elementSpec" href="#TEI.lg" title="&lt;lg&gt;">lg</a> <a class="link_odd_elementSpec" href="#TEI.licence" title="&lt;licence&gt;">licence</a> <a class="link_odd_elementSpec" href="#TEI.list" title="&lt;list&gt;">list</a> <a class="link_odd_elementSpec" href="#TEI.listBibl" title="&lt;listBibl&gt;">listBibl</a> <a class="link_odd_elementSpec" href="#TEI.listChange" title="&lt;listChange&gt;">listChange</a> <a class="link_odd_elementSpec" href="#TEI.listWit" title="&lt;listWit&gt;">listWit</a> <a class="link_odd_elementSpec" href="#TEI.monogr" title="&lt;monogr&gt;">monogr</a> <a class="link_odd_elementSpec" href="#TEI.name" title="&lt;name&gt;">name</a> <a class="link_odd_elementSpec" href="#TEI.note" title="&lt;note&gt;">note</a> <a class="link_odd_elementSpec" href="#TEI.orgName" title="&lt;orgName&gt;">orgName</a> <a class="link_odd_elementSpec" href="#TEI.p" title="&lt;p&gt;">p</a> <a class="link_odd_elementSpec" href="#TEI.pb" title="&lt;pb&gt;">pb</a> <a class="link_odd_elementSpec" href="#TEI.persName" title="&lt;persName&gt;">persName</a> <a class="link_odd_elementSpec" href="#TEI.placeName" title="&lt;placeName&gt;">placeName</a> <a class="link_odd_elementSpec" href="#TEI.principal" title="&lt;principal&gt;">principal</a> <a class="link_odd_elementSpec" href="#TEI.ptr" title="&lt;ptr&gt;">ptr</a> <a class="link_odd_elementSpec" href="#TEI.pubPlace" title="&lt;pubPlace&gt;">pubPlace</a> <a class="link_odd_elementSpec" href="#TEI.publicationStmt" title="&lt;publicationStmt&gt;">publicationStmt</a> <a class="link_odd_elementSpec" href="#TEI.publisher" title="&lt;publisher&gt;">publisher</a> <a class="link_odd_elementSpec" href="#TEI.q" title="&lt;q&gt;">q</a> <a class="link_odd_elementSpec" href="#TEI.quote" title="&lt;quote&gt;">quote</a> <a class="link_odd_elementSpec" href="#TEI.rdg" title="&lt;rdg&gt;">rdg</a> <a class="link_odd_elementSpec" href="#TEI.ref" title="&lt;ref&gt;">ref</a> <a class="link_odd_elementSpec" href="#TEI.resp" title="&lt;resp&gt;">resp</a> <a class="link_odd_elementSpec" href="#TEI.respStmt" title="&lt;respStmt&gt;">respStmt</a> <a class="link_odd_elementSpec" href="#TEI.revisionDesc" title="&lt;revisionDesc&gt;">revisionDesc</a> <a class="link_odd_elementSpec" href="#TEI.s" title="&lt;s&gt;">s</a> <a class="link_odd_elementSpec" href="#TEI.seg" title="&lt;seg&gt;">seg</a> <a class="link_odd_elementSpec" href="#TEI.signed" title="&lt;signed&gt;">signed</a> <a class="link_odd_elementSpec" href="#TEI.sourceDesc" title="&lt;sourceDesc&gt;">sourceDesc</a> <a class="link_odd_elementSpec" href="#TEI.teiHeader" title="&lt;teiHeader&gt;">teiHeader</a> <a class="link_odd_elementSpec" href="#TEI.term" title="&lt;term&gt;">term</a> <a class="link_odd_elementSpec" href="#TEI.text" title="&lt;text&gt;">text</a> <a class="link_odd_elementSpec" href="#TEI.title" title="&lt;title&gt;">title</a> <a class="link_odd_elementSpec" href="#TEI.titlePage" title="&lt;titlePage&gt;">titlePage</a> <a class="link_odd_elementSpec" href="#TEI.titlePart" title="&lt;titlePart&gt;">titlePart</a> <a class="link_odd_elementSpec" href="#TEI.titleStmt" title="&lt;titleStmt&gt;">titleStmt</a> <a class="link_odd_elementSpec" href="#TEI.trailer" title="&lt;trailer&gt;">trailer</a> <a class="link_odd_elementSpec" href="#TEI.variantEncoding" title="&lt;variantEncoding&gt;">variantEncoding</a> <a class="link_odd_elementSpec" href="#TEI.w" title="&lt;w&gt;">w</a> <a class="link_odd_elementSpec" href="#TEI.witness" title="&lt;witness&gt;">witness</a>]</span></span></td>
+                           <td class="wovenodd-col2"><span class="showmembers1"><a class="link_odd_classSpec" href="#TEI.att.global" title="att.global">att.global</a><span class="showmembers2">[<a class="link_odd_elementSpec" href="#TEI.TEI" title="&lt;TEI&gt;">TEI</a> <a class="link_odd_elementSpec" href="#TEI.abbr" title="&lt;abbr&gt;">abbr</a> <a class="link_odd_elementSpec" href="#TEI.app" title="&lt;app&gt;">app</a> <a class="link_odd_elementSpec" href="#TEI.author" title="&lt;author&gt;">author</a> <a class="link_odd_elementSpec" href="#TEI.authority" title="&lt;authority&gt;">authority</a> <a class="link_odd_elementSpec" href="#TEI.back" title="&lt;back&gt;">back</a> <a class="link_odd_elementSpec" href="#TEI.bibl" title="&lt;bibl&gt;">bibl</a> <a class="link_odd_elementSpec" href="#TEI.biblStruct" title="&lt;biblStruct&gt;">biblStruct</a> <a class="link_odd_elementSpec" href="#TEI.body" title="&lt;body&gt;">body</a> <a class="link_odd_elementSpec" href="#TEI.byline" title="&lt;byline&gt;">byline</a> <a class="link_odd_elementSpec" href="#TEI.cb" title="&lt;cb&gt;">cb</a> <a class="link_odd_elementSpec" href="#TEI.change" title="&lt;change&gt;">change</a> <a class="link_odd_elementSpec" href="#TEI.cit" title="&lt;cit&gt;">cit</a> <a class="link_odd_elementSpec" href="#TEI.date" title="&lt;date&gt;">date</a> <a class="link_odd_elementSpec" href="#TEI.div" title="&lt;div&gt;">div</a> <a class="link_odd_elementSpec" href="#TEI.docImprint" title="&lt;docImprint&gt;">docImprint</a> <a class="link_odd_elementSpec" href="#TEI.docTitle" title="&lt;docTitle&gt;">docTitle</a> <a class="link_odd_elementSpec" href="#TEI.edition" title="&lt;edition&gt;">edition</a> <a class="link_odd_elementSpec" href="#TEI.editionStmt" title="&lt;editionStmt&gt;">editionStmt</a> <a class="link_odd_elementSpec" href="#TEI.emph" title="&lt;emph&gt;">emph</a> <a class="link_odd_elementSpec" href="#TEI.encodingDesc" title="&lt;encodingDesc&gt;">encodingDesc</a> <a class="link_odd_elementSpec" href="#TEI.epigraph" title="&lt;epigraph&gt;">epigraph</a> <a class="link_odd_elementSpec" href="#TEI.figDesc" title="&lt;figDesc&gt;">figDesc</a> <a class="link_odd_elementSpec" href="#TEI.figure" title="&lt;figure&gt;">figure</a> <a class="link_odd_elementSpec" href="#TEI.fileDesc" title="&lt;fileDesc&gt;">fileDesc</a> <a class="link_odd_elementSpec" href="#TEI.foreign" title="&lt;foreign&gt;">foreign</a> <a class="link_odd_elementSpec" href="#TEI.front" title="&lt;front&gt;">front</a> <a class="link_odd_elementSpec" href="#TEI.funder" title="&lt;funder&gt;">funder</a> <a class="link_odd_elementSpec" href="#TEI.fw" title="&lt;fw&gt;">fw</a> <a class="link_odd_elementSpec" href="#TEI.gloss" title="&lt;gloss&gt;">gloss</a> <a class="link_odd_elementSpec" href="#TEI.graphic" title="&lt;graphic&gt;">graphic</a> <a class="link_odd_elementSpec" href="#TEI.head" title="&lt;head&gt;">head</a> <a class="link_odd_elementSpec" href="#TEI.hi" title="&lt;hi&gt;">hi</a> <a class="link_odd_elementSpec" href="#TEI.imprimatur" title="&lt;imprimatur&gt;">imprimatur</a> <a class="link_odd_elementSpec" href="#TEI.imprint" title="&lt;imprint&gt;">imprint</a> <a class="link_odd_elementSpec" href="#TEI.item" title="&lt;item&gt;">item</a> <a class="link_odd_elementSpec" href="#TEI.l" title="&lt;l&gt;">l</a> <a class="link_odd_elementSpec" href="#TEI.lb" title="&lt;lb&gt;">lb</a> <a class="link_odd_elementSpec" href="#TEI.lem" title="&lt;lem&gt;">lem</a> <a class="link_odd_elementSpec" href="#TEI.lg" title="&lt;lg&gt;">lg</a> <a class="link_odd_elementSpec" href="#TEI.licence" title="&lt;licence&gt;">licence</a> <a class="link_odd_elementSpec" href="#TEI.list" title="&lt;list&gt;">list</a> <a class="link_odd_elementSpec" href="#TEI.listBibl" title="&lt;listBibl&gt;">listBibl</a> <a class="link_odd_elementSpec" href="#TEI.listChange" title="&lt;listChange&gt;">listChange</a> <a class="link_odd_elementSpec" href="#TEI.listTranspose" title="&lt;listTranspose&gt;">listTranspose</a> <a class="link_odd_elementSpec" href="#TEI.listWit" title="&lt;listWit&gt;">listWit</a> <a class="link_odd_elementSpec" href="#TEI.monogr" title="&lt;monogr&gt;">monogr</a> <a class="link_odd_elementSpec" href="#TEI.name" title="&lt;name&gt;">name</a> <a class="link_odd_elementSpec" href="#TEI.note" title="&lt;note&gt;">note</a> <a class="link_odd_elementSpec" href="#TEI.orgName" title="&lt;orgName&gt;">orgName</a> <a class="link_odd_elementSpec" href="#TEI.p" title="&lt;p&gt;">p</a> <a class="link_odd_elementSpec" href="#TEI.pb" title="&lt;pb&gt;">pb</a> <a class="link_odd_elementSpec" href="#TEI.persName" title="&lt;persName&gt;">persName</a> <a class="link_odd_elementSpec" href="#TEI.placeName" title="&lt;placeName&gt;">placeName</a> <a class="link_odd_elementSpec" href="#TEI.principal" title="&lt;principal&gt;">principal</a> <a class="link_odd_elementSpec" href="#TEI.ptr" title="&lt;ptr&gt;">ptr</a> <a class="link_odd_elementSpec" href="#TEI.pubPlace" title="&lt;pubPlace&gt;">pubPlace</a> <a class="link_odd_elementSpec" href="#TEI.publicationStmt" title="&lt;publicationStmt&gt;">publicationStmt</a> <a class="link_odd_elementSpec" href="#TEI.publisher" title="&lt;publisher&gt;">publisher</a> <a class="link_odd_elementSpec" href="#TEI.q" title="&lt;q&gt;">q</a> <a class="link_odd_elementSpec" href="#TEI.quote" title="&lt;quote&gt;">quote</a> <a class="link_odd_elementSpec" href="#TEI.rdg" title="&lt;rdg&gt;">rdg</a> <a class="link_odd_elementSpec" href="#TEI.ref" title="&lt;ref&gt;">ref</a> <a class="link_odd_elementSpec" href="#TEI.resp" title="&lt;resp&gt;">resp</a> <a class="link_odd_elementSpec" href="#TEI.respStmt" title="&lt;respStmt&gt;">respStmt</a> <a class="link_odd_elementSpec" href="#TEI.revisionDesc" title="&lt;revisionDesc&gt;">revisionDesc</a> <a class="link_odd_elementSpec" href="#TEI.s" title="&lt;s&gt;">s</a> <a class="link_odd_elementSpec" href="#TEI.seg" title="&lt;seg&gt;">seg</a> <a class="link_odd_elementSpec" href="#TEI.signed" title="&lt;signed&gt;">signed</a> <a class="link_odd_elementSpec" href="#TEI.sourceDesc" title="&lt;sourceDesc&gt;">sourceDesc</a> <a class="link_odd_elementSpec" href="#TEI.standOff" title="&lt;standOff&gt;">standOff</a> <a class="link_odd_elementSpec" href="#TEI.teiHeader" title="&lt;teiHeader&gt;">teiHeader</a> <a class="link_odd_elementSpec" href="#TEI.term" title="&lt;term&gt;">term</a> <a class="link_odd_elementSpec" href="#TEI.text" title="&lt;text&gt;">text</a> <a class="link_odd_elementSpec" href="#TEI.title" title="&lt;title&gt;">title</a> <a class="link_odd_elementSpec" href="#TEI.titlePage" title="&lt;titlePage&gt;">titlePage</a> <a class="link_odd_elementSpec" href="#TEI.titlePart" title="&lt;titlePart&gt;">titlePart</a> <a class="link_odd_elementSpec" href="#TEI.titleStmt" title="&lt;titleStmt&gt;">titleStmt</a> <a class="link_odd_elementSpec" href="#TEI.trailer" title="&lt;trailer&gt;">trailer</a> <a class="link_odd_elementSpec" href="#TEI.transpose" title="&lt;transpose&gt;">transpose</a> <a class="link_odd_elementSpec" href="#TEI.variantEncoding" title="&lt;variantEncoding&gt;">variantEncoding</a> <a class="link_odd_elementSpec" href="#TEI.w" title="&lt;w&gt;">w</a> <a class="link_odd_elementSpec" href="#TEI.witness" title="&lt;witness&gt;">witness</a>]</span></span></td>
                         </tr>
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Attributes</span></td>
@@ -15457,7 +15997,7 @@ element witness
                                                 </tr>
                                                 <tr>
                                                    <td colspan="2">
-                                                      <div id="index.xml-egXML-d31e50338" class="pre egXML_valid"><span class="element">&lt;head <span class="attribute">rend</span>="<span class="attributevalue">align(center) case(allcaps)</span>"&gt;</span>
+                                                      <div id="index.xml-egXML-d31e52097" class="pre egXML_valid"><span class="element">&lt;head <span class="attribute">rend</span>="<span class="attributevalue">align(center) case(allcaps)</span>"&gt;</span>
                                                           <span class="element">&lt;lb/&gt;</span>To The <span class="element">&lt;lb/&gt;</span>Duchesse <span class="element">&lt;lb/&gt;</span>of <span class="element">&lt;lb/&gt;</span>Newcastle,
                                                          <span class="element">&lt;lb/&gt;</span>On Her <span class="element">&lt;lb/&gt;</span>
                                                           <span class="element">&lt;hi <span class="attribute">rend</span>="<span class="attributevalue">case(mixed)</span>"&gt;</span>New Blazing-World<span class="element">&lt;/hi&gt;</span>. 
@@ -15492,7 +16032,7 @@ element witness
                                                 </tr>
                                                 <tr>
                                                    <td colspan="2">
-                                                      <div id="index.xml-egXML-d31e50394" class="pre egXML_valid"><span class="element">&lt;head <span class="attribute">style</span>="<span class="attributevalue">text-align: center; font-variant: small-caps</span>"&gt;</span>
+                                                      <div id="index.xml-egXML-d31e52153" class="pre egXML_valid"><span class="element">&lt;head <span class="attribute">style</span>="<span class="attributevalue">text-align: center; font-variant: small-caps</span>"&gt;</span>
                                                           <span class="element">&lt;lb/&gt;</span>To The <span class="element">&lt;lb/&gt;</span>Duchesse <span class="element">&lt;lb/&gt;</span>of <span class="element">&lt;lb/&gt;</span>Newcastle, <span class="element">&lt;lb/&gt;</span>On Her
                                                          <span class="element">&lt;lb/&gt;</span>
                                                           <span class="element">&lt;hi <span class="attribute">style</span>="<span class="attributevalue">font-variant: normal</span>"&gt;</span>New Blazing-World<span class="element">&lt;/hi&gt;</span>. 
@@ -15528,7 +16068,7 @@ element witness
                                                 </tr>
                                                 <tr>
                                                    <td colspan="2">
-                                                      <div id="index.xml-egXML-d31e50482" class="pre egXML_valid"><span class="element">&lt;head <span class="attribute">rendition</span>="<span class="attributevalue">#ac #sc</span>"&gt;</span>
+                                                      <div id="index.xml-egXML-d31e52241" class="pre egXML_valid"><span class="element">&lt;head <span class="attribute">rendition</span>="<span class="attributevalue">#ac #sc</span>"&gt;</span>
                                                           <span class="element">&lt;lb/&gt;</span>To The <span class="element">&lt;lb/&gt;</span>Duchesse <span class="element">&lt;lb/&gt;</span>of <span class="element">&lt;lb/&gt;</span>Newcastle, <span class="element">&lt;lb/&gt;</span>On Her
                                                          <span class="element">&lt;lb/&gt;</span>
                                                           <span class="element">&lt;hi <span class="attribute">rendition</span>="<span class="attributevalue">#normal</span>"&gt;</span>New Blazing-World<span class="element">&lt;/hi&gt;</span>. 
@@ -15580,7 +16120,7 @@ element witness
                         </tr>
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Members</span></td>
-                           <td class="wovenodd-col2"><span class="showmembers1"><a class="link_odd_classSpec" href="#TEI.att.global" title="att.global">att.global</a><span class="showmembers2">[<a class="link_odd_elementSpec" href="#TEI.TEI" title="&lt;TEI&gt;">TEI</a> <a class="link_odd_elementSpec" href="#TEI.abbr" title="&lt;abbr&gt;">abbr</a> <a class="link_odd_elementSpec" href="#TEI.app" title="&lt;app&gt;">app</a> <a class="link_odd_elementSpec" href="#TEI.author" title="&lt;author&gt;">author</a> <a class="link_odd_elementSpec" href="#TEI.authority" title="&lt;authority&gt;">authority</a> <a class="link_odd_elementSpec" href="#TEI.back" title="&lt;back&gt;">back</a> <a class="link_odd_elementSpec" href="#TEI.bibl" title="&lt;bibl&gt;">bibl</a> <a class="link_odd_elementSpec" href="#TEI.biblStruct" title="&lt;biblStruct&gt;">biblStruct</a> <a class="link_odd_elementSpec" href="#TEI.body" title="&lt;body&gt;">body</a> <a class="link_odd_elementSpec" href="#TEI.byline" title="&lt;byline&gt;">byline</a> <a class="link_odd_elementSpec" href="#TEI.cb" title="&lt;cb&gt;">cb</a> <a class="link_odd_elementSpec" href="#TEI.change" title="&lt;change&gt;">change</a> <a class="link_odd_elementSpec" href="#TEI.cit" title="&lt;cit&gt;">cit</a> <a class="link_odd_elementSpec" href="#TEI.date" title="&lt;date&gt;">date</a> <a class="link_odd_elementSpec" href="#TEI.div" title="&lt;div&gt;">div</a> <a class="link_odd_elementSpec" href="#TEI.docImprint" title="&lt;docImprint&gt;">docImprint</a> <a class="link_odd_elementSpec" href="#TEI.docTitle" title="&lt;docTitle&gt;">docTitle</a> <a class="link_odd_elementSpec" href="#TEI.edition" title="&lt;edition&gt;">edition</a> <a class="link_odd_elementSpec" href="#TEI.editionStmt" title="&lt;editionStmt&gt;">editionStmt</a> <a class="link_odd_elementSpec" href="#TEI.emph" title="&lt;emph&gt;">emph</a> <a class="link_odd_elementSpec" href="#TEI.encodingDesc" title="&lt;encodingDesc&gt;">encodingDesc</a> <a class="link_odd_elementSpec" href="#TEI.epigraph" title="&lt;epigraph&gt;">epigraph</a> <a class="link_odd_elementSpec" href="#TEI.figDesc" title="&lt;figDesc&gt;">figDesc</a> <a class="link_odd_elementSpec" href="#TEI.figure" title="&lt;figure&gt;">figure</a> <a class="link_odd_elementSpec" href="#TEI.fileDesc" title="&lt;fileDesc&gt;">fileDesc</a> <a class="link_odd_elementSpec" href="#TEI.foreign" title="&lt;foreign&gt;">foreign</a> <a class="link_odd_elementSpec" href="#TEI.front" title="&lt;front&gt;">front</a> <a class="link_odd_elementSpec" href="#TEI.funder" title="&lt;funder&gt;">funder</a> <a class="link_odd_elementSpec" href="#TEI.fw" title="&lt;fw&gt;">fw</a> <a class="link_odd_elementSpec" href="#TEI.gloss" title="&lt;gloss&gt;">gloss</a> <a class="link_odd_elementSpec" href="#TEI.graphic" title="&lt;graphic&gt;">graphic</a> <a class="link_odd_elementSpec" href="#TEI.head" title="&lt;head&gt;">head</a> <a class="link_odd_elementSpec" href="#TEI.hi" title="&lt;hi&gt;">hi</a> <a class="link_odd_elementSpec" href="#TEI.imprimatur" title="&lt;imprimatur&gt;">imprimatur</a> <a class="link_odd_elementSpec" href="#TEI.imprint" title="&lt;imprint&gt;">imprint</a> <a class="link_odd_elementSpec" href="#TEI.item" title="&lt;item&gt;">item</a> <a class="link_odd_elementSpec" href="#TEI.l" title="&lt;l&gt;">l</a> <a class="link_odd_elementSpec" href="#TEI.lb" title="&lt;lb&gt;">lb</a> <a class="link_odd_elementSpec" href="#TEI.lem" title="&lt;lem&gt;">lem</a> <a class="link_odd_elementSpec" href="#TEI.lg" title="&lt;lg&gt;">lg</a> <a class="link_odd_elementSpec" href="#TEI.licence" title="&lt;licence&gt;">licence</a> <a class="link_odd_elementSpec" href="#TEI.list" title="&lt;list&gt;">list</a> <a class="link_odd_elementSpec" href="#TEI.listBibl" title="&lt;listBibl&gt;">listBibl</a> <a class="link_odd_elementSpec" href="#TEI.listChange" title="&lt;listChange&gt;">listChange</a> <a class="link_odd_elementSpec" href="#TEI.listWit" title="&lt;listWit&gt;">listWit</a> <a class="link_odd_elementSpec" href="#TEI.monogr" title="&lt;monogr&gt;">monogr</a> <a class="link_odd_elementSpec" href="#TEI.name" title="&lt;name&gt;">name</a> <a class="link_odd_elementSpec" href="#TEI.note" title="&lt;note&gt;">note</a> <a class="link_odd_elementSpec" href="#TEI.orgName" title="&lt;orgName&gt;">orgName</a> <a class="link_odd_elementSpec" href="#TEI.p" title="&lt;p&gt;">p</a> <a class="link_odd_elementSpec" href="#TEI.pb" title="&lt;pb&gt;">pb</a> <a class="link_odd_elementSpec" href="#TEI.persName" title="&lt;persName&gt;">persName</a> <a class="link_odd_elementSpec" href="#TEI.placeName" title="&lt;placeName&gt;">placeName</a> <a class="link_odd_elementSpec" href="#TEI.principal" title="&lt;principal&gt;">principal</a> <a class="link_odd_elementSpec" href="#TEI.ptr" title="&lt;ptr&gt;">ptr</a> <a class="link_odd_elementSpec" href="#TEI.pubPlace" title="&lt;pubPlace&gt;">pubPlace</a> <a class="link_odd_elementSpec" href="#TEI.publicationStmt" title="&lt;publicationStmt&gt;">publicationStmt</a> <a class="link_odd_elementSpec" href="#TEI.publisher" title="&lt;publisher&gt;">publisher</a> <a class="link_odd_elementSpec" href="#TEI.q" title="&lt;q&gt;">q</a> <a class="link_odd_elementSpec" href="#TEI.quote" title="&lt;quote&gt;">quote</a> <a class="link_odd_elementSpec" href="#TEI.rdg" title="&lt;rdg&gt;">rdg</a> <a class="link_odd_elementSpec" href="#TEI.ref" title="&lt;ref&gt;">ref</a> <a class="link_odd_elementSpec" href="#TEI.resp" title="&lt;resp&gt;">resp</a> <a class="link_odd_elementSpec" href="#TEI.respStmt" title="&lt;respStmt&gt;">respStmt</a> <a class="link_odd_elementSpec" href="#TEI.revisionDesc" title="&lt;revisionDesc&gt;">revisionDesc</a> <a class="link_odd_elementSpec" href="#TEI.s" title="&lt;s&gt;">s</a> <a class="link_odd_elementSpec" href="#TEI.seg" title="&lt;seg&gt;">seg</a> <a class="link_odd_elementSpec" href="#TEI.signed" title="&lt;signed&gt;">signed</a> <a class="link_odd_elementSpec" href="#TEI.sourceDesc" title="&lt;sourceDesc&gt;">sourceDesc</a> <a class="link_odd_elementSpec" href="#TEI.teiHeader" title="&lt;teiHeader&gt;">teiHeader</a> <a class="link_odd_elementSpec" href="#TEI.term" title="&lt;term&gt;">term</a> <a class="link_odd_elementSpec" href="#TEI.text" title="&lt;text&gt;">text</a> <a class="link_odd_elementSpec" href="#TEI.title" title="&lt;title&gt;">title</a> <a class="link_odd_elementSpec" href="#TEI.titlePage" title="&lt;titlePage&gt;">titlePage</a> <a class="link_odd_elementSpec" href="#TEI.titlePart" title="&lt;titlePart&gt;">titlePart</a> <a class="link_odd_elementSpec" href="#TEI.titleStmt" title="&lt;titleStmt&gt;">titleStmt</a> <a class="link_odd_elementSpec" href="#TEI.trailer" title="&lt;trailer&gt;">trailer</a> <a class="link_odd_elementSpec" href="#TEI.variantEncoding" title="&lt;variantEncoding&gt;">variantEncoding</a> <a class="link_odd_elementSpec" href="#TEI.w" title="&lt;w&gt;">w</a> <a class="link_odd_elementSpec" href="#TEI.witness" title="&lt;witness&gt;">witness</a>]</span></span></td>
+                           <td class="wovenodd-col2"><span class="showmembers1"><a class="link_odd_classSpec" href="#TEI.att.global" title="att.global">att.global</a><span class="showmembers2">[<a class="link_odd_elementSpec" href="#TEI.TEI" title="&lt;TEI&gt;">TEI</a> <a class="link_odd_elementSpec" href="#TEI.abbr" title="&lt;abbr&gt;">abbr</a> <a class="link_odd_elementSpec" href="#TEI.app" title="&lt;app&gt;">app</a> <a class="link_odd_elementSpec" href="#TEI.author" title="&lt;author&gt;">author</a> <a class="link_odd_elementSpec" href="#TEI.authority" title="&lt;authority&gt;">authority</a> <a class="link_odd_elementSpec" href="#TEI.back" title="&lt;back&gt;">back</a> <a class="link_odd_elementSpec" href="#TEI.bibl" title="&lt;bibl&gt;">bibl</a> <a class="link_odd_elementSpec" href="#TEI.biblStruct" title="&lt;biblStruct&gt;">biblStruct</a> <a class="link_odd_elementSpec" href="#TEI.body" title="&lt;body&gt;">body</a> <a class="link_odd_elementSpec" href="#TEI.byline" title="&lt;byline&gt;">byline</a> <a class="link_odd_elementSpec" href="#TEI.cb" title="&lt;cb&gt;">cb</a> <a class="link_odd_elementSpec" href="#TEI.change" title="&lt;change&gt;">change</a> <a class="link_odd_elementSpec" href="#TEI.cit" title="&lt;cit&gt;">cit</a> <a class="link_odd_elementSpec" href="#TEI.date" title="&lt;date&gt;">date</a> <a class="link_odd_elementSpec" href="#TEI.div" title="&lt;div&gt;">div</a> <a class="link_odd_elementSpec" href="#TEI.docImprint" title="&lt;docImprint&gt;">docImprint</a> <a class="link_odd_elementSpec" href="#TEI.docTitle" title="&lt;docTitle&gt;">docTitle</a> <a class="link_odd_elementSpec" href="#TEI.edition" title="&lt;edition&gt;">edition</a> <a class="link_odd_elementSpec" href="#TEI.editionStmt" title="&lt;editionStmt&gt;">editionStmt</a> <a class="link_odd_elementSpec" href="#TEI.emph" title="&lt;emph&gt;">emph</a> <a class="link_odd_elementSpec" href="#TEI.encodingDesc" title="&lt;encodingDesc&gt;">encodingDesc</a> <a class="link_odd_elementSpec" href="#TEI.epigraph" title="&lt;epigraph&gt;">epigraph</a> <a class="link_odd_elementSpec" href="#TEI.figDesc" title="&lt;figDesc&gt;">figDesc</a> <a class="link_odd_elementSpec" href="#TEI.figure" title="&lt;figure&gt;">figure</a> <a class="link_odd_elementSpec" href="#TEI.fileDesc" title="&lt;fileDesc&gt;">fileDesc</a> <a class="link_odd_elementSpec" href="#TEI.foreign" title="&lt;foreign&gt;">foreign</a> <a class="link_odd_elementSpec" href="#TEI.front" title="&lt;front&gt;">front</a> <a class="link_odd_elementSpec" href="#TEI.funder" title="&lt;funder&gt;">funder</a> <a class="link_odd_elementSpec" href="#TEI.fw" title="&lt;fw&gt;">fw</a> <a class="link_odd_elementSpec" href="#TEI.gloss" title="&lt;gloss&gt;">gloss</a> <a class="link_odd_elementSpec" href="#TEI.graphic" title="&lt;graphic&gt;">graphic</a> <a class="link_odd_elementSpec" href="#TEI.head" title="&lt;head&gt;">head</a> <a class="link_odd_elementSpec" href="#TEI.hi" title="&lt;hi&gt;">hi</a> <a class="link_odd_elementSpec" href="#TEI.imprimatur" title="&lt;imprimatur&gt;">imprimatur</a> <a class="link_odd_elementSpec" href="#TEI.imprint" title="&lt;imprint&gt;">imprint</a> <a class="link_odd_elementSpec" href="#TEI.item" title="&lt;item&gt;">item</a> <a class="link_odd_elementSpec" href="#TEI.l" title="&lt;l&gt;">l</a> <a class="link_odd_elementSpec" href="#TEI.lb" title="&lt;lb&gt;">lb</a> <a class="link_odd_elementSpec" href="#TEI.lem" title="&lt;lem&gt;">lem</a> <a class="link_odd_elementSpec" href="#TEI.lg" title="&lt;lg&gt;">lg</a> <a class="link_odd_elementSpec" href="#TEI.licence" title="&lt;licence&gt;">licence</a> <a class="link_odd_elementSpec" href="#TEI.list" title="&lt;list&gt;">list</a> <a class="link_odd_elementSpec" href="#TEI.listBibl" title="&lt;listBibl&gt;">listBibl</a> <a class="link_odd_elementSpec" href="#TEI.listChange" title="&lt;listChange&gt;">listChange</a> <a class="link_odd_elementSpec" href="#TEI.listTranspose" title="&lt;listTranspose&gt;">listTranspose</a> <a class="link_odd_elementSpec" href="#TEI.listWit" title="&lt;listWit&gt;">listWit</a> <a class="link_odd_elementSpec" href="#TEI.monogr" title="&lt;monogr&gt;">monogr</a> <a class="link_odd_elementSpec" href="#TEI.name" title="&lt;name&gt;">name</a> <a class="link_odd_elementSpec" href="#TEI.note" title="&lt;note&gt;">note</a> <a class="link_odd_elementSpec" href="#TEI.orgName" title="&lt;orgName&gt;">orgName</a> <a class="link_odd_elementSpec" href="#TEI.p" title="&lt;p&gt;">p</a> <a class="link_odd_elementSpec" href="#TEI.pb" title="&lt;pb&gt;">pb</a> <a class="link_odd_elementSpec" href="#TEI.persName" title="&lt;persName&gt;">persName</a> <a class="link_odd_elementSpec" href="#TEI.placeName" title="&lt;placeName&gt;">placeName</a> <a class="link_odd_elementSpec" href="#TEI.principal" title="&lt;principal&gt;">principal</a> <a class="link_odd_elementSpec" href="#TEI.ptr" title="&lt;ptr&gt;">ptr</a> <a class="link_odd_elementSpec" href="#TEI.pubPlace" title="&lt;pubPlace&gt;">pubPlace</a> <a class="link_odd_elementSpec" href="#TEI.publicationStmt" title="&lt;publicationStmt&gt;">publicationStmt</a> <a class="link_odd_elementSpec" href="#TEI.publisher" title="&lt;publisher&gt;">publisher</a> <a class="link_odd_elementSpec" href="#TEI.q" title="&lt;q&gt;">q</a> <a class="link_odd_elementSpec" href="#TEI.quote" title="&lt;quote&gt;">quote</a> <a class="link_odd_elementSpec" href="#TEI.rdg" title="&lt;rdg&gt;">rdg</a> <a class="link_odd_elementSpec" href="#TEI.ref" title="&lt;ref&gt;">ref</a> <a class="link_odd_elementSpec" href="#TEI.resp" title="&lt;resp&gt;">resp</a> <a class="link_odd_elementSpec" href="#TEI.respStmt" title="&lt;respStmt&gt;">respStmt</a> <a class="link_odd_elementSpec" href="#TEI.revisionDesc" title="&lt;revisionDesc&gt;">revisionDesc</a> <a class="link_odd_elementSpec" href="#TEI.s" title="&lt;s&gt;">s</a> <a class="link_odd_elementSpec" href="#TEI.seg" title="&lt;seg&gt;">seg</a> <a class="link_odd_elementSpec" href="#TEI.signed" title="&lt;signed&gt;">signed</a> <a class="link_odd_elementSpec" href="#TEI.sourceDesc" title="&lt;sourceDesc&gt;">sourceDesc</a> <a class="link_odd_elementSpec" href="#TEI.standOff" title="&lt;standOff&gt;">standOff</a> <a class="link_odd_elementSpec" href="#TEI.teiHeader" title="&lt;teiHeader&gt;">teiHeader</a> <a class="link_odd_elementSpec" href="#TEI.term" title="&lt;term&gt;">term</a> <a class="link_odd_elementSpec" href="#TEI.text" title="&lt;text&gt;">text</a> <a class="link_odd_elementSpec" href="#TEI.title" title="&lt;title&gt;">title</a> <a class="link_odd_elementSpec" href="#TEI.titlePage" title="&lt;titlePage&gt;">titlePage</a> <a class="link_odd_elementSpec" href="#TEI.titlePart" title="&lt;titlePart&gt;">titlePart</a> <a class="link_odd_elementSpec" href="#TEI.titleStmt" title="&lt;titleStmt&gt;">titleStmt</a> <a class="link_odd_elementSpec" href="#TEI.trailer" title="&lt;trailer&gt;">trailer</a> <a class="link_odd_elementSpec" href="#TEI.transpose" title="&lt;transpose&gt;">transpose</a> <a class="link_odd_elementSpec" href="#TEI.variantEncoding" title="&lt;variantEncoding&gt;">variantEncoding</a> <a class="link_odd_elementSpec" href="#TEI.w" title="&lt;w&gt;">w</a> <a class="link_odd_elementSpec" href="#TEI.witness" title="&lt;witness&gt;">witness</a>]</span></span></td>
                         </tr>
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Attributes</span></td>
@@ -15635,7 +16175,7 @@ element witness
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Example</span></td>
                            <td class="wovenodd-col2">
-                              <div id="index.xml-egXML-d31e51027" class="pre egXML_valid">Blessed are the
+                              <div id="index.xml-egXML-d31e52799" class="pre egXML_valid">Blessed are the
                                  <span class="element">&lt;choice&gt;</span>
                                   <span class="element">&lt;sic&gt;</span>cheesemakers<span class="element">&lt;/sic&gt;</span>
                                   <span class="element">&lt;corr <span class="attribute">resp</span>="<span class="attributevalue">#editor</span>" <span class="attribute">cert</span>="<span class="attributevalue">high</span>"&gt;</span>peacemakers<span class="element">&lt;/corr&gt;</span>
@@ -15645,7 +16185,7 @@ element witness
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Example</span></td>
                            <td class="wovenodd-col2">
-                              <div id="index.xml-egXML-d31e51039" class="pre egXML_valid">
+                              <div id="index.xml-egXML-d31e52811" class="pre egXML_valid">
                                  <span class="comment">&lt;!-- in the &lt;text&gt; ... --&gt;</span><span class="element">&lt;lg&gt;</span>
                                  <span class="comment">&lt;!-- ... --&gt;</span>
                                   <span class="element">&lt;l&gt;</span>Punkes, Panders, baſe extortionizing
@@ -15679,7 +16219,7 @@ element witness
                         </tr>
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Members</span></td>
-                           <td class="wovenodd-col2"><span class="showmembers1"><a class="link_odd_classSpec" href="#TEI.att.global" title="att.global">att.global</a><span class="showmembers2">[<a class="link_odd_elementSpec" href="#TEI.TEI" title="&lt;TEI&gt;">TEI</a> <a class="link_odd_elementSpec" href="#TEI.abbr" title="&lt;abbr&gt;">abbr</a> <a class="link_odd_elementSpec" href="#TEI.app" title="&lt;app&gt;">app</a> <a class="link_odd_elementSpec" href="#TEI.author" title="&lt;author&gt;">author</a> <a class="link_odd_elementSpec" href="#TEI.authority" title="&lt;authority&gt;">authority</a> <a class="link_odd_elementSpec" href="#TEI.back" title="&lt;back&gt;">back</a> <a class="link_odd_elementSpec" href="#TEI.bibl" title="&lt;bibl&gt;">bibl</a> <a class="link_odd_elementSpec" href="#TEI.biblStruct" title="&lt;biblStruct&gt;">biblStruct</a> <a class="link_odd_elementSpec" href="#TEI.body" title="&lt;body&gt;">body</a> <a class="link_odd_elementSpec" href="#TEI.byline" title="&lt;byline&gt;">byline</a> <a class="link_odd_elementSpec" href="#TEI.cb" title="&lt;cb&gt;">cb</a> <a class="link_odd_elementSpec" href="#TEI.change" title="&lt;change&gt;">change</a> <a class="link_odd_elementSpec" href="#TEI.cit" title="&lt;cit&gt;">cit</a> <a class="link_odd_elementSpec" href="#TEI.date" title="&lt;date&gt;">date</a> <a class="link_odd_elementSpec" href="#TEI.div" title="&lt;div&gt;">div</a> <a class="link_odd_elementSpec" href="#TEI.docImprint" title="&lt;docImprint&gt;">docImprint</a> <a class="link_odd_elementSpec" href="#TEI.docTitle" title="&lt;docTitle&gt;">docTitle</a> <a class="link_odd_elementSpec" href="#TEI.edition" title="&lt;edition&gt;">edition</a> <a class="link_odd_elementSpec" href="#TEI.editionStmt" title="&lt;editionStmt&gt;">editionStmt</a> <a class="link_odd_elementSpec" href="#TEI.emph" title="&lt;emph&gt;">emph</a> <a class="link_odd_elementSpec" href="#TEI.encodingDesc" title="&lt;encodingDesc&gt;">encodingDesc</a> <a class="link_odd_elementSpec" href="#TEI.epigraph" title="&lt;epigraph&gt;">epigraph</a> <a class="link_odd_elementSpec" href="#TEI.figDesc" title="&lt;figDesc&gt;">figDesc</a> <a class="link_odd_elementSpec" href="#TEI.figure" title="&lt;figure&gt;">figure</a> <a class="link_odd_elementSpec" href="#TEI.fileDesc" title="&lt;fileDesc&gt;">fileDesc</a> <a class="link_odd_elementSpec" href="#TEI.foreign" title="&lt;foreign&gt;">foreign</a> <a class="link_odd_elementSpec" href="#TEI.front" title="&lt;front&gt;">front</a> <a class="link_odd_elementSpec" href="#TEI.funder" title="&lt;funder&gt;">funder</a> <a class="link_odd_elementSpec" href="#TEI.fw" title="&lt;fw&gt;">fw</a> <a class="link_odd_elementSpec" href="#TEI.gloss" title="&lt;gloss&gt;">gloss</a> <a class="link_odd_elementSpec" href="#TEI.graphic" title="&lt;graphic&gt;">graphic</a> <a class="link_odd_elementSpec" href="#TEI.head" title="&lt;head&gt;">head</a> <a class="link_odd_elementSpec" href="#TEI.hi" title="&lt;hi&gt;">hi</a> <a class="link_odd_elementSpec" href="#TEI.imprimatur" title="&lt;imprimatur&gt;">imprimatur</a> <a class="link_odd_elementSpec" href="#TEI.imprint" title="&lt;imprint&gt;">imprint</a> <a class="link_odd_elementSpec" href="#TEI.item" title="&lt;item&gt;">item</a> <a class="link_odd_elementSpec" href="#TEI.l" title="&lt;l&gt;">l</a> <a class="link_odd_elementSpec" href="#TEI.lb" title="&lt;lb&gt;">lb</a> <a class="link_odd_elementSpec" href="#TEI.lem" title="&lt;lem&gt;">lem</a> <a class="link_odd_elementSpec" href="#TEI.lg" title="&lt;lg&gt;">lg</a> <a class="link_odd_elementSpec" href="#TEI.licence" title="&lt;licence&gt;">licence</a> <a class="link_odd_elementSpec" href="#TEI.list" title="&lt;list&gt;">list</a> <a class="link_odd_elementSpec" href="#TEI.listBibl" title="&lt;listBibl&gt;">listBibl</a> <a class="link_odd_elementSpec" href="#TEI.listChange" title="&lt;listChange&gt;">listChange</a> <a class="link_odd_elementSpec" href="#TEI.listWit" title="&lt;listWit&gt;">listWit</a> <a class="link_odd_elementSpec" href="#TEI.monogr" title="&lt;monogr&gt;">monogr</a> <a class="link_odd_elementSpec" href="#TEI.name" title="&lt;name&gt;">name</a> <a class="link_odd_elementSpec" href="#TEI.note" title="&lt;note&gt;">note</a> <a class="link_odd_elementSpec" href="#TEI.orgName" title="&lt;orgName&gt;">orgName</a> <a class="link_odd_elementSpec" href="#TEI.p" title="&lt;p&gt;">p</a> <a class="link_odd_elementSpec" href="#TEI.pb" title="&lt;pb&gt;">pb</a> <a class="link_odd_elementSpec" href="#TEI.persName" title="&lt;persName&gt;">persName</a> <a class="link_odd_elementSpec" href="#TEI.placeName" title="&lt;placeName&gt;">placeName</a> <a class="link_odd_elementSpec" href="#TEI.principal" title="&lt;principal&gt;">principal</a> <a class="link_odd_elementSpec" href="#TEI.ptr" title="&lt;ptr&gt;">ptr</a> <a class="link_odd_elementSpec" href="#TEI.pubPlace" title="&lt;pubPlace&gt;">pubPlace</a> <a class="link_odd_elementSpec" href="#TEI.publicationStmt" title="&lt;publicationStmt&gt;">publicationStmt</a> <a class="link_odd_elementSpec" href="#TEI.publisher" title="&lt;publisher&gt;">publisher</a> <a class="link_odd_elementSpec" href="#TEI.q" title="&lt;q&gt;">q</a> <a class="link_odd_elementSpec" href="#TEI.quote" title="&lt;quote&gt;">quote</a> <a class="link_odd_elementSpec" href="#TEI.rdg" title="&lt;rdg&gt;">rdg</a> <a class="link_odd_elementSpec" href="#TEI.ref" title="&lt;ref&gt;">ref</a> <a class="link_odd_elementSpec" href="#TEI.resp" title="&lt;resp&gt;">resp</a> <a class="link_odd_elementSpec" href="#TEI.respStmt" title="&lt;respStmt&gt;">respStmt</a> <a class="link_odd_elementSpec" href="#TEI.revisionDesc" title="&lt;revisionDesc&gt;">revisionDesc</a> <a class="link_odd_elementSpec" href="#TEI.s" title="&lt;s&gt;">s</a> <a class="link_odd_elementSpec" href="#TEI.seg" title="&lt;seg&gt;">seg</a> <a class="link_odd_elementSpec" href="#TEI.signed" title="&lt;signed&gt;">signed</a> <a class="link_odd_elementSpec" href="#TEI.sourceDesc" title="&lt;sourceDesc&gt;">sourceDesc</a> <a class="link_odd_elementSpec" href="#TEI.teiHeader" title="&lt;teiHeader&gt;">teiHeader</a> <a class="link_odd_elementSpec" href="#TEI.term" title="&lt;term&gt;">term</a> <a class="link_odd_elementSpec" href="#TEI.text" title="&lt;text&gt;">text</a> <a class="link_odd_elementSpec" href="#TEI.title" title="&lt;title&gt;">title</a> <a class="link_odd_elementSpec" href="#TEI.titlePage" title="&lt;titlePage&gt;">titlePage</a> <a class="link_odd_elementSpec" href="#TEI.titlePart" title="&lt;titlePart&gt;">titlePart</a> <a class="link_odd_elementSpec" href="#TEI.titleStmt" title="&lt;titleStmt&gt;">titleStmt</a> <a class="link_odd_elementSpec" href="#TEI.trailer" title="&lt;trailer&gt;">trailer</a> <a class="link_odd_elementSpec" href="#TEI.variantEncoding" title="&lt;variantEncoding&gt;">variantEncoding</a> <a class="link_odd_elementSpec" href="#TEI.w" title="&lt;w&gt;">w</a> <a class="link_odd_elementSpec" href="#TEI.witness" title="&lt;witness&gt;">witness</a>]</span></span></td>
+                           <td class="wovenodd-col2"><span class="showmembers1"><a class="link_odd_classSpec" href="#TEI.att.global" title="att.global">att.global</a><span class="showmembers2">[<a class="link_odd_elementSpec" href="#TEI.TEI" title="&lt;TEI&gt;">TEI</a> <a class="link_odd_elementSpec" href="#TEI.abbr" title="&lt;abbr&gt;">abbr</a> <a class="link_odd_elementSpec" href="#TEI.app" title="&lt;app&gt;">app</a> <a class="link_odd_elementSpec" href="#TEI.author" title="&lt;author&gt;">author</a> <a class="link_odd_elementSpec" href="#TEI.authority" title="&lt;authority&gt;">authority</a> <a class="link_odd_elementSpec" href="#TEI.back" title="&lt;back&gt;">back</a> <a class="link_odd_elementSpec" href="#TEI.bibl" title="&lt;bibl&gt;">bibl</a> <a class="link_odd_elementSpec" href="#TEI.biblStruct" title="&lt;biblStruct&gt;">biblStruct</a> <a class="link_odd_elementSpec" href="#TEI.body" title="&lt;body&gt;">body</a> <a class="link_odd_elementSpec" href="#TEI.byline" title="&lt;byline&gt;">byline</a> <a class="link_odd_elementSpec" href="#TEI.cb" title="&lt;cb&gt;">cb</a> <a class="link_odd_elementSpec" href="#TEI.change" title="&lt;change&gt;">change</a> <a class="link_odd_elementSpec" href="#TEI.cit" title="&lt;cit&gt;">cit</a> <a class="link_odd_elementSpec" href="#TEI.date" title="&lt;date&gt;">date</a> <a class="link_odd_elementSpec" href="#TEI.div" title="&lt;div&gt;">div</a> <a class="link_odd_elementSpec" href="#TEI.docImprint" title="&lt;docImprint&gt;">docImprint</a> <a class="link_odd_elementSpec" href="#TEI.docTitle" title="&lt;docTitle&gt;">docTitle</a> <a class="link_odd_elementSpec" href="#TEI.edition" title="&lt;edition&gt;">edition</a> <a class="link_odd_elementSpec" href="#TEI.editionStmt" title="&lt;editionStmt&gt;">editionStmt</a> <a class="link_odd_elementSpec" href="#TEI.emph" title="&lt;emph&gt;">emph</a> <a class="link_odd_elementSpec" href="#TEI.encodingDesc" title="&lt;encodingDesc&gt;">encodingDesc</a> <a class="link_odd_elementSpec" href="#TEI.epigraph" title="&lt;epigraph&gt;">epigraph</a> <a class="link_odd_elementSpec" href="#TEI.figDesc" title="&lt;figDesc&gt;">figDesc</a> <a class="link_odd_elementSpec" href="#TEI.figure" title="&lt;figure&gt;">figure</a> <a class="link_odd_elementSpec" href="#TEI.fileDesc" title="&lt;fileDesc&gt;">fileDesc</a> <a class="link_odd_elementSpec" href="#TEI.foreign" title="&lt;foreign&gt;">foreign</a> <a class="link_odd_elementSpec" href="#TEI.front" title="&lt;front&gt;">front</a> <a class="link_odd_elementSpec" href="#TEI.funder" title="&lt;funder&gt;">funder</a> <a class="link_odd_elementSpec" href="#TEI.fw" title="&lt;fw&gt;">fw</a> <a class="link_odd_elementSpec" href="#TEI.gloss" title="&lt;gloss&gt;">gloss</a> <a class="link_odd_elementSpec" href="#TEI.graphic" title="&lt;graphic&gt;">graphic</a> <a class="link_odd_elementSpec" href="#TEI.head" title="&lt;head&gt;">head</a> <a class="link_odd_elementSpec" href="#TEI.hi" title="&lt;hi&gt;">hi</a> <a class="link_odd_elementSpec" href="#TEI.imprimatur" title="&lt;imprimatur&gt;">imprimatur</a> <a class="link_odd_elementSpec" href="#TEI.imprint" title="&lt;imprint&gt;">imprint</a> <a class="link_odd_elementSpec" href="#TEI.item" title="&lt;item&gt;">item</a> <a class="link_odd_elementSpec" href="#TEI.l" title="&lt;l&gt;">l</a> <a class="link_odd_elementSpec" href="#TEI.lb" title="&lt;lb&gt;">lb</a> <a class="link_odd_elementSpec" href="#TEI.lem" title="&lt;lem&gt;">lem</a> <a class="link_odd_elementSpec" href="#TEI.lg" title="&lt;lg&gt;">lg</a> <a class="link_odd_elementSpec" href="#TEI.licence" title="&lt;licence&gt;">licence</a> <a class="link_odd_elementSpec" href="#TEI.list" title="&lt;list&gt;">list</a> <a class="link_odd_elementSpec" href="#TEI.listBibl" title="&lt;listBibl&gt;">listBibl</a> <a class="link_odd_elementSpec" href="#TEI.listChange" title="&lt;listChange&gt;">listChange</a> <a class="link_odd_elementSpec" href="#TEI.listTranspose" title="&lt;listTranspose&gt;">listTranspose</a> <a class="link_odd_elementSpec" href="#TEI.listWit" title="&lt;listWit&gt;">listWit</a> <a class="link_odd_elementSpec" href="#TEI.monogr" title="&lt;monogr&gt;">monogr</a> <a class="link_odd_elementSpec" href="#TEI.name" title="&lt;name&gt;">name</a> <a class="link_odd_elementSpec" href="#TEI.note" title="&lt;note&gt;">note</a> <a class="link_odd_elementSpec" href="#TEI.orgName" title="&lt;orgName&gt;">orgName</a> <a class="link_odd_elementSpec" href="#TEI.p" title="&lt;p&gt;">p</a> <a class="link_odd_elementSpec" href="#TEI.pb" title="&lt;pb&gt;">pb</a> <a class="link_odd_elementSpec" href="#TEI.persName" title="&lt;persName&gt;">persName</a> <a class="link_odd_elementSpec" href="#TEI.placeName" title="&lt;placeName&gt;">placeName</a> <a class="link_odd_elementSpec" href="#TEI.principal" title="&lt;principal&gt;">principal</a> <a class="link_odd_elementSpec" href="#TEI.ptr" title="&lt;ptr&gt;">ptr</a> <a class="link_odd_elementSpec" href="#TEI.pubPlace" title="&lt;pubPlace&gt;">pubPlace</a> <a class="link_odd_elementSpec" href="#TEI.publicationStmt" title="&lt;publicationStmt&gt;">publicationStmt</a> <a class="link_odd_elementSpec" href="#TEI.publisher" title="&lt;publisher&gt;">publisher</a> <a class="link_odd_elementSpec" href="#TEI.q" title="&lt;q&gt;">q</a> <a class="link_odd_elementSpec" href="#TEI.quote" title="&lt;quote&gt;">quote</a> <a class="link_odd_elementSpec" href="#TEI.rdg" title="&lt;rdg&gt;">rdg</a> <a class="link_odd_elementSpec" href="#TEI.ref" title="&lt;ref&gt;">ref</a> <a class="link_odd_elementSpec" href="#TEI.resp" title="&lt;resp&gt;">resp</a> <a class="link_odd_elementSpec" href="#TEI.respStmt" title="&lt;respStmt&gt;">respStmt</a> <a class="link_odd_elementSpec" href="#TEI.revisionDesc" title="&lt;revisionDesc&gt;">revisionDesc</a> <a class="link_odd_elementSpec" href="#TEI.s" title="&lt;s&gt;">s</a> <a class="link_odd_elementSpec" href="#TEI.seg" title="&lt;seg&gt;">seg</a> <a class="link_odd_elementSpec" href="#TEI.signed" title="&lt;signed&gt;">signed</a> <a class="link_odd_elementSpec" href="#TEI.sourceDesc" title="&lt;sourceDesc&gt;">sourceDesc</a> <a class="link_odd_elementSpec" href="#TEI.standOff" title="&lt;standOff&gt;">standOff</a> <a class="link_odd_elementSpec" href="#TEI.teiHeader" title="&lt;teiHeader&gt;">teiHeader</a> <a class="link_odd_elementSpec" href="#TEI.term" title="&lt;term&gt;">term</a> <a class="link_odd_elementSpec" href="#TEI.text" title="&lt;text&gt;">text</a> <a class="link_odd_elementSpec" href="#TEI.title" title="&lt;title&gt;">title</a> <a class="link_odd_elementSpec" href="#TEI.titlePage" title="&lt;titlePage&gt;">titlePage</a> <a class="link_odd_elementSpec" href="#TEI.titlePart" title="&lt;titlePart&gt;">titlePart</a> <a class="link_odd_elementSpec" href="#TEI.titleStmt" title="&lt;titleStmt&gt;">titleStmt</a> <a class="link_odd_elementSpec" href="#TEI.trailer" title="&lt;trailer&gt;">trailer</a> <a class="link_odd_elementSpec" href="#TEI.transpose" title="&lt;transpose&gt;">transpose</a> <a class="link_odd_elementSpec" href="#TEI.variantEncoding" title="&lt;variantEncoding&gt;">variantEncoding</a> <a class="link_odd_elementSpec" href="#TEI.w" title="&lt;w&gt;">w</a> <a class="link_odd_elementSpec" href="#TEI.witness" title="&lt;witness&gt;">witness</a>]</span></span></td>
                         </tr>
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Attributes</span></td>
@@ -15739,7 +16279,7 @@ element witness
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Example</span></td>
                            <td class="wovenodd-col2">
-                              <div id="index.xml-egXML-d31e51522" class="pre egXML_valid"><span class="element">&lt;p&gt;</span>
+                              <div id="index.xml-egXML-d31e53307" class="pre egXML_valid"><span class="element">&lt;p&gt;</span>
                                  <span class="comment">&lt;!-- ... --&gt;</span> As Willard McCarty (<span class="element">&lt;bibl <span class="attribute">xml:id</span>="<span class="attributevalue">mcc_2012</span>"&gt;</span>2012, p.2<span class="element">&lt;/bibl&gt;</span>) tells us, <span class="element">&lt;quote <span class="attribute">source</span>="<span class="attributevalue">#mcc_2012</span>"&gt;</span>‘Collaboration’ is a problematic and should be a contested
                                     term.<span class="element">&lt;/quote&gt;</span>
                                  <span class="comment">&lt;!-- ... --&gt;</span>
@@ -15749,7 +16289,7 @@ element witness
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Example</span></td>
                            <td class="wovenodd-col2">
-                              <div id="index.xml-egXML-d31e51537" class="pre egXML_valid"><span class="element">&lt;p&gt;</span>
+                              <div id="index.xml-egXML-d31e53322" class="pre egXML_valid"><span class="element">&lt;p&gt;</span>
                                  <span class="comment">&lt;!-- ... --&gt;</span>
                                   <span class="element">&lt;quote <span class="attribute">source</span>="<span class="attributevalue">#chicago_15_ed</span>"&gt;</span>Grammatical theories are in flux, and the more we learn, the
                                     less we seem to know.<span class="element">&lt;/quote&gt;</span>
@@ -15767,12 +16307,12 @@ element witness
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Example</span></td>
                            <td class="wovenodd-col2">
-                              <div id="index.xml-egXML-d31e51564" class="pre egXML_valid"><span class="element">&lt;elementRef <span class="attribute">key</span>="<span class="attributevalue">p</span>" <span class="attribute">source</span>="<span class="attributevalue">tei:2.0.1</span>"/&gt;</span></div>Include in the schema an element named <a class="link_ref" href="#TEI.p" title="&lt;p&gt;">&lt;p&gt;</a> available from the TEI P5 2.0.1 release.</td>
+                              <div id="index.xml-egXML-d31e53349" class="pre egXML_valid"><span class="element">&lt;elementRef <span class="attribute">key</span>="<span class="attributevalue">p</span>" <span class="attribute">source</span>="<span class="attributevalue">tei:2.0.1</span>"/&gt;</span></div>Include in the schema an element named <a class="link_ref" href="#TEI.p" title="&lt;p&gt;">&lt;p&gt;</a> available from the TEI P5 2.0.1 release.</td>
                         </tr>
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Example</span></td>
                            <td class="wovenodd-col2">
-                              <div id="index.xml-egXML-d31e51575" class="pre egXML_valid"><span class="element">&lt;schemaSpec <span class="attribute">ident</span>="<span class="attributevalue">myODD</span>"
+                              <div id="index.xml-egXML-d31e53360" class="pre egXML_valid"><span class="element">&lt;schemaSpec <span class="attribute">ident</span>="<span class="attributevalue">myODD</span>"
                                      <span class="attribute">source</span>="<span class="attributevalue">mycompiledODD.xml</span>"&gt;</span>
                                  <span class="comment">&lt;!-- further declarations specifying the components required --&gt;</span>
                                  <span class="element">&lt;/schemaSpec&gt;</span></div>Create a schema using components taken from the file <span class="ident">mycompiledODD.xml</span>.</td>
@@ -15824,7 +16364,7 @@ element witness
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Example</span></td>
                            <td class="wovenodd-col2">In this example <span class="att">mimeType</span> is used to indicate that the URL points to a TEI XML file encoded in UTF-8.
-                              <div id="index.xml-egXML-d31e51673" class="pre egXML_valid"><span class="element">&lt;ref <span class="attribute">mimeType</span>="<span class="attributevalue">application/tei+xml; charset=UTF-8</span>"
+                              <div id="index.xml-egXML-d31e53458" class="pre egXML_valid"><span class="element">&lt;ref <span class="attribute">mimeType</span>="<span class="attributevalue">application/tei+xml; charset=UTF-8</span>"
                                      <span class="attribute">target</span>="<span class="attributevalue">https://raw.githubusercontent.com/TEIC/TEI/dev/P5/Source/guidelines-en.xml</span>"/&gt;</span></div>
                            </td>
                         </tr>
@@ -15877,14 +16417,14 @@ element witness
                                                 </tr>
                                                 <tr>
                                                    <td colspan="2">Normalization of part-of-speech information within a dictionary entry.
-                                                      <div id="index.xml-egXML-d31e51765" class="pre egXML_valid"><span class="element">&lt;gramGrp&gt;</span>
+                                                      <div id="index.xml-egXML-d31e53550" class="pre egXML_valid"><span class="element">&lt;gramGrp&gt;</span>
                                                           <span class="element">&lt;pos <span class="attribute">norm</span>="<span class="attributevalue">noun</span>"&gt;</span>n<span class="element">&lt;/pos&gt;</span>
                                                          <span class="element">&lt;/gramGrp&gt;</span></div>
                                                    </td>
                                                 </tr>
                                                 <tr>
                                                    <td colspan="2">Normalization of a source form in a tokenized historical corpus.
-                                                      <div id="index.xml-egXML-d31e51772" class="pre egXML_valid"><span class="element">&lt;s&gt;</span>
+                                                      <div id="index.xml-egXML-d31e53557" class="pre egXML_valid"><span class="element">&lt;s&gt;</span>
                                                           <span class="element">&lt;w&gt;</span>for<span class="element">&lt;/w&gt;</span>
                                                           <span class="element">&lt;w <span class="attribute">norm</span>="<span class="attributevalue">virtue's</span>"&gt;</span>vertues<span class="element">&lt;/w&gt;</span>
                                                           <span class="element">&lt;w&gt;</span>sake<span class="element">&lt;/w&gt;</span>
@@ -15893,7 +16433,7 @@ element witness
                                                 </tr>
                                                 <tr>
                                                    <td colspan="2">
-                                                      <div id="index.xml-egXML-d31e51783" class="pre egXML_valid"><span class="element">&lt;s&gt;</span>
+                                                      <div id="index.xml-egXML-d31e53568" class="pre egXML_valid"><span class="element">&lt;s&gt;</span>
                                                           <span class="element">&lt;w <span class="attribute">norm</span>="<span class="attributevalue">persuasion</span>"&gt;</span>perswasion<span class="element">&lt;/w&gt;</span>
                                                           <span class="element">&lt;w&gt;</span>of<span class="element">&lt;/w&gt;</span>
                                                           <span class="element">&lt;w <span class="attribute">norm</span>="<span class="attributevalue">Unity</span>"&gt;</span>Vnitie<span class="element">&lt;/w&gt;</span>
@@ -15902,7 +16442,7 @@ element witness
                                                 </tr>
                                                 <tr>
                                                    <td colspan="2">Example of normalization from <a class="link_ref" href="http://www.deutschestextarchiv.de/anonym_aviso_1609/258">Aviso. Relation oder Zeitung. Wolfenbüttel, 1609. In: Deutsches Textarchiv</a>.
-                                                      <div id="index.xml-egXML-d31e51800" class="pre egXML_valid"><span class="element">&lt;s&gt;</span>
+                                                      <div id="index.xml-egXML-d31e53585" class="pre egXML_valid"><span class="element">&lt;s&gt;</span>
                                                           <span class="element">&lt;w <span class="attribute">norm</span>="<span class="attributevalue">freiwillig</span>"&gt;</span>freywillig<span class="element">&lt;/w&gt;</span>
                                                           <span class="element">&lt;pc <span class="attribute">norm</span>="<span class="attributevalue">,</span>"
                                                               <span class="attribute">join</span>="<span class="attributevalue">left</span>"&gt;</span>/<span class="element">&lt;/pc&gt;</span>
@@ -15914,12 +16454,12 @@ element witness
                                                 </tr>
                                                 <tr>
                                                    <td colspan="2">
-                                                      <div id="index.xml-egXML-d31e51820" class="pre egXML_valid"><span class="element">&lt;w <span class="attribute">norm</span>="<span class="attributevalue">Teil</span>"&gt;</span>Theyll<span class="element">&lt;/w&gt;</span></div>
+                                                      <div id="index.xml-egXML-d31e53605" class="pre egXML_valid"><span class="element">&lt;w <span class="attribute">norm</span>="<span class="attributevalue">Teil</span>"&gt;</span>Theyll<span class="element">&lt;/w&gt;</span></div>
                                                    </td>
                                                 </tr>
                                                 <tr>
                                                    <td colspan="2">
-                                                      <div id="index.xml-egXML-d31e51825" class="pre egXML_valid"><span class="element">&lt;w <span class="attribute">norm</span>="<span class="attributevalue">Freude</span>"&gt;</span>Frewde<span class="element">&lt;/w&gt;</span></div>
+                                                      <div id="index.xml-egXML-d31e53610" class="pre egXML_valid"><span class="element">&lt;w <span class="attribute">norm</span>="<span class="attributevalue">Freude</span>"&gt;</span>Frewde<span class="element">&lt;/w&gt;</span></div>
                                                    </td>
                                                 </tr>
                                              </table>
@@ -15945,13 +16485,13 @@ element witness
                                                       would like to preserve it for any number of reasons, the use of <span class="att">orig</span> is essential and could have uses for both the speaker to see past mistakes, researchers
                                                       to get insight into how untrained speakers write their language instinctually (in
                                                       contrast to prescribed convention), etc.:
-                                                      <div id="index.xml-egXML-d31e51861" class="pre egXML_valid"><span class="element">&lt;w <span class="attribute">orig</span>="<span class="attributevalue">ntsa sia'i</span>"&gt;</span>ntsasia'i<span class="element">&lt;/w&gt;</span></div>
+                                                      <div id="index.xml-egXML-d31e53646" class="pre egXML_valid"><span class="element">&lt;w <span class="attribute">orig</span>="<span class="attributevalue">ntsa sia'i</span>"&gt;</span>ntsasia'i<span class="element">&lt;/w&gt;</span></div>
                                                    </td>
                                                 </tr>
                                                 <tr>
                                                    <td colspan="2">Example from the <a class="link_ref" href="https://earlyprint.org">EarlyPrint</a> project. Fragment of text where obvious errors have been corrected but the original
                                                       forms remain recorded:
-                                                      <div id="index.xml-egXML-d31e51870" class="pre egXML_valid"><span class="element">&lt;w <span class="attribute">lemma</span>="<span class="attributevalue">he</span>"
+                                                      <div id="index.xml-egXML-d31e53655" class="pre egXML_valid"><span class="element">&lt;w <span class="attribute">lemma</span>="<span class="attributevalue">he</span>"
                                                              <span class="attribute">pos</span>="<span class="attributevalue">pns</span>"
                                                              <span class="attribute">xml:id</span>="<span class="attributevalue">b1afj-003-a-0950</span>"&gt;</span>he<span class="element">&lt;/w&gt;</span>
                                                          <span class="element">&lt;w <span class="attribute">lemma</span>="<span class="attributevalue">have</span>"
@@ -15970,7 +16510,7 @@ element witness
                                                    <td colspan="2">An example from the EarlyPrint project showing the use of both <span class="att">norm</span> and <span class="att">orig</span>. The <span class="att">orig</span> attribute preserves the original version (sometimes with spelling errors, often with
                                                       printer abbreviations), the element content resolves printer abbreviations but retains
                                                       the original orthography, and the <span class="att">norm</span> attribute holds normalized values:
-                                                      <div id="index.xml-egXML-d31e51894" class="pre egXML_valid"><span class="element">&lt;w <span class="attribute">lemma</span>="<span class="attributevalue">commandment</span>"
+                                                      <div id="index.xml-egXML-d31e53679" class="pre egXML_valid"><span class="element">&lt;w <span class="attribute">lemma</span>="<span class="attributevalue">commandment</span>"
                                                              <span class="attribute">pos</span>="<span class="attributevalue">n1</span>"
                                                              <span class="attribute">norm</span>="<span class="attributevalue">commandment</span>"
                                                              <span class="attribute">xml:id</span>="<span class="attributevalue">b9avr-018-a-7720</span>"
@@ -16033,12 +16573,12 @@ element witness
                                                 </tr>
                                                 <tr>
                                                    <td colspan="2">
-                                                      <div id="index.xml-egXML-d31e52003" class="pre egXML_valid"><span class="element">&lt;w <span class="attribute">lemma</span>="<span class="attributevalue">wife</span>"&gt;</span>wives<span class="element">&lt;/w&gt;</span></div>
+                                                      <div id="index.xml-egXML-d31e53788" class="pre egXML_valid"><span class="element">&lt;w <span class="attribute">lemma</span>="<span class="attributevalue">wife</span>"&gt;</span>wives<span class="element">&lt;/w&gt;</span></div>
                                                    </td>
                                                 </tr>
                                                 <tr>
                                                    <td colspan="2">
-                                                      <div id="index.xml-egXML-d31e52008" class="pre egXML_valid"><span class="element">&lt;w <span class="attribute">lemma</span>="<span class="attributevalue">Arznei</span>"&gt;</span>Artzeneyen<span class="element">&lt;/w&gt;</span></div>
+                                                      <div id="index.xml-egXML-d31e53793" class="pre egXML_valid"><span class="element">&lt;w <span class="attribute">lemma</span>="<span class="attributevalue">Arznei</span>"&gt;</span>Artzeneyen<span class="element">&lt;/w&gt;</span></div>
                                                    </td>
                                                 </tr>
                                              </table>
@@ -16060,7 +16600,7 @@ element witness
                                                 </tr>
                                                 <tr>
                                                    <td colspan="2">
-                                                      <div id="index.xml-egXML-d31e52036" class="pre egXML_valid"><span class="element">&lt;w <span class="attribute">type</span>="<span class="attributevalue">verb</span>"
+                                                      <div id="index.xml-egXML-d31e53821" class="pre egXML_valid"><span class="element">&lt;w <span class="attribute">type</span>="<span class="attributevalue">verb</span>"
                                                              <span class="attribute">lemma</span>="<span class="attributevalue">hit</span>"
                                                              <span class="attribute">lemmaRef</span>="<span class="attributevalue">http://www.example.com/lexicon/hitvb.xml</span>"&gt;</span>hitt<span class="element">&lt;m <span class="attribute">type</span>="<span class="attributevalue">suffix</span>"&gt;</span>ing<span class="element">&lt;/m&gt;</span>
                                                          <span class="element">&lt;/w&gt;</span></div>
@@ -16086,7 +16626,7 @@ element witness
                                                 </tr>
                                                 <tr>
                                                    <td colspan="2">The German sentence <span class="q">‘Wir fahren in den Urlaub.’</span> tagged with the Stuttgart-Tuebingen-Tagset (STTS).
-                                                      <div id="index.xml-egXML-d31e52070" class="pre egXML_valid"><span class="element">&lt;s&gt;</span>
+                                                      <div id="index.xml-egXML-d31e53855" class="pre egXML_valid"><span class="element">&lt;s&gt;</span>
                                                           <span class="element">&lt;w <span class="attribute">pos</span>="<span class="attributevalue">PPER</span>"&gt;</span>Wir<span class="element">&lt;/w&gt;</span>
                                                           <span class="element">&lt;w <span class="attribute">pos</span>="<span class="attributevalue">VVFIN</span>"&gt;</span>fahren<span class="element">&lt;/w&gt;</span>
                                                           <span class="element">&lt;w <span class="attribute">pos</span>="<span class="attributevalue">APPR</span>"&gt;</span>in<span class="element">&lt;/w&gt;</span>
@@ -16098,13 +16638,13 @@ element witness
                                                 </tr>
                                                 <tr>
                                                    <td colspan="2">The English sentence <span class="q">‘We're going to Brazil.’</span> tagged with the <a class="link_ref" href="http://ucrel.lancs.ac.uk/claws5tags.html">CLAWS-5</a> tagset, arranged inline (with significant whitespace).
-                                                      <div id="index.xml-egXML-d31e52093" class="pre egXML_valid"><span class="element">&lt;p&gt;</span><span class="element">&lt;w <span class="attribute">pos</span>="<span class="attributevalue">PNP</span>"&gt;</span>We<span class="element">&lt;/w&gt;</span><span class="element">&lt;w <span class="attribute">pos</span>="<span class="attributevalue">VBB</span>"&gt;</span>'re<span class="element">&lt;/w&gt;</span> <span class="element">&lt;w <span class="attribute">pos</span>="<span class="attributevalue">VVG</span>"&gt;</span>going<span class="element">&lt;/w&gt;</span> <span class="element">&lt;w <span class="attribute">pos</span>="<span class="attributevalue">PRP</span>"&gt;</span>to<span class="element">&lt;/w&gt;</span> <span class="element">&lt;w <span class="attribute">pos</span>="<span class="attributevalue">NP0</span>"&gt;</span>Brazil<span class="element">&lt;/w&gt;</span><span class="element">&lt;pc <span class="attribute">pos</span>="<span class="attributevalue">PUN</span>"&gt;</span>.<span class="element">&lt;/pc&gt;</span><span class="element">&lt;/p&gt;</span>
+                                                      <div id="index.xml-egXML-d31e53878" class="pre egXML_valid"><span class="element">&lt;p&gt;</span><span class="element">&lt;w <span class="attribute">pos</span>="<span class="attributevalue">PNP</span>"&gt;</span>We<span class="element">&lt;/w&gt;</span><span class="element">&lt;w <span class="attribute">pos</span>="<span class="attributevalue">VBB</span>"&gt;</span>'re<span class="element">&lt;/w&gt;</span> <span class="element">&lt;w <span class="attribute">pos</span>="<span class="attributevalue">VVG</span>"&gt;</span>going<span class="element">&lt;/w&gt;</span> <span class="element">&lt;w <span class="attribute">pos</span>="<span class="attributevalue">PRP</span>"&gt;</span>to<span class="element">&lt;/w&gt;</span> <span class="element">&lt;w <span class="attribute">pos</span>="<span class="attributevalue">NP0</span>"&gt;</span>Brazil<span class="element">&lt;/w&gt;</span><span class="element">&lt;pc <span class="attribute">pos</span>="<span class="attributevalue">PUN</span>"&gt;</span>.<span class="element">&lt;/pc&gt;</span><span class="element">&lt;/p&gt;</span>
                                                                  </div>
                                                    </td>
                                                 </tr>
                                                 <tr>
                                                    <td colspan="2">The English sentence <span class="q">‘We're going on vacation to Brazil for a month!’</span> tagged with the <a class="link_ref" href="http://ucrel.lancs.ac.uk/claws7tags.html">CLAWS-7</a> tagset and arranged sequentially.
-                                                      <div id="index.xml-egXML-d31e52120" class="pre egXML_valid"><span class="element">&lt;p&gt;</span>
+                                                      <div id="index.xml-egXML-d31e53905" class="pre egXML_valid"><span class="element">&lt;p&gt;</span>
                                                           <span class="element">&lt;w <span class="attribute">pos</span>="<span class="attributevalue">PPIS2</span>"&gt;</span>We<span class="element">&lt;/w&gt;</span>
                                                           <span class="element">&lt;w <span class="attribute">pos</span>="<span class="attributevalue">VBR</span>"&gt;</span>'re<span class="element">&lt;/w&gt;</span>
                                                           <span class="element">&lt;w <span class="attribute">pos</span>="<span class="attributevalue">VVG</span>"&gt;</span>going<span class="element">&lt;/w&gt;</span>
@@ -16138,7 +16678,7 @@ element witness
                                                 </tr>
                                                 <tr>
                                                    <td colspan="2">
-                                                      <div id="index.xml-egXML-d31e52175" class="pre egXML_valid"><span class="element">&lt;ab&gt;</span>
+                                                      <div id="index.xml-egXML-d31e53960" class="pre egXML_valid"><span class="element">&lt;ab&gt;</span>
                                                           <span class="element">&lt;w <span class="attribute">pos</span>="<span class="attributevalue">PPER</span>"
                                                               <span class="attribute">msd</span>="<span class="attributevalue">1.Pl.*.Nom</span>"&gt;</span>Wir<span class="element">&lt;/w&gt;</span>
                                                           <span class="element">&lt;w <span class="attribute">pos</span>="<span class="attributevalue">VVFIN</span>"
@@ -16192,7 +16732,7 @@ element witness
                                                 <tr>
                                                    <td colspan="2">The example below assumes that the lack of whitespace is marked redundantly, by using
                                                       the appropriate values of <span class="att">join</span>.
-                                                      <div id="index.xml-egXML-d31e52259" class="pre egXML_valid"><span class="element">&lt;s&gt;</span>
+                                                      <div id="index.xml-egXML-d31e54044" class="pre egXML_valid"><span class="element">&lt;s&gt;</span>
                                                           <span class="element">&lt;pc <span class="attribute">join</span>="<span class="attributevalue">right</span>"&gt;</span>"<span class="element">&lt;/pc&gt;</span>
                                                           <span class="element">&lt;w <span class="attribute">join</span>="<span class="attributevalue">left</span>"&gt;</span>Friends<span class="element">&lt;/w&gt;</span>
                                                           <span class="element">&lt;w&gt;</span>will<span class="element">&lt;/w&gt;</span>
@@ -16208,7 +16748,7 @@ element witness
                                                 <tr>
                                                    <td colspan="2">The English sentence <span class="q">‘We're going on vacation.’</span> tagged with the CLAWS-5 tagset, arranged sequentially, tagged on the assumption that
                                                       only the lack of the preceding whitespace is indicated.
-                                                      <div id="index.xml-egXML-d31e52280" class="pre egXML_valid"><span class="element">&lt;p&gt;</span>
+                                                      <div id="index.xml-egXML-d31e54065" class="pre egXML_valid"><span class="element">&lt;p&gt;</span>
                                                           <span class="element">&lt;w <span class="attribute">pos</span>="<span class="attributevalue">PNP</span>"&gt;</span>We<span class="element">&lt;/w&gt;</span>
                                                           <span class="element">&lt;w <span class="attribute">pos</span>="<span class="attributevalue">VBB</span>"
                                                               <span class="attribute">join</span>="<span class="attributevalue">left</span>"&gt;</span>'re<span class="element">&lt;/w&gt;</span>
@@ -16574,14 +17114,14 @@ element witness
                                                 </tr>
                                                 <tr>
                                                    <td colspan="2">
-                                                      <div id="index.xml-egXML-d31e52980" class="pre egXML_valid"><span class="element">&lt;add <span class="attribute">place</span>="<span class="attributevalue">margin</span>"&gt;</span>[An addition written in the margin]<span class="element">&lt;/add&gt;</span>
+                                                      <div id="index.xml-egXML-d31e54765" class="pre egXML_valid"><span class="element">&lt;add <span class="attribute">place</span>="<span class="attributevalue">margin</span>"&gt;</span>[An addition written in the margin]<span class="element">&lt;/add&gt;</span>
                                                          <span class="element">&lt;add <span class="attribute">place</span>="<span class="attributevalue">bottom opposite</span>"&gt;</span>[An addition written at the
                                                           foot of the current page and also on the facing page]<span class="element">&lt;/add&gt;</span></div>
                                                    </td>
                                                 </tr>
                                                 <tr>
                                                    <td colspan="2">
-                                                      <div id="index.xml-egXML-d31e52987" class="pre egXML_valid"><span class="element">&lt;note <span class="attribute">place</span>="<span class="attributevalue">bottom</span>"&gt;</span>Ibid, p.7<span class="element">&lt;/note&gt;</span></div>
+                                                      <div id="index.xml-egXML-d31e54772" class="pre egXML_valid"><span class="element">&lt;note <span class="attribute">place</span>="<span class="attributevalue">bottom</span>"&gt;</span>Ibid, p.7<span class="element">&lt;/note&gt;</span></div>
                                                    </td>
                                                 </tr>
                                              </table>
@@ -16640,7 +17180,7 @@ element witness
                                                 </tr>
                                                 <tr>
                                                    <td colspan="2">
-                                                      <div id="index.xml-egXML-d31e53099" class="pre egXML_valid"><span class="element">&lt;linkGrp <span class="attribute">xml:id</span>="<span class="attributevalue">pol-swh_aln_2.1-linkGrp</span>"&gt;</span>
+                                                      <div id="index.xml-egXML-d31e54884" class="pre egXML_valid"><span class="element">&lt;linkGrp <span class="attribute">xml:id</span>="<span class="attributevalue">pol-swh_aln_2.1-linkGrp</span>"&gt;</span>
                                                           <span class="element">&lt;ptr <span class="attribute">xml:id</span>="<span class="attributevalue">pol-swh_aln_2.1.1-ptr</span>"
                                                               <span class="attribute">target</span>="<span class="attributevalue">pol/UDHR/text.xml#pol_txt_1-head</span>"
                                                               <span class="attribute">type</span>="<span class="attributevalue">tuv</span>"
@@ -16845,7 +17385,7 @@ element witness
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Example</span></td>
                            <td class="wovenodd-col2">
-                              <div id="index.xml-egXML-d31e53406" class="pre egXML_valid">The MS. was lost in transmission by mail from <span class="element">&lt;del <span class="attribute">rend</span>="<span class="attributevalue">overstrike</span>"&gt;</span>
+                              <div id="index.xml-egXML-d31e55191" class="pre egXML_valid">The MS. was lost in transmission by mail from <span class="element">&lt;del <span class="attribute">rend</span>="<span class="attributevalue">overstrike</span>"&gt;</span>
                                   <span class="element">&lt;gap <span class="attribute">reason</span>="<span class="attributevalue">illegible</span>"
                                       <span class="attribute">extent</span>="<span class="attributevalue">one or two letters</span>" <span class="attribute">atLeast</span>="<span class="attributevalue">1</span>" <span class="attribute">atMost</span>="<span class="attributevalue">2</span>" <span class="attribute">unit</span>="<span class="attributevalue">chars</span>"/&gt;</span>
                                  <span class="element">&lt;/del&gt;</span> Philadelphia to the Graphic office, New York.
@@ -16855,7 +17395,7 @@ element witness
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Example</span></td>
                            <td class="wovenodd-col2">
-                              <div id="index.xml-egXML-d31e53416" class="pre egXML_valid"> Americares has been supporting the health sector in Eastern
+                              <div id="index.xml-egXML-d31e55201" class="pre egXML_valid"> Americares has been supporting the health sector in Eastern
                                   Europe since 1986, and since 1992 has provided <span class="element">&lt;measure <span class="attribute">atLeast</span>="<span class="attributevalue">120000000</span>" <span class="attribute">unit</span>="<span class="attributevalue">USD</span>"
                                      <span class="attribute">commodity</span>="<span class="attributevalue">currency</span>"&gt;</span>more than
                                   $120m<span class="element">&lt;/measure&gt;</span> in aid to Ukrainians.
@@ -16995,7 +17535,7 @@ element witness
                                                 </tr>
                                                 <tr>
                                                    <td colspan="2">
-                                                      <div id="index.xml-egXML-d31e53693" class="pre egXML_valid">David's other principal backer, Josiah
+                                                      <div id="index.xml-egXML-d31e55478" class="pre egXML_valid">David's other principal backer, Josiah
                                                           ha-Kohen <span class="element">&lt;index <span class="attribute">indexName</span>="<span class="attributevalue">NAMES</span>"&gt;</span>
                                                           <span class="element">&lt;term <span class="attribute">sortKey</span>="<span class="attributevalue">Azarya_Josiah_Kohen</span>"&gt;</span>Josiah ha-Kohen b. Azarya<span class="element">&lt;/term&gt;</span>
                                                          <span class="element">&lt;/index&gt;</span> b. Azarya, son of one of the last gaons of Sura was David's own first
@@ -17240,7 +17780,7 @@ element witness
                         </tr>
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Members</span></td>
-                           <td class="wovenodd-col2"><span class="showmembers1"><a class="link_odd_elementSpec" href="#TEI.TEI" title="&lt;TEI&gt;">TEI</a> <a class="link_odd_elementSpec" href="#TEI.abbr" title="&lt;abbr&gt;">abbr</a> <a class="link_odd_elementSpec" href="#TEI.app" title="&lt;app&gt;">app</a> <a class="link_odd_elementSpec" href="#TEI.bibl" title="&lt;bibl&gt;">bibl</a> <a class="link_odd_elementSpec" href="#TEI.biblStruct" title="&lt;biblStruct&gt;">biblStruct</a> <a class="link_odd_elementSpec" href="#TEI.cb" title="&lt;cb&gt;">cb</a> <a class="link_odd_elementSpec" href="#TEI.change" title="&lt;change&gt;">change</a> <a class="link_odd_elementSpec" href="#TEI.cit" title="&lt;cit&gt;">cit</a> <a class="link_odd_elementSpec" href="#TEI.date" title="&lt;date&gt;">date</a> <a class="link_odd_elementSpec" href="#TEI.div" title="&lt;div&gt;">div</a> <a class="link_odd_elementSpec" href="#TEI.figure" title="&lt;figure&gt;">figure</a> <a class="link_odd_elementSpec" href="#TEI.fw" title="&lt;fw&gt;">fw</a> <a class="link_odd_elementSpec" href="#TEI.gloss" title="&lt;gloss&gt;">gloss</a> <a class="link_odd_elementSpec" href="#TEI.graphic" title="&lt;graphic&gt;">graphic</a> <a class="link_odd_elementSpec" href="#TEI.head" title="&lt;head&gt;">head</a> <a class="link_odd_elementSpec" href="#TEI.lb" title="&lt;lb&gt;">lb</a> <a class="link_odd_elementSpec" href="#TEI.lg" title="&lt;lg&gt;">lg</a> <a class="link_odd_elementSpec" href="#TEI.list" title="&lt;list&gt;">list</a> <a class="link_odd_elementSpec" href="#TEI.listBibl" title="&lt;listBibl&gt;">listBibl</a> <a class="link_odd_elementSpec" href="#TEI.listChange" title="&lt;listChange&gt;">listChange</a> <a class="link_odd_elementSpec" href="#TEI.name" title="&lt;name&gt;">name</a> <a class="link_odd_elementSpec" href="#TEI.note" title="&lt;note&gt;">note</a> <a class="link_odd_elementSpec" href="#TEI.orgName" title="&lt;orgName&gt;">orgName</a> <a class="link_odd_elementSpec" href="#TEI.pb" title="&lt;pb&gt;">pb</a> <a class="link_odd_elementSpec" href="#TEI.persName" title="&lt;persName&gt;">persName</a> <a class="link_odd_elementSpec" href="#TEI.placeName" title="&lt;placeName&gt;">placeName</a> <a class="link_odd_elementSpec" href="#TEI.ptr" title="&lt;ptr&gt;">ptr</a> <a class="link_odd_elementSpec" href="#TEI.quote" title="&lt;quote&gt;">quote</a> <a class="link_odd_elementSpec" href="#TEI.ref" title="&lt;ref&gt;">ref</a> <a class="link_odd_elementSpec" href="#TEI.s" title="&lt;s&gt;">s</a> <a class="link_odd_elementSpec" href="#TEI.seg" title="&lt;seg&gt;">seg</a> <a class="link_odd_elementSpec" href="#TEI.term" title="&lt;term&gt;">term</a> <a class="link_odd_elementSpec" href="#TEI.text" title="&lt;text&gt;">text</a> <a class="link_odd_elementSpec" href="#TEI.title" title="&lt;title&gt;">title</a> <a class="link_odd_elementSpec" href="#TEI.titlePage" title="&lt;titlePage&gt;">titlePage</a> <a class="link_odd_elementSpec" href="#TEI.titlePart" title="&lt;titlePart&gt;">titlePart</a> <a class="link_odd_elementSpec" href="#TEI.trailer" title="&lt;trailer&gt;">trailer</a> <a class="link_odd_elementSpec" href="#TEI.w" title="&lt;w&gt;">w</a></span></td>
+                           <td class="wovenodd-col2"><span class="showmembers1"><a class="link_odd_elementSpec" href="#TEI.TEI" title="&lt;TEI&gt;">TEI</a> <a class="link_odd_elementSpec" href="#TEI.abbr" title="&lt;abbr&gt;">abbr</a> <a class="link_odd_elementSpec" href="#TEI.app" title="&lt;app&gt;">app</a> <a class="link_odd_elementSpec" href="#TEI.bibl" title="&lt;bibl&gt;">bibl</a> <a class="link_odd_elementSpec" href="#TEI.biblStruct" title="&lt;biblStruct&gt;">biblStruct</a> <a class="link_odd_elementSpec" href="#TEI.cb" title="&lt;cb&gt;">cb</a> <a class="link_odd_elementSpec" href="#TEI.change" title="&lt;change&gt;">change</a> <a class="link_odd_elementSpec" href="#TEI.cit" title="&lt;cit&gt;">cit</a> <a class="link_odd_elementSpec" href="#TEI.date" title="&lt;date&gt;">date</a> <a class="link_odd_elementSpec" href="#TEI.div" title="&lt;div&gt;">div</a> <a class="link_odd_elementSpec" href="#TEI.figure" title="&lt;figure&gt;">figure</a> <a class="link_odd_elementSpec" href="#TEI.fw" title="&lt;fw&gt;">fw</a> <a class="link_odd_elementSpec" href="#TEI.gloss" title="&lt;gloss&gt;">gloss</a> <a class="link_odd_elementSpec" href="#TEI.graphic" title="&lt;graphic&gt;">graphic</a> <a class="link_odd_elementSpec" href="#TEI.head" title="&lt;head&gt;">head</a> <a class="link_odd_elementSpec" href="#TEI.lb" title="&lt;lb&gt;">lb</a> <a class="link_odd_elementSpec" href="#TEI.lg" title="&lt;lg&gt;">lg</a> <a class="link_odd_elementSpec" href="#TEI.list" title="&lt;list&gt;">list</a> <a class="link_odd_elementSpec" href="#TEI.listBibl" title="&lt;listBibl&gt;">listBibl</a> <a class="link_odd_elementSpec" href="#TEI.listChange" title="&lt;listChange&gt;">listChange</a> <a class="link_odd_elementSpec" href="#TEI.name" title="&lt;name&gt;">name</a> <a class="link_odd_elementSpec" href="#TEI.note" title="&lt;note&gt;">note</a> <a class="link_odd_elementSpec" href="#TEI.orgName" title="&lt;orgName&gt;">orgName</a> <a class="link_odd_elementSpec" href="#TEI.pb" title="&lt;pb&gt;">pb</a> <a class="link_odd_elementSpec" href="#TEI.persName" title="&lt;persName&gt;">persName</a> <a class="link_odd_elementSpec" href="#TEI.placeName" title="&lt;placeName&gt;">placeName</a> <a class="link_odd_elementSpec" href="#TEI.ptr" title="&lt;ptr&gt;">ptr</a> <a class="link_odd_elementSpec" href="#TEI.quote" title="&lt;quote&gt;">quote</a> <a class="link_odd_elementSpec" href="#TEI.ref" title="&lt;ref&gt;">ref</a> <a class="link_odd_elementSpec" href="#TEI.s" title="&lt;s&gt;">s</a> <a class="link_odd_elementSpec" href="#TEI.seg" title="&lt;seg&gt;">seg</a> <a class="link_odd_elementSpec" href="#TEI.standOff" title="&lt;standOff&gt;">standOff</a> <a class="link_odd_elementSpec" href="#TEI.term" title="&lt;term&gt;">term</a> <a class="link_odd_elementSpec" href="#TEI.text" title="&lt;text&gt;">text</a> <a class="link_odd_elementSpec" href="#TEI.title" title="&lt;title&gt;">title</a> <a class="link_odd_elementSpec" href="#TEI.titlePage" title="&lt;titlePage&gt;">titlePage</a> <a class="link_odd_elementSpec" href="#TEI.titlePart" title="&lt;titlePart&gt;">titlePart</a> <a class="link_odd_elementSpec" href="#TEI.trailer" title="&lt;trailer&gt;">trailer</a> <a class="link_odd_elementSpec" href="#TEI.w" title="&lt;w&gt;">w</a></span></td>
                         </tr>
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Attributes</span></td>
@@ -17262,7 +17802,7 @@ element witness
                                                 </tr>
                                                 <tr>
                                                    <td colspan="2">
-                                                      <div id="index.xml-egXML-d31e54345" class="pre egXML_valid"><span class="element">&lt;div <span class="attribute">type</span>="<span class="attributevalue">verse</span>"&gt;</span>
+                                                      <div id="index.xml-egXML-d31e56134" class="pre egXML_valid"><span class="element">&lt;div <span class="attribute">type</span>="<span class="attributevalue">verse</span>"&gt;</span>
                                                           <span class="element">&lt;head&gt;</span>Night in Tarras<span class="element">&lt;/head&gt;</span>
                                                           <span class="element">&lt;lg <span class="attribute">type</span>="<span class="attributevalue">stanza</span>"&gt;</span>
                                                            <span class="element">&lt;l&gt;</span>At evening tramping on the hot white road<span class="element">&lt;/l&gt;</span>
@@ -17403,7 +17943,7 @@ element witness
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Content model</span></td>
                            <td class="wovenodd-col2">
-                              <pre id="index.xml-eg-d31e54589" class="pre_eg cdata">
+                              <pre id="index.xml-eg-d31e56378" class="pre_eg cdata">
 &lt;content&gt;
  &lt;alternate minOccurs="0"
   maxOccurs="unbounded"&gt;
@@ -17412,15 +17952,15 @@ element witness
   &lt;classRef key="model.inter"/&gt;
  &lt;/alternate&gt;
 &lt;/content&gt;
-    <a href="#index.xml-eg-d31e54589" class="anchorlink">⚓</a></pre>
+    <a href="#index.xml-eg-d31e56378" class="anchorlink">⚓</a></pre>
                            </td>
                         </tr>
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Declaration</span></td>
                            <td class="wovenodd-col2">
-                              <pre id="index.xml-eg-d31e54596" class="pre_eg">
+                              <pre id="index.xml-eg-d31e56385" class="pre_eg">
 tei_macro.limitedContent =
-   ( text | tei_model.limitedPhrase | tei_model.inter )*<a href="#index.xml-eg-d31e54596" class="anchorlink">⚓</a></pre>
+   ( text | tei_model.limitedPhrase | tei_model.inter )*<a href="#index.xml-eg-d31e56385" class="anchorlink">⚓</a></pre>
                            </td>
                         </tr>
                      </table>
@@ -17446,7 +17986,7 @@ tei_macro.limitedContent =
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Content model</span></td>
                            <td class="wovenodd-col2">
-                              <pre id="index.xml-eg-d31e54679" class="pre_eg cdata">
+                              <pre id="index.xml-eg-d31e56468" class="pre_eg cdata">
 &lt;content&gt;
  &lt;alternate minOccurs="0"
   maxOccurs="unbounded"&gt;
@@ -17454,14 +17994,14 @@ tei_macro.limitedContent =
   &lt;classRef key="model.paraPart"/&gt;
  &lt;/alternate&gt;
 &lt;/content&gt;
-    <a href="#index.xml-eg-d31e54679" class="anchorlink">⚓</a></pre>
+    <a href="#index.xml-eg-d31e56468" class="anchorlink">⚓</a></pre>
                            </td>
                         </tr>
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Declaration</span></td>
                            <td class="wovenodd-col2">
-                              <pre id="index.xml-eg-d31e54686" class="pre_eg">
-tei_macro.paraContent = ( text | tei_model.paraPart )*<a href="#index.xml-eg-d31e54686" class="anchorlink">⚓</a></pre>
+                              <pre id="index.xml-eg-d31e56475" class="pre_eg">
+tei_macro.paraContent = ( text | tei_model.paraPart )*<a href="#index.xml-eg-d31e56475" class="anchorlink">⚓</a></pre>
                            </td>
                         </tr>
                      </table>
@@ -17487,7 +18027,7 @@ tei_macro.paraContent = ( text | tei_model.paraPart )*<a href="#index.xml-eg-d31
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Content model</span></td>
                            <td class="wovenodd-col2">
-                              <pre id="index.xml-eg-d31e54779" class="pre_eg cdata">
+                              <pre id="index.xml-eg-d31e56568" class="pre_eg cdata">
 &lt;content&gt;
  &lt;alternate minOccurs="0"
   maxOccurs="unbounded"&gt;
@@ -17498,13 +18038,13 @@ tei_macro.paraContent = ( text | tei_model.paraPart )*<a href="#index.xml-eg-d31
   &lt;classRef key="model.global"/&gt;
  &lt;/alternate&gt;
 &lt;/content&gt;
-    <a href="#index.xml-eg-d31e54779" class="anchorlink">⚓</a></pre>
+    <a href="#index.xml-eg-d31e56568" class="anchorlink">⚓</a></pre>
                            </td>
                         </tr>
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Declaration</span></td>
                            <td class="wovenodd-col2">
-                              <pre id="index.xml-eg-d31e54786" class="pre_eg">
+                              <pre id="index.xml-eg-d31e56575" class="pre_eg">
 tei_macro.phraseSeq =
    (
       text
@@ -17512,7 +18052,7 @@ tei_macro.phraseSeq =
     | tei_model.attributable
     | tei_model.phrase
     | tei_model.global
-   )*<a href="#index.xml-eg-d31e54786" class="anchorlink">⚓</a></pre>
+   )*<a href="#index.xml-eg-d31e56575" class="anchorlink">⚓</a></pre>
                            </td>
                         </tr>
                      </table>
@@ -17539,7 +18079,7 @@ tei_macro.phraseSeq =
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Content model</span></td>
                            <td class="wovenodd-col2">
-                              <pre id="index.xml-eg-d31e54850" class="pre_eg cdata">
+                              <pre id="index.xml-eg-d31e56639" class="pre_eg cdata">
 &lt;content&gt;
  &lt;alternate minOccurs="0"
   maxOccurs="unbounded"&gt;
@@ -17548,15 +18088,15 @@ tei_macro.phraseSeq =
   &lt;classRef key="model.global"/&gt;
  &lt;/alternate&gt;
 &lt;/content&gt;
-    <a href="#index.xml-eg-d31e54850" class="anchorlink">⚓</a></pre>
+    <a href="#index.xml-eg-d31e56639" class="anchorlink">⚓</a></pre>
                            </td>
                         </tr>
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Declaration</span></td>
                            <td class="wovenodd-col2">
-                              <pre id="index.xml-eg-d31e54857" class="pre_eg">
+                              <pre id="index.xml-eg-d31e56646" class="pre_eg">
 tei_macro.phraseSeq.limited =
-   ( text | tei_model.limitedPhrase | tei_model.global )*<a href="#index.xml-eg-d31e54857" class="anchorlink">⚓</a></pre>
+   ( text | tei_model.limitedPhrase | tei_model.global )*<a href="#index.xml-eg-d31e56646" class="anchorlink">⚓</a></pre>
                            </td>
                         </tr>
                      </table>
@@ -17584,7 +18124,7 @@ tei_macro.phraseSeq.limited =
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Content model</span></td>
                            <td class="wovenodd-col2">
-                              <pre id="index.xml-eg-d31e54923" class="pre_eg cdata">
+                              <pre id="index.xml-eg-d31e56712" class="pre_eg cdata">
 &lt;content&gt;
  &lt;alternate minOccurs="0"
   maxOccurs="unbounded"&gt;
@@ -17596,13 +18136,13 @@ tei_macro.phraseSeq.limited =
   &lt;classRef key="model.global"/&gt;
  &lt;/alternate&gt;
 &lt;/content&gt;
-    <a href="#index.xml-eg-d31e54923" class="anchorlink">⚓</a></pre>
+    <a href="#index.xml-eg-d31e56712" class="anchorlink">⚓</a></pre>
                            </td>
                         </tr>
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Declaration</span></td>
                            <td class="wovenodd-col2">
-                              <pre id="index.xml-eg-d31e54930" class="pre_eg">
+                              <pre id="index.xml-eg-d31e56719" class="pre_eg">
 tei_macro.specialPara =
    (
       text
@@ -17611,7 +18151,7 @@ tei_macro.specialPara =
     | tei_model.inter
     | tei_model.divPart
     | tei_model.global
-   )*<a href="#index.xml-eg-d31e54930" class="anchorlink">⚓</a></pre>
+   )*<a href="#index.xml-eg-d31e56719" class="anchorlink">⚓</a></pre>
                            </td>
                         </tr>
                      </table>
@@ -17640,7 +18180,7 @@ tei_macro.specialPara =
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Content model</span></td>
                            <td class="wovenodd-col2">
-                              <pre id="index.xml-eg-d31e54979" class="pre_eg cdata">
+                              <pre id="index.xml-eg-d31e56768" class="pre_eg cdata">
 &lt;content&gt;
  &lt;valList type="closed"&gt;
   &lt;valItem ident="high"/&gt;
@@ -17649,14 +18189,14 @@ tei_macro.specialPara =
   &lt;valItem ident="unknown"/&gt;
  &lt;/valList&gt;
 &lt;/content&gt;
-    <a href="#index.xml-eg-d31e54979" class="anchorlink">⚓</a></pre>
+    <a href="#index.xml-eg-d31e56768" class="anchorlink">⚓</a></pre>
                            </td>
                         </tr>
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Declaration</span></td>
                            <td class="wovenodd-col2">
-                              <pre id="index.xml-eg-d31e54986" class="pre_eg cdata">
-tei_teidata.certainty = "high" | "medium" | "low" | "unknown"<a href="#index.xml-eg-d31e54986" class="anchorlink">⚓</a></pre>
+                              <pre id="index.xml-eg-d31e56775" class="pre_eg cdata">
+tei_teidata.certainty = "high" | "medium" | "low" | "unknown"<a href="#index.xml-eg-d31e56775" class="anchorlink">⚓</a></pre>
                            </td>
                         </tr>
                         <tr>
@@ -17690,18 +18230,18 @@ tei_teidata.certainty = "high" | "medium" | "low" | "unknown"<a href="#index.xml
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Content model</span></td>
                            <td class="wovenodd-col2">
-                              <pre id="index.xml-eg-d31e55036" class="pre_eg cdata">
+                              <pre id="index.xml-eg-d31e56825" class="pre_eg cdata">
 &lt;content&gt;
  &lt;dataRef name="nonNegativeInteger"/&gt;
 &lt;/content&gt;
-    <a href="#index.xml-eg-d31e55036" class="anchorlink">⚓</a></pre>
+    <a href="#index.xml-eg-d31e56825" class="anchorlink">⚓</a></pre>
                            </td>
                         </tr>
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Declaration</span></td>
                            <td class="wovenodd-col2">
-                              <pre id="index.xml-eg-d31e55043" class="pre_eg cdata">
-tei_teidata.count = xsd:nonNegativeInteger<a href="#index.xml-eg-d31e55043" class="anchorlink">⚓</a></pre>
+                              <pre id="index.xml-eg-d31e56832" class="pre_eg cdata">
+tei_teidata.count = xsd:nonNegativeInteger<a href="#index.xml-eg-d31e56832" class="anchorlink">⚓</a></pre>
                            </td>
                         </tr>
                         <tr>
@@ -17734,43 +18274,43 @@ tei_teidata.count = xsd:nonNegativeInteger<a href="#index.xml-eg-d31e55043" clas
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Content model</span></td>
                            <td class="wovenodd-col2">
-                              <pre id="index.xml-eg-d31e55081" class="pre_eg cdata">
+                              <pre id="index.xml-eg-d31e56870" class="pre_eg cdata">
 &lt;content&gt;
  &lt;dataRef name="token"
   restriction="[0-9.,DHMPRSTWYZ/:+\-]+"/&gt;
 &lt;/content&gt;
-    <a href="#index.xml-eg-d31e55081" class="anchorlink">⚓</a></pre>
+    <a href="#index.xml-eg-d31e56870" class="anchorlink">⚓</a></pre>
                            </td>
                         </tr>
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Declaration</span></td>
                            <td class="wovenodd-col2">
-                              <pre id="index.xml-eg-d31e55088" class="pre_eg cdata">
-tei_teidata.duration.iso = token { pattern = "[0-9.,DHMPRSTWYZ/:+\-]+" }<a href="#index.xml-eg-d31e55088" class="anchorlink">⚓</a></pre>
+                              <pre id="index.xml-eg-d31e56877" class="pre_eg cdata">
+tei_teidata.duration.iso = token { pattern = "[0-9.,DHMPRSTWYZ/:+\-]+" }<a href="#index.xml-eg-d31e56877" class="anchorlink">⚓</a></pre>
                            </td>
                         </tr>
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Example</span></td>
                            <td class="wovenodd-col2">
-                              <div id="index.xml-egXML-d31e55095" class="pre egXML_valid"><span class="element">&lt;time <span class="attribute">dur-iso</span>="<span class="attributevalue">PT0,75H</span>"&gt;</span>three-quarters of an hour<span class="element">&lt;/time&gt;</span></div>
+                              <div id="index.xml-egXML-d31e56884" class="pre egXML_valid"><span class="element">&lt;time <span class="attribute">dur-iso</span>="<span class="attributevalue">PT0,75H</span>"&gt;</span>three-quarters of an hour<span class="element">&lt;/time&gt;</span></div>
                            </td>
                         </tr>
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Example</span></td>
                            <td class="wovenodd-col2">
-                              <div id="index.xml-egXML-d31e55103" class="pre egXML_valid"><span class="element">&lt;date <span class="attribute">dur-iso</span>="<span class="attributevalue">P1,5D</span>"&gt;</span>a day and a half<span class="element">&lt;/date&gt;</span></div>
+                              <div id="index.xml-egXML-d31e56892" class="pre egXML_valid"><span class="element">&lt;date <span class="attribute">dur-iso</span>="<span class="attributevalue">P1,5D</span>"&gt;</span>a day and a half<span class="element">&lt;/date&gt;</span></div>
                            </td>
                         </tr>
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Example</span></td>
                            <td class="wovenodd-col2">
-                              <div id="index.xml-egXML-d31e55111" class="pre egXML_valid"><span class="element">&lt;date <span class="attribute">dur-iso</span>="<span class="attributevalue">P14D</span>"&gt;</span>a fortnight<span class="element">&lt;/date&gt;</span></div>
+                              <div id="index.xml-egXML-d31e56900" class="pre egXML_valid"><span class="element">&lt;date <span class="attribute">dur-iso</span>="<span class="attributevalue">P14D</span>"&gt;</span>a fortnight<span class="element">&lt;/date&gt;</span></div>
                            </td>
                         </tr>
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Example</span></td>
                            <td class="wovenodd-col2">
-                              <div id="index.xml-egXML-d31e55119" class="pre egXML_valid"><span class="element">&lt;time <span class="attribute">dur-iso</span>="<span class="attributevalue">PT0.02S</span>"&gt;</span>20 ms<span class="element">&lt;/time&gt;</span></div>
+                              <div id="index.xml-egXML-d31e56908" class="pre egXML_valid"><span class="element">&lt;time <span class="attribute">dur-iso</span>="<span class="attributevalue">PT0.02S</span>"&gt;</span>20 ms<span class="element">&lt;/time&gt;</span></div>
                            </td>
                         </tr>
                         <tr>
@@ -17809,42 +18349,42 @@ tei_teidata.duration.iso = token { pattern = "[0-9.,DHMPRSTWYZ/:+\-]+" }<a href=
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Content model</span></td>
                            <td class="wovenodd-col2">
-                              <pre id="index.xml-eg-d31e55172" class="pre_eg cdata">
+                              <pre id="index.xml-eg-d31e56961" class="pre_eg cdata">
 &lt;content&gt;
  &lt;dataRef name="duration"/&gt;
 &lt;/content&gt;
-    <a href="#index.xml-eg-d31e55172" class="anchorlink">⚓</a></pre>
+    <a href="#index.xml-eg-d31e56961" class="anchorlink">⚓</a></pre>
                            </td>
                         </tr>
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Declaration</span></td>
                            <td class="wovenodd-col2">
-                              <pre id="index.xml-eg-d31e55179" class="pre_eg cdata">
-tei_teidata.duration.w3c = xsd:duration<a href="#index.xml-eg-d31e55179" class="anchorlink">⚓</a></pre>
+                              <pre id="index.xml-eg-d31e56968" class="pre_eg cdata">
+tei_teidata.duration.w3c = xsd:duration<a href="#index.xml-eg-d31e56968" class="anchorlink">⚓</a></pre>
                            </td>
                         </tr>
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Example</span></td>
                            <td class="wovenodd-col2">
-                              <div id="index.xml-egXML-d31e55186" class="pre egXML_valid"><span class="element">&lt;time <span class="attribute">dur</span>="<span class="attributevalue">PT45M</span>"&gt;</span>forty-five minutes<span class="element">&lt;/time&gt;</span></div>
+                              <div id="index.xml-egXML-d31e56975" class="pre egXML_valid"><span class="element">&lt;time <span class="attribute">dur</span>="<span class="attributevalue">PT45M</span>"&gt;</span>forty-five minutes<span class="element">&lt;/time&gt;</span></div>
                            </td>
                         </tr>
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Example</span></td>
                            <td class="wovenodd-col2">
-                              <div id="index.xml-egXML-d31e55194" class="pre egXML_valid"><span class="element">&lt;date <span class="attribute">dur</span>="<span class="attributevalue">P1DT12H</span>"&gt;</span>a day and a half<span class="element">&lt;/date&gt;</span></div>
+                              <div id="index.xml-egXML-d31e56983" class="pre egXML_valid"><span class="element">&lt;date <span class="attribute">dur</span>="<span class="attributevalue">P1DT12H</span>"&gt;</span>a day and a half<span class="element">&lt;/date&gt;</span></div>
                            </td>
                         </tr>
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Example</span></td>
                            <td class="wovenodd-col2">
-                              <div id="index.xml-egXML-d31e55202" class="pre egXML_valid"><span class="element">&lt;date <span class="attribute">dur</span>="<span class="attributevalue">P7D</span>"&gt;</span>a week<span class="element">&lt;/date&gt;</span></div>
+                              <div id="index.xml-egXML-d31e56991" class="pre egXML_valid"><span class="element">&lt;date <span class="attribute">dur</span>="<span class="attributevalue">P7D</span>"&gt;</span>a week<span class="element">&lt;/date&gt;</span></div>
                            </td>
                         </tr>
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Example</span></td>
                            <td class="wovenodd-col2">
-                              <div id="index.xml-egXML-d31e55210" class="pre egXML_valid"><span class="element">&lt;time <span class="attribute">dur</span>="<span class="attributevalue">PT0.02S</span>"&gt;</span>20 ms<span class="element">&lt;/time&gt;</span></div>
+                              <div id="index.xml-egXML-d31e56999" class="pre egXML_valid"><span class="element">&lt;time <span class="attribute">dur</span>="<span class="attributevalue">PT0.02S</span>"&gt;</span>20 ms<span class="element">&lt;/time&gt;</span></div>
                            </td>
                         </tr>
                         <tr>
@@ -17899,18 +18439,18 @@ tei_teidata.duration.w3c = xsd:duration<a href="#index.xml-eg-d31e55179" class="
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Content model</span></td>
                            <td class="wovenodd-col2">
-                              <pre id="index.xml-eg-d31e55328" class="pre_eg cdata">
+                              <pre id="index.xml-eg-d31e57117" class="pre_eg cdata">
 &lt;content&gt;
  &lt;dataRef key="teidata.word"/&gt;
 &lt;/content&gt;
-    <a href="#index.xml-eg-d31e55328" class="anchorlink">⚓</a></pre>
+    <a href="#index.xml-eg-d31e57117" class="anchorlink">⚓</a></pre>
                            </td>
                         </tr>
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Declaration</span></td>
                            <td class="wovenodd-col2">
-                              <pre id="index.xml-eg-d31e55335" class="pre_eg">
-tei_teidata.enumerated = <a class="link_ref" href="#TEI.teidata.word" title="teidata.word">teidata.word</a><a href="#index.xml-eg-d31e55335" class="anchorlink">⚓</a></pre>
+                              <pre id="index.xml-eg-d31e57124" class="pre_eg">
+tei_teidata.enumerated = <a class="link_ref" href="#TEI.teidata.word" title="teidata.word">teidata.word</a><a href="#index.xml-eg-d31e57124" class="anchorlink">⚓</a></pre>
                            </td>
                         </tr>
                         <tr>
@@ -17949,7 +18489,7 @@ tei_teidata.enumerated = <a class="link_ref" href="#TEI.teidata.word" title="tei
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Content model</span></td>
                            <td class="wovenodd-col2">
-                              <pre id="index.xml-eg-d31e55392" class="pre_eg cdata">
+                              <pre id="index.xml-eg-d31e57181" class="pre_eg cdata">
 &lt;content&gt;
  &lt;alternate&gt;
   &lt;dataRef name="language"/&gt;
@@ -17958,14 +18498,14 @@ tei_teidata.enumerated = <a class="link_ref" href="#TEI.teidata.word" title="tei
   &lt;/valList&gt;
  &lt;/alternate&gt;
 &lt;/content&gt;
-    <a href="#index.xml-eg-d31e55392" class="anchorlink">⚓</a></pre>
+    <a href="#index.xml-eg-d31e57181" class="anchorlink">⚓</a></pre>
                            </td>
                         </tr>
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Declaration</span></td>
                            <td class="wovenodd-col2">
-                              <pre id="index.xml-eg-d31e55399" class="pre_eg cdata">
-tei_teidata.language = xsd:language | ( "" )<a href="#index.xml-eg-d31e55399" class="anchorlink">⚓</a></pre>
+                              <pre id="index.xml-eg-d31e57188" class="pre_eg cdata">
+tei_teidata.language = xsd:language | ( "" )<a href="#index.xml-eg-d31e57188" class="anchorlink">⚓</a></pre>
                            </td>
                         </tr>
                         <tr>
@@ -18057,18 +18597,18 @@ tei_teidata.language = xsd:language | ( "" )<a href="#index.xml-eg-d31e55399" cl
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Content model</span></td>
                            <td class="wovenodd-col2">
-                              <pre id="index.xml-eg-d31e55536" class="pre_eg cdata">
+                              <pre id="index.xml-eg-d31e57325" class="pre_eg cdata">
 &lt;content&gt;
  &lt;dataRef name="Name"/&gt;
 &lt;/content&gt;
-    <a href="#index.xml-eg-d31e55536" class="anchorlink">⚓</a></pre>
+    <a href="#index.xml-eg-d31e57325" class="anchorlink">⚓</a></pre>
                            </td>
                         </tr>
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Declaration</span></td>
                            <td class="wovenodd-col2">
-                              <pre id="index.xml-eg-d31e55543" class="pre_eg cdata">
-tei_teidata.name = xsd:Name<a href="#index.xml-eg-d31e55543" class="anchorlink">⚓</a></pre>
+                              <pre id="index.xml-eg-d31e57332" class="pre_eg cdata">
+tei_teidata.name = xsd:Name<a href="#index.xml-eg-d31e57332" class="anchorlink">⚓</a></pre>
                            </td>
                         </tr>
                         <tr>
@@ -18101,7 +18641,7 @@ tei_teidata.name = xsd:Name<a href="#index.xml-eg-d31e55543" class="anchorlink">
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Content model</span></td>
                            <td class="wovenodd-col2">
-                              <pre id="index.xml-eg-d31e55583" class="pre_eg cdata">
+                              <pre id="index.xml-eg-d31e57372" class="pre_eg cdata">
 &lt;content&gt;
  &lt;alternate&gt;
   &lt;dataRef name="double"/&gt;
@@ -18110,15 +18650,15 @@ tei_teidata.name = xsd:Name<a href="#index.xml-eg-d31e55543" class="anchorlink">
   &lt;dataRef name="decimal"/&gt;
  &lt;/alternate&gt;
 &lt;/content&gt;
-    <a href="#index.xml-eg-d31e55583" class="anchorlink">⚓</a></pre>
+    <a href="#index.xml-eg-d31e57372" class="anchorlink">⚓</a></pre>
                            </td>
                         </tr>
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Declaration</span></td>
                            <td class="wovenodd-col2">
-                              <pre id="index.xml-eg-d31e55590" class="pre_eg cdata">
+                              <pre id="index.xml-eg-d31e57379" class="pre_eg cdata">
 tei_teidata.numeric =
-   xsd:double | token { pattern = "(\-?[\d]+/\-?[\d]+)" } | xsd:decimal<a href="#index.xml-eg-d31e55590" class="anchorlink">⚓</a></pre>
+   xsd:double | token { pattern = "(\-?[\d]+/\-?[\d]+)" } | xsd:decimal<a href="#index.xml-eg-d31e57379" class="anchorlink">⚓</a></pre>
                            </td>
                         </tr>
                         <tr>
@@ -18162,29 +18702,29 @@ tei_teidata.numeric =
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Content model</span></td>
                            <td class="wovenodd-col2">
-                              <pre id="index.xml-eg-d31e55636" class="pre_eg cdata">
+                              <pre id="index.xml-eg-d31e57425" class="pre_eg cdata">
 &lt;content&gt;
  &lt;dataRef name="token"
   restriction="[\-+]?\d+(\.\d+)?(%|cm|mm|in|pt|pc|px|em|ex|ch|rem|vw|vh|vmin|vmax)"/&gt;
 &lt;/content&gt;
-    <a href="#index.xml-eg-d31e55636" class="anchorlink">⚓</a></pre>
+    <a href="#index.xml-eg-d31e57425" class="anchorlink">⚓</a></pre>
                            </td>
                         </tr>
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Declaration</span></td>
                            <td class="wovenodd-col2">
-                              <pre id="index.xml-eg-d31e55643" class="pre_eg cdata">
+                              <pre id="index.xml-eg-d31e57432" class="pre_eg cdata">
 tei_teidata.outputMeasurement =
    token
    {
       pattern = "[\-+]?\d+(\.\d+)?(%|cm|mm|in|pt|pc|px|em|ex|ch|rem|vw|vh|vmin|vmax)"
-   }<a href="#index.xml-eg-d31e55643" class="anchorlink">⚓</a></pre>
+   }<a href="#index.xml-eg-d31e57432" class="anchorlink">⚓</a></pre>
                            </td>
                         </tr>
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Example</span></td>
                            <td class="wovenodd-col2">
-                              <div id="index.xml-egXML-d31e55650" class="pre egXML_valid"><span class="element">&lt;figure&gt;</span>
+                              <div id="index.xml-egXML-d31e57439" class="pre egXML_valid"><span class="element">&lt;figure&gt;</span>
                                   <span class="element">&lt;head&gt;</span>The TEI Logo<span class="element">&lt;/head&gt;</span>
                                   <span class="element">&lt;figDesc&gt;</span>Stylized yellow angle brackets with the letters <span class="element">&lt;mentioned&gt;</span>TEI<span class="element">&lt;/mentioned&gt;</span> in
                                     between and <span class="element">&lt;mentioned&gt;</span>text encoding initiative<span class="element">&lt;/mentioned&gt;</span> underneath, all on a white
@@ -18225,18 +18765,18 @@ tei_teidata.outputMeasurement =
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Content model</span></td>
                            <td class="wovenodd-col2">
-                              <pre id="index.xml-eg-d31e55699" class="pre_eg cdata">
+                              <pre id="index.xml-eg-d31e57488" class="pre_eg cdata">
 &lt;content&gt;
  &lt;dataRef name="token"/&gt;
 &lt;/content&gt;
-    <a href="#index.xml-eg-d31e55699" class="anchorlink">⚓</a></pre>
+    <a href="#index.xml-eg-d31e57488" class="anchorlink">⚓</a></pre>
                            </td>
                         </tr>
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Declaration</span></td>
                            <td class="wovenodd-col2">
-                              <pre id="index.xml-eg-d31e55706" class="pre_eg cdata">
-tei_teidata.pattern = token<a href="#index.xml-eg-d31e55706" class="anchorlink">⚓</a></pre>
+                              <pre id="index.xml-eg-d31e57495" class="pre_eg cdata">
+tei_teidata.pattern = token<a href="#index.xml-eg-d31e57495" class="anchorlink">⚓</a></pre>
                            </td>
                         </tr>
                         <tr>
@@ -18274,26 +18814,26 @@ tei_teidata.pattern = token<a href="#index.xml-eg-d31e55706" class="anchorlink">
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Content model</span></td>
                            <td class="wovenodd-col2">
-                              <pre id="index.xml-eg-d31e55766" class="pre_eg cdata">
+                              <pre id="index.xml-eg-d31e57555" class="pre_eg cdata">
 &lt;content&gt;
  &lt;dataRef name="token"
   restriction="(-?[0-9]+(\.[0-9]+)?,-?[0-9]+(\.[0-9]+)?)"/&gt;
 &lt;/content&gt;
-    <a href="#index.xml-eg-d31e55766" class="anchorlink">⚓</a></pre>
+    <a href="#index.xml-eg-d31e57555" class="anchorlink">⚓</a></pre>
                            </td>
                         </tr>
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Declaration</span></td>
                            <td class="wovenodd-col2">
-                              <pre id="index.xml-eg-d31e55773" class="pre_eg cdata">
+                              <pre id="index.xml-eg-d31e57562" class="pre_eg cdata">
 tei_teidata.point =
-   token { pattern = "(-?[0-9]+(\.[0-9]+)?,-?[0-9]+(\.[0-9]+)?)" }<a href="#index.xml-eg-d31e55773" class="anchorlink">⚓</a></pre>
+   token { pattern = "(-?[0-9]+(\.[0-9]+)?,-?[0-9]+(\.[0-9]+)?)" }<a href="#index.xml-eg-d31e57562" class="anchorlink">⚓</a></pre>
                            </td>
                         </tr>
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Example</span></td>
                            <td class="wovenodd-col2">
-                              <div id="index.xml-egXML-d31e55780" class="pre egXML_valid"><span class="element">&lt;facsimile&gt;</span>
+                              <div id="index.xml-egXML-d31e57569" class="pre egXML_valid"><span class="element">&lt;facsimile&gt;</span>
                                   <span class="element">&lt;surface <span class="attribute">ulx</span>="<span class="attributevalue">0</span>" <span class="attribute">uly</span>="<span class="attributevalue">0</span>" <span class="attribute">lrx</span>="<span class="attributevalue">400</span>" <span class="attribute">lry</span>="<span class="attributevalue">280</span>"&gt;</span>
                                    <span class="element">&lt;zone <span class="attribute">points</span>="<span class="attributevalue">220,100 300,210 170,250 123,234</span>"&gt;</span>
                                     <span class="element">&lt;graphic <span class="attribute">url</span>="<span class="attributevalue">handwriting.png</span>"/&gt;</span>
@@ -18333,6 +18873,7 @@ tei_teidata.point =
                                     <li class="item"><a class="link_odd_elementSpec" href="#TEI.change" title="&lt;change&gt;">change</a>/@who</li>
                                     <li class="item"><a class="link_odd_elementSpec" href="#TEI.change" title="&lt;change&gt;">change</a>/@target</li>
                                     <li class="item"><a class="link_odd_elementSpec" href="#TEI.lem" title="&lt;lem&gt;">lem</a>/@wit</li>
+                                    <li class="item"><a class="link_odd_elementSpec" href="#TEI.listTranspose" title="&lt;listTranspose&gt;">listTranspose</a>/@wit</li>
                                     <li class="item"><a class="link_odd_elementSpec" href="#TEI.ptr" title="&lt;ptr&gt;">ptr</a>/@target</li>
                                     <li class="item"><a class="link_odd_elementSpec" href="#TEI.rdg" title="&lt;rdg&gt;">rdg</a>/@wit</li>
                                     <li class="item"><a class="link_odd_elementSpec" href="#TEI.ref" title="&lt;ref&gt;">ref</a>/@target</li>
@@ -18345,18 +18886,18 @@ tei_teidata.point =
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Content model</span></td>
                            <td class="wovenodd-col2">
-                              <pre id="index.xml-eg-d31e55873" class="pre_eg cdata">
+                              <pre id="index.xml-eg-d31e57666" class="pre_eg cdata">
 &lt;content&gt;
  &lt;dataRef restriction="\S+" name="anyURI"/&gt;
 &lt;/content&gt;
-    <a href="#index.xml-eg-d31e55873" class="anchorlink">⚓</a></pre>
+    <a href="#index.xml-eg-d31e57666" class="anchorlink">⚓</a></pre>
                            </td>
                         </tr>
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Declaration</span></td>
                            <td class="wovenodd-col2">
-                              <pre id="index.xml-eg-d31e55880" class="pre_eg cdata">
-tei_teidata.pointer = xsd:anyURI { pattern = "\S+" }<a href="#index.xml-eg-d31e55880" class="anchorlink">⚓</a></pre>
+                              <pre id="index.xml-eg-d31e57673" class="pre_eg cdata">
+tei_teidata.pointer = xsd:anyURI { pattern = "\S+" }<a href="#index.xml-eg-d31e57673" class="anchorlink">⚓</a></pre>
                            </td>
                         </tr>
                         <tr>
@@ -18392,21 +18933,21 @@ tei_teidata.pointer = xsd:anyURI { pattern = "\S+" }<a href="#index.xml-eg-d31e5
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Content model</span></td>
                            <td class="wovenodd-col2">
-                              <pre id="index.xml-eg-d31e55943" class="pre_eg cdata">
+                              <pre id="index.xml-eg-d31e57736" class="pre_eg cdata">
 &lt;content&gt;
  &lt;alternate&gt;
   &lt;dataRef key="teidata.probability"/&gt;
   &lt;dataRef key="teidata.certainty"/&gt;
  &lt;/alternate&gt;
 &lt;/content&gt;
-    <a href="#index.xml-eg-d31e55943" class="anchorlink">⚓</a></pre>
+    <a href="#index.xml-eg-d31e57736" class="anchorlink">⚓</a></pre>
                            </td>
                         </tr>
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Declaration</span></td>
                            <td class="wovenodd-col2">
-                              <pre id="index.xml-eg-d31e55950" class="pre_eg">
-tei_teidata.probCert = <a class="link_ref" href="#TEI.teidata.probability" title="teidata.probability">teidata.probability</a> | <a class="link_ref" href="#TEI.teidata.certainty" title="teidata.certainty">teidata.certainty</a><a href="#index.xml-eg-d31e55950" class="anchorlink">⚓</a></pre>
+                              <pre id="index.xml-eg-d31e57743" class="pre_eg">
+tei_teidata.probCert = <a class="link_ref" href="#TEI.teidata.probability" title="teidata.probability">teidata.probability</a> | <a class="link_ref" href="#TEI.teidata.certainty" title="teidata.certainty">teidata.certainty</a><a href="#index.xml-eg-d31e57743" class="anchorlink">⚓</a></pre>
                            </td>
                         </tr>
                      </table>
@@ -18432,18 +18973,18 @@ tei_teidata.probCert = <a class="link_ref" href="#TEI.teidata.probability" title
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Content model</span></td>
                            <td class="wovenodd-col2">
-                              <pre id="index.xml-eg-d31e55987" class="pre_eg cdata">
+                              <pre id="index.xml-eg-d31e57780" class="pre_eg cdata">
 &lt;content&gt;
  &lt;dataRef name="double"/&gt;
 &lt;/content&gt;
-    <a href="#index.xml-eg-d31e55987" class="anchorlink">⚓</a></pre>
+    <a href="#index.xml-eg-d31e57780" class="anchorlink">⚓</a></pre>
                            </td>
                         </tr>
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Declaration</span></td>
                            <td class="wovenodd-col2">
-                              <pre id="index.xml-eg-d31e55994" class="pre_eg cdata">
-tei_teidata.probability = xsd:double<a href="#index.xml-eg-d31e55994" class="anchorlink">⚓</a></pre>
+                              <pre id="index.xml-eg-d31e57787" class="pre_eg cdata">
+tei_teidata.probability = xsd:double<a href="#index.xml-eg-d31e57787" class="anchorlink">⚓</a></pre>
                            </td>
                         </tr>
                         <tr>
@@ -18475,18 +19016,18 @@ tei_teidata.probability = xsd:double<a href="#index.xml-eg-d31e55994" class="anc
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Content model</span></td>
                            <td class="wovenodd-col2">
-                              <pre id="index.xml-eg-d31e56036" class="pre_eg cdata">
+                              <pre id="index.xml-eg-d31e57829" class="pre_eg cdata">
 &lt;content&gt;
  &lt;textNode/&gt;
 &lt;/content&gt;
-    <a href="#index.xml-eg-d31e56036" class="anchorlink">⚓</a></pre>
+    <a href="#index.xml-eg-d31e57829" class="anchorlink">⚓</a></pre>
                            </td>
                         </tr>
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Declaration</span></td>
                            <td class="wovenodd-col2">
-                              <pre id="index.xml-eg-d31e56043" class="pre_eg cdata">
-tei_teidata.replacement = text<a href="#index.xml-eg-d31e56043" class="anchorlink">⚓</a></pre>
+                              <pre id="index.xml-eg-d31e57836" class="pre_eg cdata">
+tei_teidata.replacement = text<a href="#index.xml-eg-d31e57836" class="anchorlink">⚓</a></pre>
                            </td>
                         </tr>
                      </table>
@@ -18514,7 +19055,7 @@ tei_teidata.replacement = text<a href="#index.xml-eg-d31e56043" class="anchorlin
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Content model</span></td>
                            <td class="wovenodd-col2">
-                              <pre id="index.xml-eg-d31e56076" class="pre_eg cdata">
+                              <pre id="index.xml-eg-d31e57869" class="pre_eg cdata">
 &lt;content&gt;
  &lt;alternate&gt;
   &lt;dataRef name="date"/&gt;
@@ -18529,13 +19070,13 @@ tei_teidata.replacement = text<a href="#index.xml-eg-d31e56043" class="anchorlin
    restriction="[0-9.,DHMPRSTWYZ/:+\-]+"/&gt;
  &lt;/alternate&gt;
 &lt;/content&gt;
-    <a href="#index.xml-eg-d31e56076" class="anchorlink">⚓</a></pre>
+    <a href="#index.xml-eg-d31e57869" class="anchorlink">⚓</a></pre>
                            </td>
                         </tr>
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Declaration</span></td>
                            <td class="wovenodd-col2">
-                              <pre id="index.xml-eg-d31e56083" class="pre_eg cdata">
+                              <pre id="index.xml-eg-d31e57876" class="pre_eg cdata">
 tei_teidata.temporal.iso =
    xsd:date
  | xsd:gYear
@@ -18545,7 +19086,7 @@ tei_teidata.temporal.iso =
  | xsd:gMonthDay
  | xsd:time
  | xsd:dateTime
- | token { pattern = "[0-9.,DHMPRSTWYZ/:+\-]+" }<a href="#index.xml-eg-d31e56083" class="anchorlink">⚓</a></pre>
+ | token { pattern = "[0-9.,DHMPRSTWYZ/:+\-]+" }<a href="#index.xml-eg-d31e57876" class="anchorlink">⚓</a></pre>
                            </td>
                         </tr>
                         <tr>
@@ -18585,7 +19126,7 @@ tei_teidata.temporal.iso =
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Content model</span></td>
                            <td class="wovenodd-col2">
-                              <pre id="index.xml-eg-d31e56141" class="pre_eg cdata">
+                              <pre id="index.xml-eg-d31e57934" class="pre_eg cdata">
 &lt;content&gt;
  &lt;alternate&gt;
   &lt;dataRef name="date"/&gt;
@@ -18598,13 +19139,13 @@ tei_teidata.temporal.iso =
   &lt;dataRef name="dateTime"/&gt;
  &lt;/alternate&gt;
 &lt;/content&gt;
-    <a href="#index.xml-eg-d31e56141" class="anchorlink">⚓</a></pre>
+    <a href="#index.xml-eg-d31e57934" class="anchorlink">⚓</a></pre>
                            </td>
                         </tr>
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Declaration</span></td>
                            <td class="wovenodd-col2">
-                              <pre id="index.xml-eg-d31e56148" class="pre_eg cdata">
+                              <pre id="index.xml-eg-d31e57941" class="pre_eg cdata">
 tei_teidata.temporal.w3c =
    xsd:date
  | xsd:gYear
@@ -18613,7 +19154,7 @@ tei_teidata.temporal.w3c =
  | xsd:gYearMonth
  | xsd:gMonthDay
  | xsd:time
- | xsd:dateTime<a href="#index.xml-eg-d31e56148" class="anchorlink">⚓</a></pre>
+ | xsd:dateTime<a href="#index.xml-eg-d31e57941" class="anchorlink">⚓</a></pre>
                            </td>
                         </tr>
                         <tr>
@@ -18651,18 +19192,18 @@ tei_teidata.temporal.w3c =
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Content model</span></td>
                            <td class="wovenodd-col2">
-                              <pre id="index.xml-eg-d31e56193" class="pre_eg cdata">
+                              <pre id="index.xml-eg-d31e57986" class="pre_eg cdata">
 &lt;content&gt;
  &lt;dataRef name="string"/&gt;
 &lt;/content&gt;
-    <a href="#index.xml-eg-d31e56193" class="anchorlink">⚓</a></pre>
+    <a href="#index.xml-eg-d31e57986" class="anchorlink">⚓</a></pre>
                            </td>
                         </tr>
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Declaration</span></td>
                            <td class="wovenodd-col2">
-                              <pre id="index.xml-eg-d31e56200" class="pre_eg cdata">
-tei_teidata.text = string<a href="#index.xml-eg-d31e56200" class="anchorlink">⚓</a></pre>
+                              <pre id="index.xml-eg-d31e57993" class="pre_eg cdata">
+tei_teidata.text = string<a href="#index.xml-eg-d31e57993" class="anchorlink">⚓</a></pre>
                            </td>
                         </tr>
                         <tr>
@@ -18698,18 +19239,18 @@ tei_teidata.text = string<a href="#index.xml-eg-d31e56200" class="anchorlink">�
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Content model</span></td>
                            <td class="wovenodd-col2">
-                              <pre id="index.xml-eg-d31e56247" class="pre_eg cdata">
+                              <pre id="index.xml-eg-d31e58040" class="pre_eg cdata">
 &lt;content&gt;
  &lt;dataRef name="boolean"/&gt;
 &lt;/content&gt;
-    <a href="#index.xml-eg-d31e56247" class="anchorlink">⚓</a></pre>
+    <a href="#index.xml-eg-d31e58040" class="anchorlink">⚓</a></pre>
                            </td>
                         </tr>
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Declaration</span></td>
                            <td class="wovenodd-col2">
-                              <pre id="index.xml-eg-d31e56254" class="pre_eg cdata">
-tei_teidata.truthValue = xsd:boolean<a href="#index.xml-eg-d31e56254" class="anchorlink">⚓</a></pre>
+                              <pre id="index.xml-eg-d31e58047" class="pre_eg cdata">
+tei_teidata.truthValue = xsd:boolean<a href="#index.xml-eg-d31e58047" class="anchorlink">⚓</a></pre>
                            </td>
                         </tr>
                         <tr>
@@ -18747,19 +19288,19 @@ tei_teidata.truthValue = xsd:boolean<a href="#index.xml-eg-d31e56254" class="anc
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Content model</span></td>
                            <td class="wovenodd-col2">
-                              <pre id="index.xml-eg-d31e56322" class="pre_eg cdata">
+                              <pre id="index.xml-eg-d31e58115" class="pre_eg cdata">
 &lt;content&gt;
  &lt;dataRef name="token"
   restriction="[\d]+(\.[\d]+){0,2}"/&gt;
 &lt;/content&gt;
-    <a href="#index.xml-eg-d31e56322" class="anchorlink">⚓</a></pre>
+    <a href="#index.xml-eg-d31e58115" class="anchorlink">⚓</a></pre>
                            </td>
                         </tr>
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Declaration</span></td>
                            <td class="wovenodd-col2">
-                              <pre id="index.xml-eg-d31e56329" class="pre_eg cdata">
-tei_teidata.version = token { pattern = "[\d]+(\.[\d]+){0,2}" }<a href="#index.xml-eg-d31e56329" class="anchorlink">⚓</a></pre>
+                              <pre id="index.xml-eg-d31e58122" class="pre_eg cdata">
+tei_teidata.version = token { pattern = "[\d]+(\.[\d]+){0,2}" }<a href="#index.xml-eg-d31e58122" class="anchorlink">⚓</a></pre>
                            </td>
                         </tr>
                         <tr>
@@ -18794,20 +19335,20 @@ tei_teidata.version = token { pattern = "[\d]+(\.[\d]+){0,2}" }<a href="#index.x
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Content model</span></td>
                            <td class="wovenodd-col2">
-                              <pre id="index.xml-eg-d31e56369" class="pre_eg cdata">
+                              <pre id="index.xml-eg-d31e58162" class="pre_eg cdata">
 &lt;content&gt;
  &lt;dataRef name="token"
   restriction="[\d]+[a-z]*[\d]*(\.[\d]+[a-z]*[\d]*){0,3}"/&gt;
 &lt;/content&gt;
-    <a href="#index.xml-eg-d31e56369" class="anchorlink">⚓</a></pre>
+    <a href="#index.xml-eg-d31e58162" class="anchorlink">⚓</a></pre>
                            </td>
                         </tr>
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Declaration</span></td>
                            <td class="wovenodd-col2">
-                              <pre id="index.xml-eg-d31e56376" class="pre_eg cdata">
+                              <pre id="index.xml-eg-d31e58169" class="pre_eg cdata">
 tei_teidata.versionNumber =
-   token { pattern = "[\d]+[a-z]*[\d]*(\.[\d]+[a-z]*[\d]*){0,3}" }<a href="#index.xml-eg-d31e56376" class="anchorlink">⚓</a></pre>
+   token { pattern = "[\d]+[a-z]*[\d]*(\.[\d]+[a-z]*[\d]*){0,3}" }<a href="#index.xml-eg-d31e58169" class="anchorlink">⚓</a></pre>
                            </td>
                         </tr>
                      </table>
@@ -18838,19 +19379,19 @@ tei_teidata.versionNumber =
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Content model</span></td>
                            <td class="wovenodd-col2">
-                              <pre id="index.xml-eg-d31e56424" class="pre_eg cdata">
+                              <pre id="index.xml-eg-d31e58217" class="pre_eg cdata">
 &lt;content&gt;
  &lt;dataRef name="token"
   restriction="[^\p{C}\p{Z}]+"/&gt;
 &lt;/content&gt;
-    <a href="#index.xml-eg-d31e56424" class="anchorlink">⚓</a></pre>
+    <a href="#index.xml-eg-d31e58217" class="anchorlink">⚓</a></pre>
                            </td>
                         </tr>
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Declaration</span></td>
                            <td class="wovenodd-col2">
-                              <pre id="index.xml-eg-d31e56431" class="pre_eg cdata">
-tei_teidata.word = token { pattern = "[^\p{C}\p{Z}]+" }<a href="#index.xml-eg-d31e56431" class="anchorlink">⚓</a></pre>
+                              <pre id="index.xml-eg-d31e58224" class="pre_eg cdata">
+tei_teidata.word = token { pattern = "[^\p{C}\p{Z}]+" }<a href="#index.xml-eg-d31e58224" class="anchorlink">⚓</a></pre>
                            </td>
                         </tr>
                         <tr>
@@ -18883,7 +19424,7 @@ tei_teidata.word = token { pattern = "[^\p{C}\p{Z}]+" }<a href="#index.xml-eg-d3
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Content model</span></td>
                            <td class="wovenodd-col2">
-                              <pre id="index.xml-eg-d31e56474" class="pre_eg cdata">
+                              <pre id="index.xml-eg-d31e58267" class="pre_eg cdata">
 &lt;content&gt;
  &lt;alternate&gt;
   &lt;dataRef name="boolean"/&gt;
@@ -18893,14 +19434,14 @@ tei_teidata.word = token { pattern = "[^\p{C}\p{Z}]+" }<a href="#index.xml-eg-d3
   &lt;/valList&gt;
  &lt;/alternate&gt;
 &lt;/content&gt;
-    <a href="#index.xml-eg-d31e56474" class="anchorlink">⚓</a></pre>
+    <a href="#index.xml-eg-d31e58267" class="anchorlink">⚓</a></pre>
                            </td>
                         </tr>
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Declaration</span></td>
                            <td class="wovenodd-col2">
-                              <pre id="index.xml-eg-d31e56481" class="pre_eg cdata">
-tei_teidata.xTruthValue = xsd:boolean | ( "unknown" | "inapplicable" )<a href="#index.xml-eg-d31e56481" class="anchorlink">⚓</a></pre>
+                              <pre id="index.xml-eg-d31e58274" class="pre_eg cdata">
+tei_teidata.xTruthValue = xsd:boolean | ( "unknown" | "inapplicable" )<a href="#index.xml-eg-d31e58274" class="anchorlink">⚓</a></pre>
                            </td>
                         </tr>
                         <tr>
@@ -18932,18 +19473,18 @@ tei_teidata.xTruthValue = xsd:boolean | ( "unknown" | "inapplicable" )<a href="#
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Content model</span></td>
                            <td class="wovenodd-col2">
-                              <pre id="index.xml-eg-d31e56522" class="pre_eg cdata">
+                              <pre id="index.xml-eg-d31e58315" class="pre_eg cdata">
 &lt;content&gt;
  &lt;textNode/&gt;
 &lt;/content&gt;
-    <a href="#index.xml-eg-d31e56522" class="anchorlink">⚓</a></pre>
+    <a href="#index.xml-eg-d31e58315" class="anchorlink">⚓</a></pre>
                            </td>
                         </tr>
                         <tr>
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Declaration</span></td>
                            <td class="wovenodd-col2">
-                              <pre id="index.xml-eg-d31e56529" class="pre_eg cdata">
-tei_teidata.xpath = text<a href="#index.xml-eg-d31e56529" class="anchorlink">⚓</a></pre>
+                              <pre id="index.xml-eg-d31e58322" class="pre_eg cdata">
+tei_teidata.xpath = text<a href="#index.xml-eg-d31e58322" class="anchorlink">⚓</a></pre>
                            </td>
                         </tr>
                         <tr>
@@ -18964,11 +19505,11 @@ tei_teidata.xpath = text<a href="#index.xml-eg-d31e56529" class="anchorlink">⚓
       <!--TEI back-->
       <div class="stdfooter autogenerated">
          <div class="footer"><!--standard links to project, institution etc--><a class="plain" href="/">Home</a> </div>
-         <address>Tiago Sousa Garcia. Date: 2023-11-16<br/>
+         <address>Tiago Sousa Garcia. Date: 2024-03-08<br/>
             <!--
 	  Generated from index.xml using XSLT stylesheets version 7.54.0
 	       based on http://www.tei-c.org/Stylesheets/
-	       on 2023-11-16T09:27:24Z.
+	       on 2024-03-08T11:41:46Z.
 	       SAXON HE 11.4.
 		 --></address>
       </div>

--- a/odd/tei_beeing_human.odd
+++ b/odd/tei_beeing_human.odd
@@ -892,7 +892,7 @@
                 <item>A small change between the versions beeing compared, usually comprised of no
                   more than a few words, that does not significantly transform the meaning of the
                   passage, but that cannot be classified with any of the more specific types
-                  (<val>ortographic</val>, <val>vocabulary</val>, <val>reference</val>).</item>
+                    (<val>ortographic</val>, <val>vocabulary</val>, <val>reference</val>).</item>
                 <label><val>ortographic</val></label>
                 <item>A change that only affects the spelling of existing words, either to correct a
                   spelling mistake in the earlier edition, or to update the text to a new spelling
@@ -903,7 +903,8 @@
                 <item>A small change that replaces one word for a synonym (or adds or deletes a
                   word) without significant impact to the meaning of the passage.</item>
                 <label><val>reference</val></label>
-                  <item>A small difference, deletion, or addition to a bibliographic or cross- reference.</item>
+                <item>A small difference, deletion, or addition to a bibliographic or cross-
+                  reference.</item>
                 <label><val>other</val></label>
                 <item>Any other type of change not currently covered by this typology. If this
                   happens, remember to open an inssue in <ref
@@ -998,9 +999,9 @@
             <label>1623</label>
             <egXML xmlns="http://www.tei-c.org/ns/Examples">
               <p>...or otherwise the sense doth plainely shew that it is spoken of the whole Moneth. </p>
-              <app type="major" subtype="add"><lem wit="#b1623"><p xml:id="frontpar7">When you
-                    have once, for your satisfaction, perused this Booke, you need not afterward
-                    seeke farre for anything therein, whereof you doubt: the <ref target="#contents"
+              <app type="major" subtype="add"><lem wit="#b1623"><p xml:id="frontpar7">When you have
+                    once, for your satisfaction, perused this Booke, you need not afterward seeke
+                    farre for anything therein, whereof you doubt: the <ref target="#contents"
                       rend="italic">Index</ref> of the Chapters or Contents of the Booke; and of the
                     Marginall notes, or Contents of the Chapters will readily direct you. For
                     example, if you would know the Spleeting of Hives, or the manner of Hiving Bees;
@@ -1031,15 +1032,73 @@
             </egXML>
           </div>
           <div xml:id="encVarMov">
-            <head>Text that has been moved from its original position in 1609</head>
+            <head>Text that has been moved from its original position in 1609 (transposition)</head>
             <p>Text that has been moved from one location in 1609 to another in 1623 (akin to cut
-              and paste) is currently not marked up in any special way, the variation already beeing
-              covered by <ref target="#encVarAdd"><val>add</val></ref> and <ref target="#encVarDel"
-                  ><val>del</val></ref>. If you do find any significant variation that falls in this
-              category, make a note of its locations in both 1609 and 1623 but, for now, mark it up
-              as additions and deletions to the normal flow of text. See <ref
-                target="https://github.com/NewcastleRSE/beeing-human-tei-data/issues/32">this github
-                issue</ref> for more.</p>
+              and paste) can be indicated by the use of a <tag>transpose</tag> element.
+                <tag>transpose</tag> will include (at least) two <tag>ptr</tag> elements pointing to
+              segments of text (paragraph or smaller), the order of which will indicate the original
+              order of those segments of text. Consider the following example:</p>
+            <label>Text A</label>
+            <egXML xmlns="http://www.tei-c.org/ns/Examples">
+              <p xml:id="Ap1">This is the first paragraph.</p>
+              <p xml:id="Ap2">This is the second paragraph.</p>
+              <p xml:id="Ap3">This is an additional paragraph.</p>
+            </egXML>
+            <label>Text B</label>
+            <egXML xmlns="http://www.tei-c.org/ns/Examples">
+              <p xml:id="Bp1">This is the first paragraph.</p>
+              <p xml:id="Bp2">This is an additional paragraph.</p>
+              <p xml:id="Bp3">This is the second paragraph.</p>
+            </egXML>
+            <p>To indicate that text B has been reordered, you would use a <tag>transpose</tag>
+              element like so: <egXML xmlns="http://www.tei-c.org/ns/Examples">
+                <transpose>
+                  <ptr target="#Bp1"/>
+                  <ptr target="#Bp3"/>
+                  <ptr target="#Bp2"/>
+                </transpose>
+              </egXML> which corresponds to the order of text A.</p>
+            <p>The <tag>transpose</tag> element will appear inside a <tag>listTranspose</tag>
+              element, which will itself appear <emph>outside</emph> the body of the text in a
+                <tag>standOff</tag> element, which will be the sibling of <tag>teiHeader</tag> and
+                <tag>text</tag>. The <tag>listTranspose</tag> element <emph>must</emph> have a
+                <att>wit</att> attribute pointing to the witness where the different order of text
+              is found. In the example above, it would be something like this: <egXML
+                xmlns="http://www.tei-c.org/ns/Examples">
+                <teiHeader>
+                  <!-- TEI Header goes here -->
+                </teiHeader>
+                <standOff>
+                  <listTranspose wit="#TextA">
+                    <transpose>
+                      <ptr target="#Bp1"/>
+                      <ptr target="#Bp3"/>
+                      <ptr target="#Bp2"/>
+                    </transpose>
+                  </listTranspose>
+                </standOff>
+                <text>
+                  <!-- Body of the text goes here -->
+                </text>
+              </egXML>
+            </p>
+            <p>Variation within transposed text should be recorded in the usual way (with
+                <tag>app</tag>, <tag>lem</tag>, and <tag>rdg</tag>as described <ref target="#encVar"
+                >above</ref>, as if the text was in the same order.</p>
+            <p>If the sections of text that have been transposed are smaller than paragraphs,
+              encapsulate them in <tag>seg</tag> elements, with a significant <att>xml:id</att>
+              following the format chXsegY, i.e., <eg>ch1seg1</eg>, <eg>ch1seg2</eg>, etc.</p>
+            <p>If the sections of text that have been transposed are larger than paragraphs, use
+              more <tag>ptr</tag> elements in the <tag>transpose</tag> element to indicate a larger
+              span of text, for example: <egXML xmlns="http://www.tei-c.org/ns/Examples">
+                <transpose>
+                  <ptr target="p5"/>
+                  <ptr target="p1"/>
+                  <ptr target="p2"/>
+                  <ptr target="p3"/>
+                  <ptr target="p4"/>
+                </transpose>
+              </egXML></p>
           </div>
         </div>
       </div>
@@ -1071,12 +1130,12 @@
           <moduleRef key="tei"/>
 
 
-          <moduleRef key="transcr" include="fw"/>
+          <moduleRef key="transcr" include="fw listTranspose transpose"/>
           <moduleRef key="namesdates" include="persName placeName orgName"/>
           <moduleRef key="analysis" include="w s"/>
           <moduleRef key="figures" include="figure figDesc"/>
           <moduleRef key="textcrit" include="listWit witness app lem rdg variantEncoding"/>
-          <moduleRef key="linking" include="seg"/>
+          <moduleRef key="linking" include="seg standOff"/>
 
           <!-- Element changes, definitions, schematron rules... -->
 
@@ -1456,6 +1515,12 @@
             </attList>
           </elementSpec>
 
+          <elementSpec ident="listTranspose" mode="change">
+            <attList>
+              <attDef ident="wit" mode="change" usage="req"/>
+            </attList>
+          </elementSpec>
+
           <elementSpec ident="ref" mode="change">
             <constraintSpec ident="ref-sanity-check" scheme="schematron">
               <constraint>
@@ -1466,6 +1531,12 @@
             <attList>
               <attDef ident="target" mode="change" usage="req"/>
             </attList>
+          </elementSpec>
+
+          <elementSpec ident="listTranspose" mode="change">
+            <classes mode="change">
+              <memberOf key="att.witnessed"/>
+            </classes>
           </elementSpec>
 
         </schemaSpec>

--- a/schema/tei_beeing_human.rng
+++ b/schema/tei_beeing_human.rng
@@ -5,7 +5,7 @@
          xmlns:xlink="http://www.w3.org/1999/xlink"
          datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes"
          ns="http://www.tei-c.org/ns/1.0"><!--
-Schema generated from ODD source 2023-11-16T09:27:29Z. .
+Schema generated from ODD source 2024-03-08T11:41:51Z. .
 TEI Edition: Version 4.5.0. Last updated on
         25th October 2022, revision 3e98e619e
 TEI Edition Location: https://www.tei-c.org/Vault/P5/Version 4.5.0/
@@ -1720,22 +1720,32 @@ The element indicated by @spanTo (<sch:value-of select="@spanTo"/>) must follow 
       <notAllowed/>
    </define>
    <define name="tei_model.global.meta">
-      <notAllowed/>
+      <choice>
+         <ref name="tei_listTranspose"/>
+      </choice>
    </define>
    <define name="tei_model.global.meta_alternation">
-      <notAllowed/>
+      <choice>
+         <ref name="tei_listTranspose"/>
+      </choice>
    </define>
    <define name="tei_model.global.meta_sequence">
-      <empty/>
+      <ref name="tei_listTranspose"/>
    </define>
    <define name="tei_model.global.meta_sequenceOptional">
-      <empty/>
+      <optional>
+         <ref name="tei_listTranspose"/>
+      </optional>
    </define>
    <define name="tei_model.global.meta_sequenceOptionalRepeatable">
-      <empty/>
+      <zeroOrMore>
+         <ref name="tei_listTranspose"/>
+      </zeroOrMore>
    </define>
    <define name="tei_model.global.meta_sequenceRepeatable">
-      <notAllowed/>
+      <oneOrMore>
+         <ref name="tei_listTranspose"/>
+      </oneOrMore>
    </define>
    <define name="tei_model.milestoneLike">
       <choice>
@@ -2578,6 +2588,11 @@ The element indicated by @spanTo (<sch:value-of select="@spanTo"/>) must follow 
    <define name="tei_model.div1Like">
       <notAllowed/>
    </define>
+   <define name="tei_model.annotationLike">
+      <choice>
+         <ref name="tei_note"/>
+      </choice>
+   </define>
    <define name="tei_model.teiHeaderPart">
       <choice>
          <ref name="tei_encodingDesc"/>
@@ -2591,9 +2606,20 @@ The element indicated by @spanTo (<sch:value-of select="@spanTo"/>) must follow 
          <ref name="tei_variantEncoding"/>
       </choice>
    </define>
+   <define name="tei_model.standOffPart">
+      <choice>
+         <ref name="tei_model.global.meta"/>
+         <ref name="tei_model.biblLike"/>
+         <ref name="tei_model.listLike"/>
+         <ref name="tei_model.annotationLike"/>
+         <ref name="tei_listChange"/>
+         <ref name="tei_seg"/>
+      </choice>
+   </define>
    <define name="tei_model.resource">
       <choice>
          <ref name="tei_text"/>
+         <ref name="tei_standOff"/>
       </choice>
    </define>
    <define name="tei_att.personal.attributes">
@@ -4586,6 +4612,42 @@ Suggested values include: 1] main (main); 2] sub (subordinate); 3] alt (alternat
          <empty/>
       </element>
    </define>
+   <define name="tei_listTranspose">
+      <element name="listTranspose">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">supplies a list of transpositions, each of which is indicated at some point in a document typically by means of metamarks. [11.3.4.5. Transpositions]</a:documentation>
+         <group>
+            <oneOrMore>
+               <ref name="tei_transpose"/>
+            </oneOrMore>
+         </group>
+         <ref name="tei_att.global.attributes"/>
+         <attribute name="wit">
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(witness or witnesses) contains a space-delimited list of one or more pointers indicating the witnesses which attest to a given reading.</a:documentation>
+            <list>
+               <oneOrMore>
+                  <data type="anyURI">
+                     <param name="pattern">\S+</param>
+                  </data>
+               </oneOrMore>
+            </list>
+         </attribute>
+         <empty/>
+      </element>
+   </define>
+   <define name="tei_transpose">
+      <element name="transpose">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">describes a single textual transposition as an ordered list of at least two pointers specifying the order in which the elements indicated should be re-combined. [11.3.4.5. Transpositions]</a:documentation>
+         <group>
+            <ref name="tei_ptr"/>
+            <ref name="tei_ptr"/>
+            <zeroOrMore>
+               <ref name="tei_ptr"/>
+            </zeroOrMore>
+         </group>
+         <ref name="tei_att.global.attributes"/>
+         <empty/>
+      </element>
+   </define>
    <define name="tei_att.datable.custom.attributes">
       <ref name="tei_att.datable.custom.attribute.when-custom"/>
       <ref name="tei_att.datable.custom.attribute.notBefore-custom"/>
@@ -5578,6 +5640,31 @@ Suggested values include: 1] interjection</a:documentation>
                </choice>
             </attribute>
          </optional>
+         <empty/>
+      </element>
+   </define>
+   <define name="tei_standOff">
+      <element name="standOff">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Functions as a container element for linked data, contextual information, and stand-off annotations embedded in a TEI document. [16.10. The standOff Container]</a:documentation>
+         <oneOrMore>
+            <ref name="tei_model.standOffPart"/>
+         </oneOrMore>
+         <pattern xmlns="http://purl.oclc.org/dsdl/schematron"
+                  id="tei_beeing_human-standOff-nested_standOff_should_be_typed-constraint-assert-8">
+            <rule context="tei:standOff">
+               <sch:assert xmlns="http://www.tei-c.org/ns/1.0"
+                           xmlns:rng="http://relaxng.org/ns/structure/1.0"
+                           xmlns:sch="http://purl.oclc.org/dsdl/schematron"
+                           xmlns:xi="http://www.w3.org/2001/XInclude"
+                           test="@type or not(ancestor::tei:standOff)">This
+      <sch:name/> element must have a @type attribute, since it is
+      nested inside a <sch:name/>
+               </sch:assert>
+            </rule>
+         </pattern>
+         <ref name="tei_att.global.attributes"/>
+         <ref name="tei_att.typed.attributes"/>
+         <ref name="tei_att.declaring.attributes"/>
          <empty/>
       </element>
    </define>


### PR DESCRIPTION
## Description

This PR adds the ability to record transposed text, i.e., text that has had its order altered. This is recorded in a `<transpose>` element, which should appear inside a `<listTranspose>` which should be inside `<standOff>`, sibling to `<teiHeader>` and `<text>`.

Fixes #32  (issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How has this been tested?

Manual testing and review

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes


## What should reviewers look for?

Please provide any specific areas of feedback you're looking for from reviewers.


<!-- adapted from a template used by the Data Safe Haven team at The Alan Turing Institute -->
