### PR TITLE
added rend to summary note that does not follow convention

### DIFF
--- a/1623.xml
+++ b/1623.xml
@@ -5038,7 +5038,7 @@
                     </app>
                 </p>
                 <p xml:id="ch3par69"><note type="authorial" subtype="summary" xml:id="ch3sumn50">50
-                        In Virgo try whether the Bees will live.</note> Also in this moneth, about
+                        <hi rend="italic">In Virgo try whether the Bees will live</hi>.</note> Also in this moneth, about
                     the middle, those Hives which you deeme to be weake because the Bees are gone up
                     from the doore, knocke with your hand, one after an other: they that at the
                     first or second stroke doe make a great noise both above and beneath, continuing

--- a/1623_consolidated.xml
+++ b/1623_consolidated.xml
@@ -4431,7 +4431,8 @@
                         <rdg wit="#b1609" source="1609.xml#ch3ancs52 1609.xml#ch3ance52"><anchor xml:id="ch3ancs52" data-origfile="1609" type="attachmentCollation" subtype="start" />for after the second sommer wel they may build new
                     combs, but they will never enlarge the old.<anchor xml:id="ch3ance52" data-origfile="1609" type="attachmentCollation" subtype="end" /></rdg></app>
                 </p>
-                <p xml:id="ch3par69"><note type="authorial" subtype="summary" xml:id="ch3sumn50">50 In Virgo try whether the Bees will live. <seg rend="italic" /></note> Also in this moneth, about
+                <p xml:id="ch3par69"><note type="authorial" subtype="summary" xml:id="ch3sumn50">50
+                        <hi rend="italic">In Virgo try whether the Bees will live</hi>.</note> Also in this moneth, about
                     the middle, those Hives which you deeme to be weake because the Bees are gone up
                     from the doore, knocke with your hand, one after an other: they that at the
                     first or second stroke doe make a great noise both above and beneath, continuing


### PR DESCRIPTION
## Description
Corrects rendering for ch3 summary note 50 because it is missing the `.` that would trigger the automatic render

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How has this been tested?

Manual review

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes


## What should reviewers look for?

Please provide any specific areas of feedback you're looking for from reviewers.


<!-- adapted from a template used by the Data Safe Haven team at The Alan Turing Institute -->
