### PR TITLE
added encoding for special list

### DIFF
--- a/1623.xml
+++ b/1623.xml
@@ -3007,7 +3007,7 @@
                 <p xml:id="ch1par61"><note type="authorial" subtype="summary" xml:id="ch1sumn62">62.
                         The Bees excellencies.</note> The Bee therefore excelling in many qualities,
                     it is fitly said in the Proverbe, <lb/>
-                    <hi rend="italic"> As <list>
+                    <seg rend="italic" type="special-list-ch1"> As <list>
                             <item>Profitable</item>
                             <item>Laborious</item>
                             <item>Loiall</item>
@@ -3020,7 +3020,7 @@
                             <item>Neat </item>
                             <item>Browne </item>
                             <item>Chillie </item>
-                        </list> as a Bee. </hi>
+                        </list> as a Bee. </seg>
                 </p>
                 <p xml:id="ch1par62"><app type="minor" subtype="add">
                         <lem wit="#b1623">

--- a/1623_consolidated.xml
+++ b/1623_consolidated.xml
@@ -2636,7 +2636,7 @@
                 </p>
                 <p xml:id="ch1par61"><note type="authorial" subtype="summary" xml:id="ch1sumn62">62. <seg rend="italic">The Bees excellencies. </seg></note> The Bee therefore excelling in many qualities,
                     it is fitly said in the Proverbe, <lb />
-                    <hi rend="italic"> As <list>
+                    <seg rend="italic" type="special-list-ch1"> As <list>
                             <item>Profitable</item>
                             <item>Laborious</item>
                             <item>Loiall</item>
@@ -2649,7 +2649,7 @@
                             <item>Neat </item>
                             <item>Browne </item>
                             <item>Chillie </item>
-                        </list> as a Bee. </hi>
+                        </list> as a Bee. </seg>
                 </p>
                 <p xml:id="ch1par62"><app type="minor" subtype="add">
                         <lem wit="#b1623">


### PR DESCRIPTION
adds additional encoding for the special list in ch1, so that it can be correctly displayed


<!-- adapted from a template used by the Data Safe Haven team at The Alan Turing Institute -->
