### PR TITLE
corrects bug that was switching ch5bibln9 around -- formatting for th…

### DIFF
--- a/1623.xml
+++ b/1623.xml
@@ -5462,8 +5462,8 @@
                             spoile that would come thereof, take the light stocks, together with the
                             small and late swarmes, <ref target="#ch5bibln9">v.</ref>
                             <note type="authorial" subtype="bibliographic" xml:id="ch5bibln9">
-                                <ref target="#ch10p1sumn3">V.c.10.p.1.&amp;<hi rend="opposite">iii</hi>.&amp;<hi rend="opposite">iiii</hi>.in
-                                    n.3.</ref>
+                                <ref target="#ch10p1sumn3"><seg rend="italic">V.c.</seg>10.<seg rend="italic">p</seg>.1.&amp;<hi rend="opposite">iii</hi>.&amp;<hi rend="opposite">iiii</hi>.<seg rend="italic">in
+                                    n</seg>.3.</ref>
                             </note> feed the midling sort, <ref target="#ch5bibln10"> v.</ref>
                             <note type="authorial" subtype="bibliographic" xml:id="ch5bibln10">
                                 <ref target="#ch8sumn5">V.c.8.n.5.</ref>

--- a/1623_consolidated.xml
+++ b/1623_consolidated.xml
@@ -4858,8 +4858,8 @@
                             spoile that would come thereof, take the light stocks, together with the
                             small and late swarmes, <ref target="#ch5bibln9"><seg rend="italic">v</seg><seg rend="italic">.</seg></ref>
                             <note type="authorial" subtype="bibliographic" xml:id="ch5bibln9">
-                                <ref target="#ch10p1sumn3"><hi rend="opposite">iii</hi>.&amp;<hi rend="opposite">iiii</hi>.in
-                                    n.3.<seg rend="italic">V</seg><seg rend="italic">.</seg><seg rend="italic">c</seg><seg rend="italic">.</seg><seg rend="normal">1</seg><seg rend="normal">0</seg><seg rend="italic">.</seg><seg rend="italic">p</seg><seg rend="italic">.</seg><seg rend="normal">1</seg><seg rend="italic">.</seg><seg rend="italic">&amp;</seg></ref>
+                                <ref target="#ch10p1sumn3"><seg rend="italic">V.c.</seg>10.<seg rend="italic">p</seg>.1.&amp;<hi rend="opposite">iii</hi>.&amp;<hi rend="opposite">iiii</hi>.<seg rend="italic">in
+                                    n</seg>.3.</ref>
                             </note> feed the midling sort, <ref target="#ch5bibln10"><seg rend="italic"> </seg><seg rend="italic">v</seg><seg rend="italic">.</seg></ref>
                             <note type="authorial" subtype="bibliographic" xml:id="ch5bibln10">
                                 <ref target="#ch8sumn5"><seg rend="italic">V</seg><seg rend="italic">.</seg><seg rend="italic">c</seg><seg rend="italic">.</seg><seg rend="normal">8</seg><seg rend="italic">.</seg><seg rend="italic">n</seg><seg rend="italic">.</seg><seg rend="normal">5</seg><seg rend="italic">.</seg></ref>
@@ -8040,7 +8040,7 @@
                         <ref target="#ch5sumn23"><seg rend="italic"> </seg><seg rend="italic">V</seg><seg rend="italic">.</seg><seg rend="italic">c</seg><seg rend="italic">.</seg><seg rend="normal">5</seg><seg rend="italic">.</seg><seg rend="italic">n</seg><seg rend="italic">.</seg><seg rend="normal">2</seg><seg rend="normal">3</seg><seg rend="italic">.</seg><seg rend="italic"> </seg></ref></note></lem><rdg wit="#b1609" /></app>
                      Those <app type="vocabulary" subtype="del"><lem wit="#b1623" /><rdg wit="#b1609" source="1609.xml#ch7ancs4 1609.xml#ch7ance4">mise</rdg></app>that neastle upon the top of the Hive, when the hackle is taken
                     off, will sit still amazed so long, that you may be sure to crush them against
-                    the Hive with your hand. Lastly, you shall doe well to set baited<ref target="#ch7glon1"><app type="reference" subtype="add"><lem wit="#b1623">*</lem><rdg wit="#b1609" /></app><seg rend="italic"> </seg></ref> traps in their way, that so they may come short. </p>
+                    the Hive with your hand. Lastly, you shall doe well to set baited<ref target="#ch7glon1"> <app type="reference" subtype="add"><lem wit="#b1623">*</lem><rdg wit="#b1609" /></app></ref> traps in their way, that so they may come short. </p>
                 <note type="authorial" subtype="gloss" place="inline" xml:id="ch7glon1">
                     <p xml:id="ch7par4"><app type="major" subtype="add"><lem wit="#b1623"><note type="authorial" subtype="summary" xml:id="ch7sumnX1">
                             <seg rend="italic">A Samsons post.</seg> </note>*There is none better than a Sampsons Post: which

--- a/scripts/automate_variation.py
+++ b/scripts/automate_variation.py
@@ -165,16 +165,24 @@ def append_hi_summary_notes(tree, ns):
     # refs
     refs = tree.findall(".//TEI:ref", ns)
     for el in refs:
+        el.text
         text = el.text
-        el.text = ''
         if text:
-            for char in text:
-                if char.isdigit():
-                    digitEl = ET.SubElement(el, 'seg', {'rend': 'normal'})
-                    digitEl.text = char
-                else:
-                    alphaEl = ET.SubElement(el, 'seg', {'rend': 'italic'})
-                    alphaEl.text = char
+            # find out if the ref element has children (i.e.,  a <term> for example)
+            if len([elem.tag for elem in el.iter() if elem is not el]) > 0:
+                # currently this should only affect one element so the formatting for that element will be hardcoded
+                print('I affect' , el.text);
+                continue
+            else:
+                # default behaviour: each character is formatted individually
+                el.text = ''
+                for char in text:
+                    if char.isdigit():
+                        digitEl = ET.SubElement(el, 'seg', {'rend': 'normal'})
+                        digitEl.text = char
+                    else:
+                        alphaEl = ET.SubElement(el, 'seg', {'rend': 'italic'})
+                        alphaEl.text = char
     
     
 


### PR DESCRIPTION
…at note is hardcoded for now. If more cases appear where bibliographic side notes require extra encoding inside, this behaviour will need to be automated.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How has this been tested?

Manual testing

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes


## What should reviewers look for?

Please provide any specific areas of feedback you're looking for from reviewers.


<!-- adapted from a template used by the Data Safe Haven team at The Alan Turing Institute -->
