### PR TITLE
ignores italics for references that are rendered as superscripts

### DIFF
--- a/1623_consolidated.xml
+++ b/1623_consolidated.xml
@@ -3440,7 +3440,7 @@
                     </app></p>
                 <p xml:id="ch3par15"><note type="authorial" subtype="summary" xml:id="ch3sumn10">10. <seg rend="italic">The spraying or spleeting of them. </seg></note>
                     <app type="major" subtype="add">
-                        <lem wit="#b1623">2. The Hive being pruned, put Spleetes in it, <ref target="#ch3glon2" rend="superscript"><seg rend="italic">a</seg></ref> three or foure, as the
+                        <lem wit="#b1623">2. The Hive being pruned, put Spleetes in it, <ref target="#ch3glon2" rend="superscript">a</ref> three or foure, as the
                             largenesse of the Hive shall require:</lem>
                         <rdg wit="#b1609" />
                     </app>
@@ -3477,7 +3477,7 @@
                         <rdg wit="#b1609" source="1609.xml#ch3ancs8xx 1609.xml#ch3ance8xx"><anchor xml:id="ch3ancs8xx" data-origfile="1609" type="attachmentCollation" subtype="start" />and<anchor xml:id="ch3ance8xx" data-origfile="1609" type="attachmentCollation" subtype="end" /></rdg></app>then shave and smooth the clefts, <app type="minor" subtype="change">
                         <lem wit="#b1623">and having brought them to a</lem>
                         <rdg wit="#b1609" source="1609.xml#ch3ancs8xxx 1609.xml#ch3ance8xxx"><anchor xml:id="ch3ancs8xxx" data-origfile="1609" type="attachmentCollation" subtype="start" />which
-                    being of a <anchor xml:id="ch3ance8xxx" data-origfile="1609" type="attachmentCollation" subtype="end" /></rdg></app> convenient <ref target="#ch3glon3" rend="superscript"><seg rend="italic">b</seg></ref> strength
+                    being of a <anchor xml:id="ch3ance8xxx" data-origfile="1609" type="attachmentCollation" subtype="end" /></rdg></app> convenient <ref target="#ch3glon3" rend="superscript">b</ref> strength
                     &amp; length, <app type="minor" subtype="del">
                         <lem wit="#b1623" />
                         <rdg wit="#b1609" source="1609.xml#ch3ancs8vii 1609.xml#ch3ance8vii"><anchor xml:id="ch3ancs8vii" data-origfile="1609" type="attachmentCollation" subtype="start" />put three of them in a hive, setting
@@ -3486,7 +3486,7 @@
                         <lem wit="#b1623">cut the lower ends forked, to stay against the Hives
                             sides, and the upper ends somwhat picked, and of that bignesse that they
                             may fitly joyne in the Cop or middle of the staffe, with their backs
-                            leaning <ref target="#ch3glon4" rend="superscript"><seg rend="italic">c</seg></ref> hard and fast
+                            leaning <ref target="#ch3glon4" rend="superscript">c</ref> hard and fast
                             against one another.</lem>
                         <rdg wit="#b1609" />
                     </app></p>
@@ -9203,13 +9203,13 @@
                             of their three workes.</lem>
                         <rdg wit="#b1609" />
                     </app></p>
-                <p xml:id="ch6par48"><note type="authorial" subtype="summary" xml:id="ch6sumn54">54. <seg rend="italic">The making of the Watering place. </seg></note> The Watring-place should<ref target="#ch6sumn55" rend="superscript"><seg rend="italic">a</seg></ref> not be farre from your
-                        Garden,<ref target="#ch6glon5" rend="superscript"><seg rend="italic">b</seg></ref> in the next side
-                    of a Pond or Brooke,<ref target="#ch6glon6" rend="superscript"><seg rend="italic">c</seg></ref> made
+                <p xml:id="ch6par48"><note type="authorial" subtype="summary" xml:id="ch6sumn54">54. <seg rend="italic">The making of the Watering place. </seg></note> The Watring-place should<ref target="#ch6sumn55" rend="superscript">a</ref> not be farre from your
+                        Garden,<ref target="#ch6glon5" rend="superscript">b</ref> in the next side
+                    of a Pond or Brooke,<ref target="#ch6glon6" rend="superscript">c</ref> made
                     shelving, not <app type="vocabulary" subtype="add">
                         <lem wit="#b1623">very</lem>
                         <rdg wit="#b1609" />
-                    </app> steepe, in manner of a Foord, and <ref target="#ch6glon7" rend="superscript"><seg rend="italic">d</seg></ref> defended from Beasts, Geese, Duckes, and such
+                    </app> steepe, in manner of a Foord, and <ref target="#ch6glon7" rend="superscript">d</ref> defended from Beasts, Geese, Duckes, and such
                     like: <app type="minor" subtype="add">
                         <lem wit="#b1623">and especially young Ducklings.<ref target="#ch6sumn59"><seg rend="italic">v</seg><seg rend="italic">.</seg><seg rend="italic">&#182;</seg><seg rend="italic"> </seg><seg rend="normal">3</seg><seg rend="italic">.</seg><seg rend="italic"> </seg><seg rend="italic">i</seg><seg rend="italic">n</seg><seg rend="italic">.</seg><seg rend="italic">n</seg><seg rend="italic">.</seg><seg rend="normal">5</seg><seg rend="normal">9</seg><seg rend="italic">.</seg></ref></lem>
                         <rdg wit="#b1609" />

--- a/scripts/automate_variation.py
+++ b/scripts/automate_variation.py
@@ -364,6 +364,10 @@ def append_hi_summary_notes(tree, ns):
                 # Elements like this will be hardcoded
                 # print('I affect ' , el.text);
                 continue
+            elif el.get('rend') == 'superscript':
+                # ignores refs that are rendered as superscript
+                # print('I affect ' , el.get('target'));
+                continue
             else:
                 # default behaviour: each character is formatted individually
                 el.text = ''


### PR DESCRIPTION
## Description

Excludes `ref` rendered as superscript from the script that adds italics to non numerical characters in references

Fixes #159 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How has this been tested?

Manual testing

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes


## What should reviewers look for?

Please provide any specific areas of feedback you're looking for from reviewers.


<!-- adapted from a template used by the Data Safe Haven team at The Alan Turing Institute -->
